### PR TITLE
fix(audio): wait for ALSA card before PipeWire restart

### DIFF
--- a/scripts/systemd/sp11-pipewire-restart.service
+++ b/scripts/systemd/sp11-pipewire-restart.service
@@ -10,8 +10,12 @@ Wants=pipewire.service
 Type=oneshot
 # Wait for the flag file written by sp11-enable-wsa-routing.sh
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do [ -f /run/sp11-wsa-routing-done ] && exit 0; sleep 1; done; exit 1'
-# Restart PipeWire and WirePlumber
-ExecStart=/bin/sh -c 'systemctl --user restart wireplumber pipewire pipewire-pulse 2>/dev/null; sleep 2; rm -f /run/sp11-wsa-routing-done 2>/dev/null; true'
+# Wait for the ALSA card to be fully available to this user session,
+# then restart PipeWire/WirePlumber.
+# The delay is critical: PipeWire starts during the GDM/login session
+# before the ALSA card is fully registered, causing "Cannot get card
+# index" errors. We wait for aplay to see the card before restarting.
+ExecStart=/bin/sh -c 'for i in $(seq 1 30); do aplay -l 2>/dev/null | grep -q X1E80100Microso && break; sleep 1; done; sleep 3; systemctl --user restart wireplumber pipewire pipewire-pulse 2>/dev/null; sleep 2; rm -f /run/sp11-wsa-routing-done 2>/dev/null; true'
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
## Summary

Follow-up fix to PR #5. The `sp11-pipewire-restart.service` was restarting PipeWire immediately after the WSA routing flag file appeared, but the ALSA card was not yet fully registered in the user session. PipeWire failed with:

```text
ALSA lib confmisc.c:165:(snd_config_get_card) Cannot get card index for X1E80100Microso
spa.alsa: 'hw:X1E80100Microso,1': playback open failed: No such device
default: failed to create context: Invalid argument
```

PipeWire would crash, restart, and eventually create the sink in a broken state — no audio despite the sink appearing in `wpctl status`.

## What Changed

Updated `scripts/systemd/sp11-pipewire-restart.service` `ExecStart` to:
1. Poll `aplay -l` for the card name (up to 30s)
2. Wait an additional 3s for the card to fully settle
3. Then restart PipeWire/WirePlumber

This ensures the ALSA card is fully available before PipeWire tries to open the speaker PCM.

## Validation

Verified working across multiple reboots with no manual intervention. Left speaker produces audio automatically after boot.