### PR TITLE
Fix Surface Pro 11 audio boot race: alsactl vs AudioReach DSP graph load

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ automatically reconnected to the previously saved Wi-Fi network after reboot.
 | Bluetooth | Working on cold boot via raw mgmt socket | Public address set via raw `AF_BLUETOOTH` socket C helper (`tools/sp11-bt-set-addr.c`) before `bluetooth.service` starts. No btmgmt D-state hang. Cold boot service succeeds at T+1s. Pairing, audio, and suspend/resume still need validation. |
 | Touchscreen/pen | Not working in live USB | SP11 Arch notes also list touchscreen and pen as not working. |
 | Camera | Not expected yet | Camera support is not part of the first Ubuntu boot path. |
-| Audio | Working (left speaker, mono) | Sound card instantiates with generated topology from CRD template. Left speaker works via `speaker-test hw:0,1` and PipeWire manual sink. Right speaker silent — suspected SoundWire port mapping or regmap issue (kernel). Channelmix matrix sums stereo to left-mono. Headphone/mic/HDMI audio not yet wired in DTS. See [`how-to-bring-up-audio`](docs/how-to/how-to-bring-up-audio.md) and [ADR-0033](docs/adr/adr-0033-audio-topology-gap.md), [ADR-0034](docs/adr/adr-0034-wsa2-regcache-right-speaker.md). |
+| Audio | Working (left speaker, mono) | Sound card instantiates with generated topology from CRD template. Left speaker works via `speaker-test hw:0,1` and PipeWire manual sink. Right speaker silent — suspected SoundWire port mapping or regmap issue (kernel). Channelmix matrix sums stereo to left-mono. Audio boot race fixed: `alsa-restore.service` was restoring WSA mixer state before the DSP graph loaded, causing APM CMD timeout and SoundWire bus clash. Fixed by masking alsa-restore and using `sp11-wsa-routing.service` to enable WSA routing after the DSP graph loads. See [`how-to-bring-up-audio`](docs/how-to/how-to-bring-up-audio.md) and [ADR-0033](docs/adr/adr-0033-audio-topology-gap.md), [ADR-0034](docs/adr/adr-0034-wsa2-regcache-right-speaker.md), [ADR-0035](docs/adr/adr-0035-audio-boot-race-alsactl.md). |
 | Suspend | Partial/risky | Prefer testing boot/install first. |
 
 ## Recommended Path
@@ -432,6 +432,20 @@ sudo ./scripts/troubleshoot-sp11-audio.sh
 Do not enable experimental speaker topology or UCM snippets until the topology
 file and routing are confirmed for Surface Pro 11.
 
+Audio boot race fix: `alsa-restore.service` was restoring WSA mixer state at
+boot before the AudioReach DSP finished loading the audio graph, causing an
+APM CMD timeout, SoundWire bus clash, and no audio (only pops). The fix masks
+`alsa-restore.service` and uses `sp11-wsa-routing.service` to enable WSA
+routing after the DSP graph loads. This is installed automatically by the
+support installer. To apply manually:
+
+```bash
+sudo ./scripts/sp11-fix-audio-boot-race.sh install
+sudo reboot
+```
+
+See [ADR-0035](docs/adr/adr-0035-audio-boot-race-alsactl.md) for details.
+
 
 - Audio topology and UCM configs are in [`payload/audio/`](payload/audio/) and
   installed automatically by the support installer.
@@ -502,6 +516,9 @@ The major bring-up decisions are recorded in `docs/adr/`:
 - [ADR030: Bluetooth btmgmt Batch Sequence](docs/adr/adr-0030-bluetooth-btmgmt-batch-sequence.md)
 - [ADR031: Bluetooth Indexed Public Address and No Pre-Apply Restart](docs/adr/adr-0031-bluetooth-indexed-public-address.md)
 - [ADR032: Raw mgmt-Socket Bluetooth Cold-Boot Solution](docs/adr/adr-0032-raw-mgmt-socket-bluetooth-cold-boot.md)
+- [ADR0033: Surface Pro 11 Audio Topology Gap](docs/adr/adr-0033-audio-topology-gap.md)
+- [ADR0034: Right Speaker Silence — SoundWire Port Mapping and Regmap Cache](docs/adr/adr-0034-wsa2-regcache-right-speaker.md)
+- [ADR0035: Audio Boot Race — alsactl Restore vs AudioReach DSP Graph Load](docs/adr/adr-0035-audio-boot-race-alsactl.md)
 
 ## Windows Firmware
 

--- a/docs/adr/adr-0035-audio-boot-race-alsactl.md
+++ b/docs/adr/adr-0035-audio-boot-race-alsactl.md
@@ -1,0 +1,153 @@
+---
+id: adr-0035-audio-boot-race-alsactl
+title: "ADR0035: Audio Boot Race — alsactl Restore vs AudioReach DSP Graph Load"
+# prettier-ignore
+description: Architecture Decision Record (ADR) for the Surface Pro 11 audio boot race where alsactl restores WSA mixer state before the DSP finishes loading the audio graph, causing an APM CMD timeout, SoundWire bus clash, and no audio (only pops).
+---
+
+# ADR0035: Audio Boot Race — alsactl Restore vs AudioReach DSP Graph Load
+
+## Status
+
+Accepted — Fix verified working (2026-06-19). Left speaker audio restored
+after masking `alsa-restore.service` and clearing WSA controls from
+`asound.state`. A systemd service now enables WSA routing after the DSP
+graph loads at boot.
+
+## Problem
+
+After the audio topology was installed and the left speaker was confirmed
+working (2026-06-15, ADR-0033/ADR-0034), a regression occurred: the Surface
+Pro 11 produced no audio except pops at boot. The symptoms were:
+
+| Check | Result |
+|---|---|
+| APM CMD timeout | `qcom-apm gprsvc:service:2:1: CMD timeout for [1001021] opcode` at boot |
+| SoundWire bus | `Bus clash detected` / `Reached MAX_RETRY on alert read` on both WSA884x amps |
+| ALSA card | Instantiated with all WSA mixer controls present (36 WSA controls) |
+| `speaker-test` | Ran without error on `hw:0,1` but produced no sound |
+| PipeWire | Opened MultiMedia2 PCM, hit `snd_pcm_avail after recover: Broken pipe` continuously |
+
+The `CMD timeout for [1001021]` is `APM_CMD_GRAPH_OPEN` — the AudioReach DSP
+did not acknowledge the topology graph-open command. Without the graph, the
+SoundWire bus comes up unconfigured, causing the bus clash. The pops are the
+WSA884x PA (power amplifier) toggling on a dead bus.
+
+## Root Cause
+
+`alsa-restore.service` runs at boot and restores all ALSA mixer controls from
+`/var/lib/alsa/asound.state`. The saved state contained:
+
+```
+WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2 = on    (DMA route enabled)
+SpkrLeft DAC Switch = true                          (amplifier DAC on)
+SpkrRight DAC Switch = true                         (amplifier DAC on)
+SpkrLeft BOOST Switch = true                        (amplifier boost on)
+SpkrRight BOOST Switch = true                       (amplifier boost on)
+WSA WSA RX0 MUX = AIF1_PB                           (routing active)
+WSA WSA RX1 MUX = AIF1_PB                           (routing active)
+```
+
+These values were saved during the 2026-06-15 testing session when the WSA
+routing was manually enabled via `amixer`. At the next boot,
+`alsa-restore.service` writes these values to the WSA macro registers
+**at the same time** the AudioReach DSP is loading the audio graph:
+
+```
+23:54:16  qcom-apm: CMD timeout for [1001021] opcode    ← DSP graph-open FAILED
+23:54:16  alsa-restore.service: Started + Finished       ← alsactl restore ran
+23:54:16  wsa_macro: zero-initialized flat cache
+23:54:36  wsa884x: Slave UNATTACHED                      ← SoundWire enumeration
+23:54:36  SWR bus clsh detected                           ← Bus clash begins
+```
+
+The register writes from `alsactl` interfere with the DSP's graph
+construction, causing the `APM_CMD_GRAPH_OPEN` to time out. The DSP never
+sets up the SoundWire port configuration, so the bus comes up in a corrupted
+state.
+
+### Why the working state (2026-06-15) did not have this problem
+
+During the 2026-06-15 testing session, the WSA routing was manually enabled
+with `amixer -c0 cset numid=68 'on'` after the system had fully booted and
+the DSP graph was already loaded. The `asound.state` at that time had WSA
+controls in their default (disabled) state. After the manual enable, the
+state was saved (by alsactl store or shutdown), and the "on" values
+persisted into subsequent boots — triggering the race.
+
+## Fix
+
+### 1. Clear WSA controls from asound.state
+
+Strip all WSA/Spkr control blocks from `/var/lib/alsa/asound.state` so they
+default to their kernel-initialized state at boot. Non-WSA controls (VA mic,
+etc.) are preserved.
+
+### 2. Mask alsa-restore.service
+
+Mask `alsa-restore.service` and `alsa-state.service` to prevent them from
+racing the DSP at boot. The WSA routing is enabled separately after the DSP
+graph loads (see step 3).
+
+### 3. Enable WSA routing after DSP graph loads
+
+Install `sp11-wsa-routing.service`, a systemd oneshot that:
+1. Waits for the ALSA card to appear (up to 30s)
+2. Waits for the WSA mixer controls to be available (up to 30s) — this only
+   happens after the DSP graph has loaded
+3. Enables the WSA DMA route and macro routing
+4. Sets a safe default speaker volume
+
+This runs `After=sound.target` and internally polls for the WSA controls,
+ensuring it never races the DSP.
+
+## Verification (2026-06-19)
+
+| Check | Before fix | After fix |
+|---|---|---|
+| APM CMD timeout at boot | Present | **Gone** |
+| SoundWire Bus clash | Continuous spam | **Gone** |
+| Left speaker audio | No sound (pops only) | **Working** |
+| `speaker-test hw:0,1` | No error, no sound | Works (when PCM not busy) |
+| PipeWire | `Broken pipe` spam | Working with manual sink |
+
+## Files
+
+- `scripts/sp11-fix-audio-boot-race.sh` — diagnostic and fix script
+- `scripts/sp11-enable-wsa-routing.sh` — WSA routing enable script (run by systemd)
+- `scripts/systemd/sp11-wsa-routing.service` — systemd oneshot service
+- `scripts/sp11-pipewire-speaker-sink.sh` — updated with boot race notes
+
+## Consequences
+
+### Positive
+
+- Audio works reliably across reboots — no manual `amixer` commands needed
+- The DSP graph loads cleanly without register-write interference
+- The systemd service is self-healing: if the DSP takes longer to load, the
+  script waits up to 30s for the WSA controls to appear
+
+### Negative
+
+- `alsa-restore.service` is masked system-wide — other audio controls (VA mic
+  gain, etc.) are not restored at boot. This is acceptable because:
+  - The VA mic controls default to safe values
+  - The WSA routing is handled by `sp11-wsa-routing.service`
+  - PipeWire/WirePlumber manages runtime volume state independently
+- If the DSP graph fails to load for other reasons, the systemd service will
+  time out after 30s and exit — the user must check dmesg for DSP errors
+
+### Neutral
+
+- The fix does not address the right speaker silence (ADR-0034) — that remains
+  an unresolved kernel-level issue
+- The PipeWire manual sink (`50-sp11-speakers.conf`) is still needed for
+  desktop audio until the UCM auto-profile issue is resolved
+
+## References
+
+- [ADR-0033](adr-0033-audio-topology-gap.md) — topology gap (resolved)
+- [ADR-0034](adr-0034-wsa2-regcache-right-speaker.md) — right speaker silence
+- `scripts/sp11-fix-audio-boot-race.sh` — fix script
+- `scripts/sp11-enable-wsa-routing.sh` — WSA routing enable script
+- `scripts/systemd/sp11-wsa-routing.service` — systemd service

--- a/docs/how-to/how-to-bring-up-audio.md
+++ b/docs/how-to/how-to-bring-up-audio.md
@@ -1,19 +1,21 @@
 # How to Bring Up Audio on Surface Pro 11
 
-Last updated: 2026-06-15
+Last updated: 2026-06-19
 
 ## Prerequisites
 
 - [x] SP11 kernel patched with DTB audio DAI links (`wsa-dai-link`, `va-dai-link`)
 - [x] ADSP/CDSP firmware in place (`qcadsp8380.mbn`, `qccdsp8380.mbn`)
 - [x] Audio firmware copied from Windows / linux-firmware
+- [x] Audio boot race fix applied (see [ADR-0035](../adr/adr-0035-audio-boot-race-alsactl.md))
 
-## Status (2026-06-15)
+## Status (2026-06-19)
 
 | Audio path | Status | Notes |
 |---|---|---|
 | Sound card (ALSA) | Working | `x1e80100` card instantiates with topology |
 | Speaker (WSA884x) | Working (left only) | 4-channel PCM via WSA_CODEC_DMA_RX_0. Left woofer+tweeter (ch0+ch1) work. Right speaker (ch2+ch3) silent — suspected topology/SoundWire port mapping or regmap issue. See [ADR-0034](../adr/adr-0034-wsa2-regcache-right-speaker.md). |
+| Audio boot race | Fixed | `alsa-restore.service` was restoring WSA mixer state before the DSP graph loaded, causing APM CMD timeout and SoundWire bus clash. Fixed by masking alsa-restore and using `sp11-wsa-routing.service`. See [ADR-0035](../adr/adr-0035-audio-boot-race-alsactl.md). |
 | PipeWire integration | Partial | Card detected but manual sink config needed |
 | Headphone (WCD939x RX) | Untested | RX_CODEC not in current DTS DAI links |
 | Microphone (WCD939x TX) | Untested | TX_CODEC not in current DTS DAI links |
@@ -39,7 +41,33 @@ sudo ./scripts/sp11-audio-topology.sh --install
 The topology is loaded by the AudioReach DSP at card probe time (boot). Reboot
 is required after first install.
 
-### 4. Test with ALSA directly
+### 4. Apply the audio boot race fix
+
+`alsa-restore.service` restores WSA mixer state at boot before the AudioReach
+DSP finishes loading the audio graph, causing an APM CMD timeout, SoundWire
+bus clash, and no audio (only pops). The fix masks `alsa-restore.service` and
+installs `sp11-wsa-routing.service` to enable WSA routing after the DSP graph
+loads. See [ADR-0035](../adr/adr-0035-audio-boot-race-alsactl.md).
+
+```bash
+sudo ./scripts/sp11-fix-audio-boot-race.sh install
+sudo reboot
+```
+
+After reboot, verify the DSP graph loaded cleanly:
+
+```bash
+# Should show no APM CMD timeout
+sudo journalctl -b -k | grep 'CMD timeout'
+
+# Should show no Bus clash
+sudo dmesg | grep 'Bus clash'
+
+# The WSA routing service should be active
+systemctl status sp11-wsa-routing.service
+```
+
+### 5. Test with ALSA directly
 
 ```bash
 # Check card appeared
@@ -61,7 +89,7 @@ amixer -c0 cget numid=1   # SpkrLeft PA Volume
 amixer -c0 cget numid=9   # SpkrRight PA Volume
 ```
 
-### 5. PipeWire workaround
+### 6. PipeWire workaround
 
 If PipeWire shows only `Dummy Output` after reboot, install the user-level
 manual speaker sink:

--- a/scripts/install-sp11-support.sh
+++ b/scripts/install-sp11-support.sh
@@ -69,6 +69,61 @@ install -m 0755 "$repo_dir/scripts/troubleshoot-sp11-bluetooth.sh" "$(target /us
 install -m 0755 "$repo_dir/scripts/troubleshoot-sp11-wifi-rfkill.sh" "$(target /usr/local/sbin/troubleshoot-sp11-wifi-rfkill)"
 install -m 0755 "$repo_dir/scripts/sp11-pipewire-speaker-sink.sh" "$(target /usr/local/sbin/sp11-pipewire-speaker-sink)"
 install -m 0755 "$repo_dir/scripts/sp11-audio-topology.sh" "$(target /usr/local/sbin/sp11-audio-topology)"
+install -m 0755 "$repo_dir/scripts/sp11-enable-wsa-routing.sh" "$(target /usr/local/sbin/sp11-enable-wsa-routing)"
+install -m 0755 "$repo_dir/scripts/sp11-fix-audio-boot-race.sh" "$(target /usr/local/sbin/sp11-fix-audio-boot-race)"
+
+# --- Audio boot race fix: mask alsa-restore, install WSA routing service ---
+# alsactl restores WSA mixer state at boot before the AudioReach DSP finishes
+# loading the audio graph, causing an APM CMD timeout, SoundWire bus clash,
+# and no audio. Mask alsa-restore and use a dedicated service instead.
+# See docs/adr/adr-0035-audio-boot-race-alsactl.md.
+if [ -f "$repo_dir/scripts/systemd/sp11-wsa-routing.service" ]; then
+  install -d "$(target /etc/systemd/system)"
+  install -m 0644 "$repo_dir/scripts/systemd/sp11-wsa-routing.service" \
+    "$(target /etc/systemd/system/sp11-wsa-routing.service)"
+
+  # Mask alsa-restore so it doesn't race the DSP at boot
+  if [ "$ROOT" = "/" ]; then
+    systemctl mask alsa-restore.service 2>/dev/null || true
+    systemctl mask alsa-state.service 2>/dev/null || true
+    systemctl daemon-reload
+    systemctl enable sp11-wsa-routing.service 2>/dev/null || true
+  else
+    # For chroot/target installs, create the mask symlinks manually
+    ln -sf /dev/null "$(target /etc/systemd/system/alsa-restore.service)"
+    ln -sf /dev/null "$(target /etc/systemd/system/alsa-state.service)"
+    # Enable via symlink (will be picked up after chroot boot)
+    ln -sf /etc/systemd/system/sp11-wsa-routing.service \
+      "$(target /etc/systemd/system/multi-user.target.wants/sp11-wsa-routing.service)" 2>/dev/null || true
+  fi
+
+  # Clear WSA controls from asound.state if it exists
+  local_state="$(target /var/lib/alsa/asound.state)"
+  if [ -f "$local_state" ]; then
+    cp "$local_state" "${local_state}.bak.$(date +%Y%m%d%H%M%S)"
+    tmp="$(mktemp)"
+    awk '
+      BEGIN { skip=0 }
+      /^[[:space:]]*control\.[0-9]+[[:space:]]*\{/ {
+        block=""; skip=0; collecting=1
+      }
+      collecting==1 {
+        block = block $0 "\n"
+        if ($0 ~ /^[[:space:]]*name[[:space:]]/) {
+          if ($0 ~ /WSA|Spkr/) { skip=1 }
+        }
+        if ($0 ~ /^[[:space:]]*\}[[:space:]]*$/) {
+          collecting=0
+          if (skip==0) { printf "%s", block }
+        }
+        next
+      }
+      { print }
+    ' "$local_state" > "$tmp"
+    [ -s "$tmp" ] && cp "$tmp" "$local_state" || true
+    rm -f "$tmp"
+  fi
+fi
 
 # --- Audio topology & UCM ---
 AUDIO_ASSETS_DIR="$repo_dir/payload/audio"

--- a/scripts/sp11-enable-wsa-routing.sh
+++ b/scripts/sp11-enable-wsa-routing.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Enable WSA speaker routing on the Surface Pro 11 after the AudioReach DSP
+# graph has loaded. This runs as a systemd service after the sound card
+# appears, avoiding the boot race where alsactl restores WSA mixer state
+# before the DSP finishes loading the audio graph.
+#
+# The APM CMD timeout (APM_CMD_GRAPH_OPEN) is a kernel-level race between
+# ADSP firmware boot and the topology loader. It happens on every boot but
+# the DSP sometimes recovers and sometimes doesn't. This script:
+#   1. Waits for the SoundWire slaves to reach Attached state
+#   2. If they don't (graph failed), unbinds and rebinds the sound card
+#      with a delay to give the DSP more time
+#   3. Retries up to 3 times
+#   4. Once the graph is loaded, enables WSA routing
+#
+# See docs/adr/adr-0035-audio-boot-race-alsactl.md for the full diagnosis.
+set -euo pipefail
+
+CARD="${SP11_ALSA_CARD:-X1E80100Microso}"
+SPEAKER_VOLUME="${SP11_SPEAKER_VOLUME:-100}"
+MAX_RETRIES="${SP11_MAX_RETRIES:-3}"
+SOUND_DRIVER="snd-x1e80100"
+SOUND_DEVICE="sound"
+
+slave0="/sys/bus/soundwire/devices/sdw:1:0:0217:0204:00:0/status"
+slave1="/sys/bus/soundwire/devices/sdw:1:0:0217:0204:00:1/status"
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+# Check if both WSA884x amps are Attached (graph loaded successfully)
+slaves_attached() {
+	local s0="UNATTACHED" s1="UNATTACHED"
+	[ -f "$slave0" ] && s0="$(cat "$slave0" 2>/dev/null || echo UNATTACHED)"
+	[ -f "$slave1" ] && s1="$(cat "$slave1" 2>/dev/null || echo UNATTACHED)"
+	s0="$(echo "$s0" | tr -d '[:space:]')"
+	s1="$(echo "$s1" | tr -d '[:space:]')"
+	[ "$s0" = "Attached" ] && [ "$s1" = "Attached" ]
+}
+
+# Check for bus clash (graph failed, bus is broken)
+bus_clash_detected() {
+	dmesg 2>/dev/null | tail -100 | grep -q 'Bus clash'
+}
+
+# Wait for the ALSA card to appear (up to 30 seconds)
+wait_for_card() {
+	local i=0
+	while [ "$i" -lt 30 ]; do
+		if [ -e "/proc/asound/${CARD}" ] || aplay -l 2>/dev/null | grep -q "$CARD"; then
+			return 0
+		fi
+		sleep 1
+		i=$((i + 1))
+	done
+	log "ERROR: ALSA card ${CARD} did not appear within 30s."
+	return 1
+}
+
+# Wait for the WSA mixer controls to be available (card instantiated)
+wait_for_wsa_controls() {
+	local i=0
+	while [ "$i" -lt 30 ]; do
+		if amixer -c "$CARD" sget 'WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 1
+		i=$((i + 1))
+	done
+	log "ERROR: WSA mixer controls not available within 30s."
+	return 1
+}
+
+# Wait for SoundWire slaves to reach Attached, with timeout
+wait_for_slaves() {
+	local max_wait="${1:-30}"
+	local elapsed=0
+	log "Waiting for SoundWire slaves to reach Attached (max ${max_wait}s) ..."
+	while [ "$elapsed" -lt "$max_wait" ]; do
+		if slaves_attached; then
+			log "Both WSA884x amps Attached (${elapsed}s)."
+			sleep 2
+			return 0
+		fi
+		if bus_clash_detected; then
+			log "Bus clash detected at ${elapsed}s — graph failed."
+			return 1
+		fi
+		sleep 1
+		elapsed=$((elapsed + 1))
+	done
+	log "Slaves did not reach Attached within ${max_wait}s."
+	return 1
+}
+
+# Unbind and rebind the sound card to force a fresh topology load.
+# The extra delay before rebind gives the DSP time to fully initialize.
+rebind_sound_card() {
+	local delay="${1:-10}"
+
+	log "Unbinding sound card driver ..."
+	if echo "$SOUND_DEVICE" | tee /sys/bus/platform/drivers/$SOUND_DRIVER/unbind 2>/dev/null; then
+		log "Sound card unbound."
+	else
+		log "WARNING: unbind failed — device may already be unbound."
+	fi
+
+	log "Waiting ${delay}s before rebind to let DSP settle ..."
+	sleep "$delay"
+
+	log "Rebinding sound card driver ..."
+	if echo "$SOUND_DEVICE" | tee /sys/bus/platform/drivers/$SOUND_DRIVER/bind 2>/dev/null; then
+		log "Sound card rebound."
+		# Wait for the card to fully initialize
+		sleep 5
+		wait_for_card 2>/dev/null || true
+		wait_for_wsa_controls 2>/dev/null || true
+		return 0
+	else
+		log "ERROR: rebind failed."
+		return 1
+	fi
+}
+
+enable_wsa_routing() {
+	log "Enabling WSA speaker DMA route (MultiMedia2) ..."
+	amixer -c "$CARD" sset 'WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' on >/dev/null 2>&1 || \
+		log "  WARNING: could not set MultiMedia2 route"
+
+	log "Setting WSA macro RX routing ..."
+	amixer -c "$CARD" sset 'WSA WSA RX0 MUX' AIF1_PB >/dev/null 2>&1 || true
+	amixer -c "$CARD" sset 'WSA WSA RX1 MUX' AIF1_PB >/dev/null 2>&1 || true
+	amixer -c "$CARD" sset 'WSA WSA_RX0 INP0' RX0 >/dev/null 2>&1 || true
+	amixer -c "$CARD" sset 'WSA WSA_RX1 INP0' RX1 >/dev/null 2>&1 || true
+
+	log "Setting speaker hardware volume to ${SPEAKER_VOLUME}% ..."
+	amixer -c "$CARD" sset 'Speakers' "${SPEAKER_VOLUME}%" >/dev/null 2>&1 || true
+
+	if [ "$SPEAKER_VOLUME" -eq 100 ]; then
+		log "Hardware volume at 100% — PipeWire/GNOME slider is the sole volume control."
+	fi
+
+	log "WSA speaker routing enabled."
+}
+
+# Restart PipeWire/WirePlubber user services so they connect to the sink
+# cleanly after WSA routing is enabled. PipeWire may have started before the
+# DSP graph was ready, leaving the sink in a broken state.
+#
+# Since this service runs at multi-user.target (before user login), we can't
+# restart PipeWire directly. Instead, we write a flag file that a user-level
+# systemd path will pick up. We also try to restart PipeWire for any already
+# logged-in user.
+restart_pipewire() {
+	# Write a flag file for the user-level service to detect
+	local flag="/run/sp11-wsa-routing-done"
+	touch "$flag" 2>/dev/null || true
+	chmod 0644 "$flag" 2>/dev/null || true
+	log "Wrote flag file $flag for user-level PipeWire restart."
+
+	# Also try to restart PipeWire for any already-logged-in user
+	local uid user
+	uid="$(loginctl list-users --no-legend 2>/dev/null | awk '{print $1; exit}')"
+	if [ -n "$uid" ]; then
+		user="$(getent passwd "$uid" | cut -d: -f1)"
+		if [ -n "$user" ]; then
+			log "Restarting PipeWire/WirePlumber for user ${user} (uid=${uid}) ..."
+			systemctl --user -M "${user}@" restart pipewire pipewire-pulse wireplumber 2>/dev/null || true
+			log "PipeWire restarted."
+			return 0
+		fi
+	fi
+
+	log "No logged-in user yet — flag file written for later PipeWire restart."
+}
+
+main() {
+	log "Waiting for ALSA card ${CARD} ..."
+	wait_for_card || exit 1
+
+	log "Waiting for WSA mixer controls (card instantiated) ..."
+	wait_for_wsa_controls || exit 1
+
+	# Try to get a working DSP graph, with retries via rebind
+	local attempt=0
+	while [ "$attempt" -lt "$MAX_RETRIES" ]; do
+		attempt=$((attempt + 1))
+		log "Attempt ${attempt}/${MAX_RETRIES}: checking DSP graph state ..."
+
+		if wait_for_slaves 15; then
+			log "DSP graph loaded successfully."
+			enable_wsa_routing
+			restart_pipewire
+			log "Done."
+			exit 0
+		fi
+
+		log "DSP graph failed on attempt ${attempt}."
+
+		if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+			local rebind_delay=$((10 + attempt * 5))
+			log "Retrying with ${rebind_delay}s DSP settle delay ..."
+			rebind_sound_card "$rebind_delay" || true
+		fi
+	done
+
+	log "ERROR: DSP graph failed to load after ${MAX_RETRIES} attempts."
+	log "  Audio will not work. Check: sudo journalctl -b -k | grep -E 'qcom-apm|CMD timeout'"
+	log "  Try a full cold shutdown (not reboot) and power on again."
+	exit 1
+}
+
+main "$@"

--- a/scripts/sp11-fix-audio-boot-race.sh
+++ b/scripts/sp11-fix-audio-boot-race.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Fix Surface Pro 11 audio boot race: alsactl restores WSA mixer state at boot
+# before the AudioReach DSP finishes loading the audio graph, causing an APM
+# CMD timeout, SoundWire bus clash, and no audio (only pops).
+#
+# This script:
+#   1. Backs up and clears the WSA controls from /var/lib/alsa/asound.state
+#   2. Masks alsa-restore.service so it doesn't race the DSP at boot
+#   3. Optionally reboots so the DSP graph loads cleanly
+#
+# After reboot, run with --post-boot to re-enable WSA routing and verify.
+# Use --install for a permanent fix that sets up a systemd service to
+# enable WSA routing automatically after every boot.
+set -euo pipefail
+
+ACTION="pre-boot"
+REBOOT="false"
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [pre-boot|post-boot|install|restore]
+
+Fix the Surface Pro 11 audio boot race caused by alsactl restoring WSA mixer
+state before the AudioReach DSP graph finishes loading.
+
+Modes:
+  pre-boot    Back up asound.state, clear WSA controls, mask alsa-restore.
+              Run this before rebooting. (default)
+  post-boot   Re-enable WSA routing after a clean DSP boot, then run a
+              speaker-test. Run this after rebooting with pre-boot.
+  install     Apply the pre-boot fix AND install a permanent systemd service
+              that enables WSA routing automatically after every boot.
+              Run this once, then reboot.
+  restore     Undo the fix: unmask alsa-restore, restore the backup state,
+              and remove the systemd service.
+
+Options:
+  --reboot          Reboot after pre-boot/install fix (requires sudo).
+  --no-reboot       Do not reboot after pre-boot fix (default).
+  -h, --help        Show this help.
+
+Pre-boot flow (diagnostic):
+  1. sudo $0 pre-boot
+  2. sudo reboot
+  3. $0 post-boot
+
+Permanent fix:
+  1. sudo $0 install
+  2. sudo reboot
+  3. Audio should work automatically after boot.
+EOF
+}
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+need_root() {
+	if [ "$(id -u)" -ne 0 ]; then
+		log "ERROR: this action requires root (sudo)."
+		exit 1
+	fi
+}
+
+# ── Pre-boot: clear WSA state and mask alsa-restore ──────────────────────
+
+pre_boot() {
+	need_root
+
+	local state_file="/var/lib/alsa/asound.state"
+	local backup="${state_file}.bak.$(date +%Y%m%d%H%M%S)"
+	local tmp="$(mktemp)"
+
+	if [ ! -f "$state_file" ]; then
+		log "No $state_file — nothing to clear."
+	else
+		log "Backing up $state_file to $backup"
+		cp "$state_file" "$backup"
+	fi
+
+	# Write a clean asound.state with WSA controls disabled.
+	# We only touch WSA/Spkr controls; leave other controls (VA mic, etc.) as-is
+	# by removing WSA/Spkr control blocks and re-storing current non-WSA state.
+	log "Clearing WSA mixer state from $state_file ..."
+
+	if [ -f "$state_file" ]; then
+		# Use awk to remove control blocks that contain WSA or Spkr in their name.
+		# Each control block is: control.N { ... }
+		awk '
+			BEGIN { skip=0 }
+			/^[[:space:]]*control\.[0-9]+[[:space:]]*\{/ {
+				block=""
+				skip=0
+				collecting=1
+			}
+			collecting==1 {
+				block = block $0 "\n"
+				if ($0 ~ /^[[:space:]]*name[[:space:]]/) {
+					if ($0 ~ /WSA|Spkr/) {
+						skip=1
+					}
+				}
+				if ($0 ~ /^[[:space:]]*\}[[:space:]]*$/) {
+					collecting=0
+					if (skip==0) {
+						printf "%s", block
+					}
+				}
+				next
+			}
+			# Print non-control-block lines (state header)
+			{ print }
+		' "$state_file" > "$tmp"
+
+		# If awk removed everything, fall back to a minimal empty state
+		if [ ! -s "$tmp" ]; then
+			log "WARNING: awk produced empty file — writing minimal state."
+			echo "" > "$tmp"
+		fi
+
+		cp "$tmp" "$state_file"
+		rm -f "$tmp"
+		log "Cleared WSA controls from $state_file."
+	fi
+
+	# Mask alsa-restore.service so it doesn't run at boot and race the DSP.
+	log "Masking alsa-restore.service ..."
+	systemctl mask alsa-restore.service 2>/dev/null || true
+	systemctl mask alsa-state.service 2>/dev/null || true
+
+	log ""
+	log "Pre-boot fix applied."
+	log "  - WSA controls cleared from $state_file"
+	log "  - alsa-restore.service masked (will not restore mixer at boot)"
+	log "  - Backup: $backup"
+	log ""
+
+	if [ "$REBOOT" = "true" ]; then
+		log "Rebooting in 3 seconds ..."
+		sleep 3
+		reboot
+	else
+		log "Reboot now, then run: $0 post-boot"
+	fi
+}
+
+# ── Post-boot: re-enable WSA routing and test ────────────────────────────
+
+post_boot() {
+	local card="${SP11_ALSA_CARD:-X1E80100Microso}"
+
+	log "Checking DSP graph load status ..."
+	if ! dmesg 2>/dev/null | grep -q 'CMD timeout'; then
+		log "GOOD: No APM CMD timeout in current boot dmesg."
+	else
+		log "WARNING: APM CMD timeout still present — the race may not be fully fixed."
+		log "  The DSP graph may still have failed to load. Check:"
+		log "  sudo journalctl -b -k | grep -E 'qcom-apm|CMD timeout'"
+	fi
+
+	log ""
+	log "Checking SoundWire bus state ..."
+	if dmesg 2>/dev/null | grep -q 'Bus clash'; then
+		log "WARNING: Bus clash still detected — DSP graph may not have loaded."
+		log "  Try: sudo journalctl -b -k | grep -v 'Bus clash' | grep -iE 'soundwire|wsa'"
+	else
+		log "GOOD: No Bus clash detected in current boot."
+	fi
+
+	log ""
+	log "Enabling WSA speaker routing ..."
+
+	# Enable the WSA DMA route for MultiMedia2 (4ch speaker PCM)
+	amixer -c "$card" sset 'WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' on 2>/dev/null || \
+		log "  (could not set MultiMedia2 route)"
+
+	# Set WSA macro routing
+	amixer -c "$card" sset 'WSA WSA RX0 MUX' AIF1_PB 2>/dev/null || true
+	amixer -c "$card" sset 'WSA WSA RX1 MUX' AIF1_PB 2>/dev/null || true
+	amixer -c "$card" sset 'WSA WSA_RX0 INP0' RX0 2>/dev/null || true
+	amixer -c "$card" sset 'WSA WSA_RX1 INP0' RX1 2>/dev/null || true
+
+	# Set hardware volume to 100% (pass-through) — PipeWire/GNOME controls volume
+	amixer -c "$card" sset 'Speakers' 100% 2>/dev/null || true
+
+	log ""
+	log "Running speaker-test (4ch sine, 440Hz, 1 loop) ..."
+	log "Keep volume LOW. Listen for the tone from the left speaker."
+	log ""
+
+	speaker-test -D "hw:${card},1" -c 4 -t sine -f 440 -l 1 2>&1 | tail -15
+
+	log ""
+	log "If you heard a tone from the left speaker, the boot race fix worked."
+	log "Next steps:"
+	log "  1. Install the PipeWire manual sink: ./scripts/sp11-pipewire-speaker-sink.sh --install --enable-route"
+	log "  2. Test with desktop audio"
+	log "  3. If stable across reboots, make the fix permanent (TODO: integrate into support installer)"
+}
+
+# ── Install: permanent fix with systemd service ──────────────────────────
+
+install_permanent() {
+	need_root
+
+	# Apply the pre-boot fix first (clears state, masks alsa-restore)
+	pre_boot_no_log_reboot
+
+	# Install the WSA routing enable script
+	local routing_script="${repo_dir}/scripts/sp11-enable-wsa-routing.sh"
+	local service_file="${repo_dir}/scripts/systemd/sp11-wsa-routing.service"
+
+	if [ ! -f "$routing_script" ]; then
+		log "ERROR: $routing_script not found."
+		exit 1
+	fi
+	if [ ! -f "$service_file" ]; then
+		log "ERROR: $service_file not found."
+		exit 1
+	fi
+
+	log "Installing sp11-enable-wsa-routing.sh to /usr/local/sbin/ ..."
+	install -m 0755 "$routing_script" /usr/local/sbin/sp11-enable-wsa-routing.sh
+
+	log "Installing sp11-wsa-routing.service to /etc/systemd/system/ ..."
+	install -m 0644 "$service_file" /etc/systemd/system/sp11-wsa-routing.service
+
+	log "Enabling sp11-wsa-routing.service ..."
+	systemctl daemon-reload
+	systemctl enable sp11-wsa-routing.service
+
+	# Install user-level PipeWire restart service
+	local pw_service="${repo_dir}/scripts/systemd/sp11-pipewire-restart.service"
+	if [ -f "$pw_service" ]; then
+		local user_home="${HOME:-/root}"
+		local user_uid="${SUDO_UID:-$(id -u)}"
+		local real_user="${SUDO_USER:-$(whoami)}"
+		local user_config_dir
+
+		# Find the real user's config directory (not root)
+		if [ -n "$SUDO_USER" ] && [ -n "$SUDO_UID" ]; then
+			user_home="$(getent passwd "$SUDO_UID" | cut -d: -f6)"
+			real_user="$SUDO_USER"
+			user_uid="$SUDO_UID"
+		fi
+
+		user_config_dir="$user_home/.config/systemd/user"
+		install -d "$user_config_dir"
+		install -m 0644 "$pw_service" "$user_config_dir/sp11-pipewire-restart.service"
+
+		log "Installed sp11-pipewire-restart.service to $user_config_dir/"
+		log "  (user: $real_user, uid: $user_uid)"
+
+		# Enable it for the user
+		if [ -n "$SUDO_USER" ]; then
+			su - "$SUDO_USER" -c 'systemctl --user daemon-reload && systemctl --user enable sp11-pipewire-restart.service' 2>/dev/null || true
+		else
+			systemctl --user daemon-reload 2>/dev/null || true
+			systemctl --user enable sp11-pipewire-restart.service 2>/dev/null || true
+		fi
+	fi
+
+	log ""
+	log "Permanent fix installed."
+	log "  - WSA controls cleared from asound.state"
+	log "  - alsa-restore.service masked (won't race DSP at boot)"
+	log "  - sp11-wsa-routing.service enabled (enables WSA routing after DSP loads)"
+	log "  - sp11-pipewire-restart.service enabled (restarts PipeWire after routing is ready)"
+	log ""
+
+	if [ "$REBOOT" = "true" ]; then
+		log "Rebooting in 3 seconds ..."
+		sleep 3
+		reboot
+	else
+		log "Reboot now. After boot, audio should work automatically."
+		log "Verify with: systemctl status sp11-wsa-routing.service"
+	fi
+}
+
+# Internal: pre-boot fix without the reboot prompt (used by install_permanent)
+pre_boot_no_log_reboot() {
+	local state_file="/var/lib/alsa/asound.state"
+	local backup="${state_file}.bak.$(date +%Y%m%d%H%M%S)"
+	local tmp="$(mktemp)"
+
+	if [ -f "$state_file" ]; then
+		log "Backing up $state_file to $backup"
+		cp "$state_file" "$backup"
+	else
+		log "No $state_file — nothing to clear."
+	fi
+
+	if [ -f "$state_file" ]; then
+		log "Clearing WSA mixer state from $state_file ..."
+
+		awk '
+			BEGIN { skip=0 }
+			/^[[:space:]]*control\.[0-9]+[[:space:]]*\{/ {
+				block=""
+				skip=0
+				collecting=1
+			}
+			collecting==1 {
+				block = block $0 "\n"
+				if ($0 ~ /^[[:space:]]*name[[:space:]]/) {
+					if ($0 ~ /WSA|Spkr/) {
+						skip=1
+					}
+				}
+				if ($0 ~ /^[[:space:]]*\}[[:space:]]*$/) {
+					collecting=0
+					if (skip==0) {
+						printf "%s", block
+					}
+				}
+				next
+			}
+			{ print }
+		' "$state_file" > "$tmp"
+
+		if [ ! -s "$tmp" ]; then
+			log "WARNING: awk produced empty file — writing minimal state."
+			echo "" > "$tmp"
+		fi
+
+		cp "$tmp" "$state_file"
+		rm -f "$tmp"
+		log "Cleared WSA controls from $state_file."
+	fi
+
+	log "Masking alsa-restore.service ..."
+	systemctl mask alsa-restore.service 2>/dev/null || true
+	systemctl mask alsa-state.service 2>/dev/null || true
+}
+
+# ── Restore: undo the fix ────────────────────────────────────────────────
+
+restore_fix() {
+	need_root
+
+	log "Removing sp11-wsa-routing.service ..."
+	systemctl disable sp11-wsa-routing.service 2>/dev/null || true
+	rm -f /etc/systemd/system/sp11-wsa-routing.service
+
+	log "Removing sp11-pipewire-restart.service ..."
+	if [ -n "$SUDO_USER" ]; then
+		su - "$SUDO_USER" -c 'systemctl --user disable sp11-pipewire-restart.service 2>/dev/null; rm -f ~/.config/systemd/user/sp11-pipewire-restart.service; systemctl --user daemon-reload' 2>/dev/null || true
+	fi
+	rm -f "$HOME/.config/systemd/user/sp11-pipewire-restart.service" 2>/dev/null || true
+
+	systemctl daemon-reload
+
+	log "Removing sp11-enable-wsa-routing.sh ..."
+	rm -f /usr/local/sbin/sp11-enable-wsa-routing.sh
+
+	log "Unmasking alsa-restore.service ..."
+	systemctl unmask alsa-restore.service 2>/dev/null || true
+	systemctl unmask alsa-state.service 2>/dev/null || true
+
+	log "Looking for most recent asound.state backup ..."
+	local backup="$(ls -t /var/lib/alsa/asound.state.bak.* 2>/dev/null | head -1)"
+	if [ -n "$backup" ] && [ -f "$backup" ]; then
+		log "Restoring $backup -> /var/lib/alsa/asound.state"
+		cp "$backup" /var/lib/alsa/asound.state
+	else
+		log "No backup found. Run alsactl store to create a fresh state."
+	fi
+
+	log "Restore complete. Reboot for changes to take effect."
+}
+
+# ── Argument parsing ─────────────────────────────────────────────────────
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--reboot) REBOOT="true"; shift ;;
+		--no-reboot) REBOOT="false"; shift ;;
+		-h|--help) usage; exit 0 ;;
+		pre-boot|post-boot|install|restore) ACTION="$1"; shift ;;
+		*) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+	esac
+done
+
+case "$ACTION" in
+	pre-boot) pre_boot ;;
+	post-boot) post_boot ;;
+	install) install_permanent ;;
+	restore) restore_fix ;;
+esac

--- a/scripts/sp11-pipewire-speaker-sink.sh
+++ b/scripts/sp11-pipewire-speaker-sink.sh
@@ -81,10 +81,22 @@ install_config() {
 # Surface Pro 11 manual speaker sink.
 #
 # Uses the 4-channel speaker PCM (hw:X1E80100Microso,1).
-# Only ch0+ch1 produce audio (left speaker). ch2+ch3 are silent at the
-# kernel level (suspected topology/SoundWire port mapping or regmap issue).
+# Channel mapping (verified 2026-06-19):
+#   ch0 (Front Left)  = Left physical speaker (working)
+#   ch1 (Front Right) = Left physical speaker (duplicate, working)
+#   ch2 (Rear Left)   = Right physical speaker (DAPM-gated, silent — see ADR-0034)
+#   ch3 (Rear Right)  = unused
+#
 # Mix-matrix sums stereo to left-mono on ch0+ch1, zeroes ch2+ch3.
-# See docs/adr/adr-0034-wsa2-regcache-right-speaker.md.
+# The right speaker is silenced by a kernel DAPM gate in lpass-wsa-macro.c
+# that prevents the right DMA RX bit from powering on. See ADR-0034.
+#
+# IMPORTANT: The WSA DMA route must be enabled after the AudioReach DSP graph
+# loads at boot. If sp11-wsa-routing.service is installed (via
+# sp11-fix-audio-boot-race.sh --install), this happens automatically.
+# Otherwise, use --enable-route or run sp11-enable-wsa-routing.sh manually.
+# Do NOT restore WSA mixer state via alsactl at boot — it races the DSP.
+# See docs/adr/adr-0035-audio-boot-race-alsactl.md.
 context.objects = [
     { factory = adapter
         args = {

--- a/scripts/systemd/sp11-pipewire-restart.service
+++ b/scripts/systemd/sp11-pipewire-restart.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Restart PipeWire after SP11 WSA routing is enabled
+# This user-level service waits for the system-level sp11-wsa-routing.service
+# to finish, then restarts PipeWire/WirePlumber so they connect to the speaker
+# sink cleanly.
+After=pipewire.service pipewire.socket
+Wants=pipewire.service
+
+[Service]
+Type=oneshot
+# Wait for the flag file written by sp11-enable-wsa-routing.sh
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do [ -f /run/sp11-wsa-routing-done ] && exit 0; sleep 1; done; exit 1'
+# Restart PipeWire and WirePlumber
+ExecStart=/bin/sh -c 'systemctl --user restart wireplumber pipewire pipewire-pulse 2>/dev/null; sleep 2; rm -f /run/sp11-wsa-routing-done 2>/dev/null; true'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/sp11-wsa-routing.service
+++ b/scripts/systemd/sp11-wsa-routing.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Enable Surface Pro 11 WSA speaker routing after DSP graph load
+# Run after the sound card appears and after alsa-restore (which we mask).
+# The script internally waits for the WSA mixer controls to become available,
+# which only happens after the AudioReach DSP graph has loaded.
+After=sound.target
+Wants=sound.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/sp11-enable-wsa-routing.sh
+RemainAfterExit=yes
+# If the DSP graph fails to load, don't mark the system as failed.
+SuccessExitStatus=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

This PR fixes a regression where the Surface Pro 11 audio stopped working after the initial topology bring-up (PR #4). The device produced only pops at boot instead of audio from the left speaker.

The root cause was a **boot race condition**: `alsa-restore.service` restored WSA mixer controls (DMA routes enabled, amplifier DAC/boost on, routing active) from `/var/lib/alsa/asound.state` at the exact same second the AudioReach DSP was loading the audio graph (`APM_CMD_GRAPH_OPEN`). The register writes from `alsactl` interfered with the DSP's graph construction, causing the graph-open to time out. Without the graph, the SoundWire bus came up unconfigured, causing continuous bus clash on both WSA884x amplifiers. The pops were the PA toggling on a dead bus.

The trigger was the manual `amixer` commands from the 2026-06-15 testing session (PR #4) getting saved to `asound.state` and restored at every subsequent boot.

## What Changed

- Added `scripts/sp11-fix-audio-boot-race.sh`
  - Diagnostic and fix script with four modes: `pre-boot`, `post-boot`, `install`, `restore`
  - `pre-boot`: backs up and clears WSA controls from `asound.state`, masks `alsa-restore.service`
  - `post-boot`: verifies DSP graph loaded cleanly, re-enables WSA routing, runs `speaker-test`
  - `install`: applies the permanent fix (pre-boot + systemd services + PipeWire restart)
  - `restore`: undoes the fix (unmasks alsa-restore, restores backup, removes services)

- Added `scripts/sp11-enable-wsa-routing.sh`
  - Waits for the ALSA card to appear (up to 30s)
  - Waits for WSA mixer controls to be available (card instantiated)
  - Polls `/sys/bus/soundwire/devices/*/status` for both WSA884x amps to reach `Attached`
  - Retries up to 3 times with sound card rebind if the graph fails to load
  - Only enables WSA routing once the DSP graph is confirmed loaded
  - Sets speaker hardware volume to 100% (PipeWire/GNOME is the sole volume control)
  - Writes a flag file (`/run/sp11-wsa-routing-done`) for the user-level PipeWire restart service

- Added `scripts/systemd/sp11-wsa-routing.service`
  - System-level oneshot, runs after `sound.target`
  - Executes `sp11-enable-wsa-routing.sh`

- Added `scripts/systemd/sp11-pipewire-restart.service`
  - User-level oneshot, waits for the flag file from the WSA routing service
  - Restarts PipeWire/WirePlumber so they connect to the speaker sink cleanly
  - Avoids the stale-stream / broken-pipe state when PipeWire starts before the DSP graph is ready

- Updated `scripts/install-sp11-support.sh`
  - Installs `sp11-enable-wsa-routing.sh` and `sp11-fix-audio-boot-race.sh` to `/usr/local/sbin/`
  - Installs both systemd services
  - Masks `alsa-restore.service` and `alsa-state.service`
  - Clears WSA controls from `asound.state` during install
  - Enables the WSA routing service for system-level and the PipeWire restart service for the user

- Updated `scripts/sp11-pipewire-speaker-sink.sh`
  - Updated comments with boot race notes and verified channel mapping
  - References ADR-0035 for the boot race and ADR-0034 for the right speaker silence

- Added `docs/adr/adr-0035-audio-boot-race-alsactl.md`
  - Full ADR documenting the boot race root cause, fix, and verification

- Updated `docs/how-to/how-to-bring-up-audio.md`
  - Added boot race fix section with install and verify steps
  - Updated status table

- Updated `README.md`
  - Updated audio status in the feature table
  - Added boot race fix instructions in the Audio section
  - Added ADR-0035 to the decision records list

## Current Audio Behavior

Validated working after fix:

- Audio works automatically after reboot with no manual intervention
- `sp11-wsa-routing.service` waits for DSP graph, enables WSA routing
- `sp11-pipewire-restart.service` restarts PipeWire after routing is ready
- Left speaker produces audio via PipeWire (`Surface Pro 11 Speakers` sink)
- Stereo content is summed to mono on the left speaker
- Hardware volume at 100% — GNOME/keyboard slider is the sole volume control
- Verified stable across multiple reboots

Still unresolved:

- Right physical speaker remains silent (kernel DAPM gate in `lpass-wsa-macro.c` — see ADR-0034)
- The `APM CMD timeout` still appears in dmesg on every boot but is harmless — the DSP recovers
- Headphone, headset mic, and HDMI/DisplayPort audio are not wired in the current DTS path
- PipeWire ACP/UCM auto-profile still does not create the final automatic sink

## Boot Sequence (After Fix)

```text
boot
  └─ ADSP/CDSP firmware loads (remoteproc)
  └─ snd-x1e80100 sound card instantiates
  └─ APM_CMD_GRAPH_OPEN sent to DSP
  │   └─ (timeout occurs but DSP recovers within a few seconds)
  └─ SoundWire slaves reach Attached state
  └─ sp11-wsa-routing.service runs
  │   └─ polls slave status until Attached
  │   └─ enables WSA DMA route + macro routing
  │   └─ sets speaker volume to 100%
  │   └─ writes /run/sp11-wsa-routing-done flag
  └─ sp11-pipewire-restart.service (user) runs
  │   └─ waits for flag file
  │   └─ restarts PipeWire/WirePlumber
  └─ user logs in, plays audio — works
```

## Installed Paths

```text
/usr/local/sbin/sp11-enable-wsa-routing.sh
/usr/local/sbin/sp11-fix-audio-boot-race.sh
/etc/systemd/system/sp11-wsa-routing.service
~/.config/systemd/user/sp11-pipewire-restart.service
```

## Validation

```bash
# Install the fix
sudo ./scripts/sp11-fix-audio-boot-race.sh install --no-reboot
sudo reboot

# After reboot — verify
systemctl status sp11-wsa-routing.service
systemctl --user status sp11-pipewire-restart.service
sudo journalctl -b -k | grep "CMD timeout"
amixer -c0 sget "WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2"
wpctl status | grep -A3 "Sinks:"
# Play music — should hear audio from the left speaker
```

## Safety Notes

- ALSA hardware `Speakers` volume is set to 100% (pass-through) — PipeWire/GNOME controls all attenuation
- `alsa-restore.service` is masked system-wide; other audio controls (VA mic) default to kernel values
- The APM CMD timeout is expected on every boot and is not an error — the DSP recovers