### PR TITLE
Support Johan G qcom-x1e 7.1.1 kernel builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ payload directory:
   2>&1 | tee build/sp11-qcom-x1e-kernel-build-$(date +%Y%m%d-%H%M%S).log
 ```
 
+To build from Johan G.'s 7.1.1 qcom-x1e tree instead of the Ubuntu concept
+default, use the published git tag explicitly:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --git-branch jg/ubuntu-qcom-x1e-7.1.1-jg-0 \
+  --image ubuntu:26.04 \
+  --patch-dir patches/jglathe-qcom-x1e-7.1.1 \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.1 \
+  --copy-to-payload \
+  --reset-source \
+  --jobs 4 \
+  2>&1 | tee build/sp11-qcom-x1e-kernel-jg-7.1.1-build-$(date +%Y%m%d-%H%M%S).log
+```
+
 Build the direct-boot USB image. This image boots the Ubuntu concept ISO kernel
 for the live environment, injects the Surface Pro 11 DTB from GRUB, and carries
 the patched kernel packages under `SP11DATA/payload/kernel-debs/` for
@@ -759,6 +776,7 @@ The major bring-up decisions are recorded in `docs/adr/`:
 - [ADR0034: Right Speaker Silence — SoundWire Port Mapping and Regmap Cache](docs/adr/adr-0034-wsa2-regcache-right-speaker.md)
 - [ADR0035: Audio Boot Race — alsactl Restore vs AudioReach DSP Graph Load](docs/adr/adr-0035-audio-boot-race-alsactl.md)
 - [ADR0036: Right Speaker Audio via PipeWire audio.position Reorder](docs/adr/adr-0036-right-speaker-audio-position-reorder.md)
+- [ADR0037: Packaged Stubble Paths for Johan G. qcom-x1e 7.1.1](docs/adr/adr-0037-jglathe-qcom-7-1-1-stubble-paths.md)
 
 ## Windows Firmware
 

--- a/README.md
+++ b/README.md
@@ -127,12 +127,16 @@ default, use the published git tag explicitly:
   --git-branch jg/ubuntu-qcom-x1e-7.1.1-jg-0 \
   --image ubuntu:26.04 \
   --patch-dir patches/jglathe-qcom-x1e-7.1.1 \
+  --build-target "binary-indep binary-qcom-x1e" \
   --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.1 \
   --copy-to-payload \
   --reset-source \
   --jobs 4 \
   2>&1 | tee build/sp11-qcom-x1e-kernel-jg-7.1.1-build-$(date +%Y%m%d-%H%M%S).log
 ```
+
+The `binary-indep` target is required for this tree because the ABI-specific
+headers package depends on `linux-qcom-x1e-headers-7.1.1-jg-0`.
 
 Build the direct-boot USB image. This image boots the Ubuntu concept ISO kernel
 for the live environment, injects the Surface Pro 11 DTB from GRUB, and carries

--- a/docs/adr/adr-0037-jglathe-qcom-7-1-1-stubble-paths.md
+++ b/docs/adr/adr-0037-jglathe-qcom-7-1-1-stubble-paths.md
@@ -1,0 +1,146 @@
+---
+id: adr-0037-jglathe-qcom-7-1-1-stubble-paths
+title: "ADR0037: Packaged Stubble Paths for Johan G. qcom-x1e 7.1.1"
+# prettier-ignore
+description: Architecture Decision Record (ADR) for patching Johan G.'s qcom-x1e 7.1.1 Ubuntu packaging to use the stubble paths provided by Ubuntu 26.04 packages.
+---
+
+# ADR0037: Packaged Stubble Paths for Johan G. qcom-x1e 7.1.1
+
+## Status
+
+Accepted — required for the `jg/ubuntu-qcom-x1e-7.1.1-jg-0` Docker build
+path (2026-06-27).
+
+## Context
+
+The Surface Pro 11 bring-up can build Johan G.'s qcom-x1e 7.1.1 kernel tree
+using this repository's Docker kernel builder:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --git-branch jg/ubuntu-qcom-x1e-7.1.1-jg-0 \
+  --image ubuntu:26.04 \
+  --patch-dir patches/jglathe-qcom-x1e-7.1.1 \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.1 \
+  --copy-to-payload \
+  --reset-source
+```
+
+That source tag already carries the Surface Pro 11 `disable-rfkill` kernel
+and Denali DTB changes, so the normal rfkill patches are not needed for this
+path.
+
+The qcom-x1e 7.1.1 packaging enables `do_stubble=true` for ARM64. During
+`stamp-install-qcom-x1e`, the packaging calls `ukify` to assemble a
+kernel-plus-stub EFI image with Stubble device-tree metadata.
+
+The upstream packaging hardcodes:
+
+```text
+--stub=/usr/local/lib/stubble/stubble.efi
+--hwids=/usr/local/share/stubble/hwids
+--sbat=@/usr/share/stubble/sbat
+```
+
+In the Ubuntu 26.04 Docker container, the `stubble` package provides:
+
+```text
+/usr/lib/stubble/stubble.efi
+/usr/share/stubble/hwids
+/usr/share/stubble/sbat
+```
+
+The build therefore failed late in package assembly with:
+
+```text
+FileNotFoundError: [Errno 2] No such file or directory:
+'/usr/local/share/stubble/hwids'
+```
+
+## Decision
+
+Carry a Johan G. qcom-x1e 7.1.1-specific packaging patch:
+
+```text
+patches/jglathe-qcom-x1e-7.1.1/0002-debian-qcom-x1e-use-packaged-stubble-paths.patch
+```
+
+The patch changes only the Stubble paths in `debian/rules.d/2-binary-arch.mk`:
+
+```diff
+--- --stub=/usr/local/lib/stubble/stubble.efi
++++ --stub=/usr/lib/stubble/stubble.efi
+--- --hwids=/usr/local/share/stubble/hwids
++++ --hwids=/usr/share/stubble/hwids
+```
+
+The SBAT path already points at `/usr/share/stubble/sbat`, so it remains
+unchanged.
+
+## Consequences
+
+The Docker build uses the files installed by Ubuntu's `stubble` package
+instead of relying on locally installed `/usr/local` copies.
+
+This keeps the fix scoped to the Johan G. 7.1.1 path through `--patch-dir
+patches/jglathe-qcom-x1e-7.1.1`; it does not change the default Ubuntu concept
+git fallback or apt-source kernel builds.
+
+If a future Johan G. tag updates its packaging to use distro Stubble paths, the
+patch will become either already applied or unnecessary. The build helper's
+patch application should then report the patch as already applied or fail in a
+way that prompts review of the version-specific patch directory.
+
+If Ubuntu changes the `stubble` package layout again, this ADR and the patch
+should be revisited rather than adding symlinks in the Docker image.
+
+## Alternatives Considered
+
+### Install symlinks in the Docker container
+
+The build could create compatibility symlinks from `/usr/local` to `/usr`.
+This was rejected because it hides an upstream packaging assumption in the
+container setup and makes the build less explicit.
+
+### Disable Stubble packaging
+
+Disabling `do_stubble` would avoid the failing `ukify` step. This was rejected
+because the qcom-x1e 7.1.1 packaging intentionally builds the Stubble-enabled
+EFI image and declares `stubble`/`systemd-ukify` as build dependencies.
+
+### Vendor Stubble files into this repository
+
+Vendoring the EFI stub or hardware-id database was rejected. The files are
+already provided by Ubuntu's `stubble` package in the build container.
+
+## Verification
+
+The patch was validated against the checked-out
+`jg/ubuntu-qcom-x1e-7.1.1-jg-0` source tree in the Docker work volume. After
+applying the patch:
+
+```text
+--stub=/usr/lib/stubble/stubble.efi
+--hwids=/usr/share/stubble/hwids
+--sbat=@/usr/share/stubble/sbat
+```
+
+The annotations compatibility patch in the same patch directory was also
+validated at the same time:
+
+```text
+CONFIG_DRM_MSM_VALIDATE_XML policy<{'arm64': '-'}>
+CONFIG_RUST_IS_AVAILABLE    policy<{'arm64': 'y'}>
+```
+
+The next full build should proceed past the previous missing
+`/usr/local/share/stubble/hwids` failure.
+
+## Related
+
+- [ADR021: Git Fallback Kernel Build Toolchain](adr-0021-git-fallback-kernel-build-toolchain.md)
+- [ADR019: Patched qcom-x1e Kernel for Wi-Fi rfkill](adr-0019-patched-qcom-x1e-kernel-for-wifi-rfkill.md)
+- [Repeat Patched Kernel Build for a New qcom-x1e Release](../how-to/how-to-repeat-kernel-build-for-new-release.md)

--- a/docs/adr/adr-0038-split-compressed-live-image-release-assets.md
+++ b/docs/adr/adr-0038-split-compressed-live-image-release-assets.md
@@ -1,0 +1,193 @@
+---
+id: adr-0038-split-compressed-live-image-release-assets
+title: "ADR0038: Split Compressed Live Image Release Assets"
+# prettier-ignore
+description: Architecture Decision Record (ADR) for publishing Surface Pro 11 live USB raw images as split compressed GitHub Release assets.
+---
+
+# ADR0038: Split Compressed Live Image Release Assets
+
+## Status
+
+Accepted — required for publishing the Surface Pro 11 direct-boot live USB
+image through GitHub Releases (2026-06-27).
+
+## Context
+
+The Surface Pro 11 bring-up can produce a direct-boot Ubuntu live USB raw disk
+image:
+
+```text
+build/sp11-ubuntu-live-direct.img
+```
+
+For the Johan G. qcom-x1e 7.1.1 test image, the raw disk image is about 6.2 GB.
+The image contains:
+
+- an EFI system partition labeled `SP11EFI`
+- an ext4 data partition labeled `SP11DATA`
+- the direct GRUB boot path for the Surface Pro 11 Denali DTB
+- the Ubuntu concept ISO payload
+- the Surface Pro 11 support tree
+- optional payloads such as audio files and qcom-x1e kernel `.deb` packages
+
+The live image validator already records a useful release outline:
+
+```text
+== Image ==
+== GPT ==
+== ESP ==
+== Data Partition ==
+== Payload ==
+== Support Helpers ==
+```
+
+That outline should travel with the image release so users can inspect the
+partition layout, boot mode, payload contents, DTB checksum, and support-helper
+markers without rebuilding the image.
+
+GitHub Release uploads reject a single asset that is 2,147,483,648 bytes or
+larger. Uploading the raw `.img` therefore fails with a validation error:
+
+```text
+size must be less than 2147483648
+```
+
+## Decision
+
+Publish live USB image releases as split compressed assets rather than as a
+single raw image.
+
+The release helper:
+
+```text
+scripts/prepare-sp11-image-release-assets.sh
+```
+
+will:
+
+1. validate the raw image with `scripts/build-sp11-live-usb-image.sh
+   --validate-image`
+2. save the validator output as `sp11-live-image-outline.txt`
+3. compress the raw image with `zstd -6`
+4. split the compressed `.zst` file into parts smaller than GitHub's asset
+   limit
+5. remove the temporary whole `.zst` file from the release directory
+6. write `sp11-live-image-release-manifest.txt`
+7. write `SHA256SUMS` for the uploaded parts and metadata files
+8. write `RELEASE-NOTES.md` with reconstruct, verify, and write commands
+9. print a `gh release create` command that uploads only GitHub-safe assets
+
+The default part size is 2,000,000,000 bytes. The helper rejects any configured
+part size that is greater than or equal to 2,147,483,648 bytes.
+
+The manifest records:
+
+- raw image size and SHA256
+- compressed image size and SHA256
+- per-part size and SHA256
+- validator outline SHA256
+- support repository commit and dirty state
+- whether validation ran
+
+The generated release notes instruct users to:
+
+```bash
+shasum -a 256 -c SHA256SUMS
+cat sp11-ubuntu-live-direct.img.zst.part-* > sp11-ubuntu-live-direct.img.zst
+printf '%s  %s\n' '<compressed-sha256>' 'sp11-ubuntu-live-direct.img.zst' | shasum -a 256 -c -
+zstd -d --force sp11-ubuntu-live-direct.img.zst
+printf '%s  %s\n' '<raw-image-sha256>' 'sp11-ubuntu-live-direct.img' | shasum -a 256 -c -
+sudo dd if=sp11-ubuntu-live-direct.img of=/dev/diskX bs=16M conv=fsync status=progress
+```
+
+The exact hashes are generated into the release notes for each release.
+
+## Consequences
+
+The image can be published entirely through GitHub Releases without relying on
+Google Drive, external object storage, or a separate hosting account.
+
+Users must download multiple part files and reconstruct the compressed image
+before writing the USB disk. This adds one step, but keeps all release assets
+under the same tag, with checksums and provenance in one place.
+
+The raw `.img` is intentionally not uploaded as a release asset. The uploaded
+payload is the split compressed archive plus metadata files.
+
+The release remains experimental. The raw image is unsigned, and users must
+verify checksums and choose the correct removable disk before writing.
+
+## Alternatives Considered
+
+### Upload the raw image to GitHub Releases
+
+This was rejected because GitHub rejects assets that are 2,147,483,648 bytes or
+larger. The current raw image is much larger than that limit.
+
+### Upload the image to a public Google Drive link
+
+This was rejected as the default path because the image would no longer live
+with the release tag, checksums, and generated provenance. External links can
+also change, hit quota limits, or be harder to mirror.
+
+An external mirror can still be added as a convenience later, but GitHub
+Releases should remain the canonical artifact location.
+
+### Split the raw image without compression
+
+This would avoid a decompression step but would require more uploaded assets
+and more total download bandwidth. Compression reduces the release size while
+still allowing deterministic reconstruction and checksum verification.
+
+### Compress without splitting
+
+This was rejected because the compressed image can still exceed GitHub's per
+asset limit. The Johan G. qcom-x1e 7.1.1 direct image compressed to about 4.2
+GB, which still requires splitting.
+
+## Verification
+
+The helper was validated against the direct image generated for the Johan G.
+qcom-x1e 7.1.1 path.
+
+Validation performed:
+
+```bash
+bash -n scripts/prepare-sp11-image-release-assets.sh
+./scripts/prepare-sp11-image-release-assets.sh \
+  --image build/sp11-ubuntu-live-direct.img \
+  --release-name sp11-ubuntu-live-direct-jg-7.1.1 \
+  --allow-dirty
+cd build/release/sp11-ubuntu-live-direct-jg-7.1.1
+shasum -a 256 -c SHA256SUMS
+```
+
+The generated release assets were:
+
+```text
+sp11-live-image-outline.txt
+sp11-live-image-release-manifest.txt
+SHA256SUMS
+sp11-ubuntu-live-direct.img.zst.part-aa
+sp11-ubuntu-live-direct.img.zst.part-ab
+sp11-ubuntu-live-direct.img.zst.part-ac
+```
+
+The split parts were below GitHub's per-asset upload limit.
+
+The parts were also stream-verified:
+
+```bash
+cat sp11-ubuntu-live-direct.img.zst.part-* | shasum -a 256
+cat sp11-ubuntu-live-direct.img.zst.part-* | zstd -d -c | shasum -a 256
+```
+
+The reconstructed compressed archive hash matched the manifest, and the
+decompressed raw image hash matched the manifest.
+
+## Related
+
+- [ADR026: Prebuilt Kernel Release Artifacts](adr-0026-prebuilt-kernel-release-artifacts.md)
+- [ADR037: Packaged Stubble Paths for Johan G. qcom-x1e 7.1.1](adr-0037-jglathe-qcom-7-1-1-stubble-paths.md)
+- [Prepare Surface Pro 11 live USB image release assets](../../scripts/prepare-sp11-image-release-assets.sh)

--- a/docs/how-to/how-to-repeat-kernel-build-for-new-release.md
+++ b/docs/how-to/how-to-repeat-kernel-build-for-new-release.md
@@ -133,12 +133,16 @@ directory between refs:
   --git-branch jg/ubuntu-qcom-x1e-7.1.1-jg-0 \
   --image ubuntu:26.04 \
   --patch-dir patches/jglathe-qcom-x1e-7.1.1 \
+  --build-target "binary-indep binary-qcom-x1e" \
   --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.1 \
   --copy-to-payload \
   --reset-source \
   --jobs 5 \
   2>&1 | tee build/sp11-qcom-x1e-kernel-jg-7.1.1-build-$(date +%Y%m%d-%H%M%S).log
 ```
+
+The `binary-indep` target is required for this tree because the ABI-specific
+headers package depends on `linux-qcom-x1e-headers-7.1.1-jg-0`.
 
 **Option B: On-device (fallback)**
 

--- a/docs/how-to/how-to-repeat-kernel-build-for-new-release.md
+++ b/docs/how-to/how-to-repeat-kernel-build-for-new-release.md
@@ -121,6 +121,25 @@ fallback (builds from the public `qcom-x1e-7.0` branch, note ABI may not match):
   --copy-to-payload
 ```
 
+To build from Johan G.'s 7.1.1 qcom-x1e tree, use the published tag from
+`jglathe/linux_ms_dev_kit`. The tag is named like a branch in GitHub URLs, but
+it is a git tag, so keep `--reset-source` when switching an existing work
+directory between refs:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --git-branch jg/ubuntu-qcom-x1e-7.1.1-jg-0 \
+  --image ubuntu:26.04 \
+  --patch-dir patches/jglathe-qcom-x1e-7.1.1 \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.1 \
+  --copy-to-payload \
+  --reset-source \
+  --jobs 5 \
+  2>&1 | tee build/sp11-qcom-x1e-kernel-jg-7.1.1-build-$(date +%Y%m%d-%H%M%S).log
+```
+
 **Option B: On-device (fallback)**
 
 On the Surface directly:

--- a/docs/how-to/how-to-troubleshoot-docker-exec-format-error.md
+++ b/docs/how-to/how-to-troubleshoot-docker-exec-format-error.md
@@ -201,7 +201,7 @@ cd /path/to/linux-surface-pro-11-oe
 ```
 
 The helper locates its own patch directory via `repo_dir`
-(`scripts/build-sp11-qcom-x1e-kernel.sh:97`), so it works from any checkout.
+(`scripts/build-sp11-qcom-x1e-kernel.sh:98`), so it works from any checkout.
 
 The default source mode is `apt`, which derives the source package and version
 from the running kernel and needs `deb-src` entries enabled for the qcom-x1e

--- a/docs/how-to/how-to-troubleshoot-kernel-git-clone-failures.md
+++ b/docs/how-to/how-to-troubleshoot-kernel-git-clone-failures.md
@@ -21,7 +21,7 @@ If the source tree was partially prepared, rerun with --reset-source after fixin
 ## Purpose
 
 The `--source git` path clones the Ubuntu qcom-x1e kernel git branch
-(`scripts/build-sp11-qcom-x1e-kernel.sh:400`):
+(`scripts/build-sp11-qcom-x1e-kernel.sh:412`):
 `https://git.launchpad.net/~ubuntu-concept/ubuntu/+source/linux/+git/resolute`
 branch `qcom-x1e-7.0`. This is a large multi-gigabyte repository. The clone is
 not shallow, so it pulls the full history.
@@ -46,7 +46,7 @@ fallbacks.
 - `sudo` access on the build host (to inspect logs and free resources).
 - Enough free disk for the kernel source tree (several GB) plus the build
   output (the wrapper requires at least 40 GiB free, enforced by
-  `scripts/build-sp11-qcom-x1e-kernel.sh:311`).
+  `scripts/build-sp11-qcom-x1e-kernel.sh:316`).
 
 ## Procedure
 
@@ -119,7 +119,7 @@ free -h
 ### 3. Retry with `--reset-source`
 
 A failed `git clone` leaves a partial directory behind. On the next run,
-`scripts/build-sp11-qcom-x1e-kernel.sh:363` (`ensure_clean_source`) may reject
+`scripts/build-sp11-qcom-x1e-kernel.sh:364` (`ensure_clean_source`) may reject
 it if it is not a valid git checkout, or if it contains untracked files from
 the incomplete clone; otherwise the helper attempts a `fetch`/`checkout` that
 can fail on the broken tree. In either case, rerun with `--reset-source` to
@@ -130,19 +130,19 @@ wipe the partial checkout and start a clean clone.
 `--reset-source` does **not** mean your repository is dirty or that this
 repo's source is unclean. It means: "delete the existing source checkout
 directory and start the clone from scratch." Concretely, in git mode
-(`scripts/build-sp11-qcom-x1e-kernel.sh:398`):
+(`scripts/build-sp11-qcom-x1e-kernel.sh:394`):
 
 - With `--reset-source`: the existing source directory is `rm -rf`'d and a
   fresh `git clone` runs.
 - Without `--reset-source`: if the directory already exists, the helper
   fetches, checks out the branch, and resets hard to `origin/$GIT_BRANCH`
-  (`scripts/build-sp11-qcom-x1e-kernel.sh:402-410`). It only **errors out** if it
+  (`scripts/build-sp11-qcom-x1e-kernel.sh:414-423`). It only **errors out** if it
   detects local changes, untracked files, or local commits not present on the
   remote — or if the directory is not a valid git checkout (as happens after a
   failed `clone` leaves a partial tree behind).
 
 The wrapper's failure message
-(`scripts/build-sp11-qcom-x1e-kernel-docker.sh:521`) always appends the
+(`scripts/build-sp11-qcom-x1e-kernel-docker.sh:560`) always appends the
 `--reset-source` hint after a failure. It is generic recovery advice for a
 partially-prepared source tree, not a diagnosis that the kernel repo is
 broken.
@@ -203,9 +203,9 @@ Resolving deltas: 100% (...), done.
 
 The build then proceeds to patch application and `debian/rules`. Common build
 dependencies are installed before the clone
-(`scripts/build-sp11-qcom-x1e-kernel.sh:734-745`); git-source-specific build
+(`scripts/build-sp11-qcom-x1e-kernel.sh:812`); git-source-specific build
 dependencies are installed after patching
-(`scripts/build-sp11-qcom-x1e-kernel.sh:749`).
+(`scripts/build-sp11-qcom-x1e-kernel.sh:826`).
 
 ## Validation
 
@@ -281,7 +281,7 @@ cd /path/to/linux-surface-pro-11-oe
 ```
 
 The helper locates its own patch directory via `repo_dir`
-(`scripts/build-sp11-qcom-x1e-kernel.sh:97`), so it works from any checkout.
+(`scripts/build-sp11-qcom-x1e-kernel.sh:98`), so it works from any checkout.
 If a previous clone failed on the Surface, add `--reset-source` to clear the
 partial checkout before retrying.
 

--- a/patches/jglathe-qcom-x1e-7.1.1/0001-debian-qcom-x1e-update-annotations-for-7.1.1-jg-0.patch
+++ b/patches/jglathe-qcom-x1e-7.1.1/0001-debian-qcom-x1e-update-annotations-for-7.1.1-jg-0.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Surface Pro 11 bring-up <noreply@example.invalid>
+Date: Sat, 27 Jun 2026 00:00:00 +0000
+Subject: [PATCH] debian.qcom-x1e: update annotations for 7.1.1-jg-0 build
+
+When building the jg/ubuntu-qcom-x1e-7.1.1-jg-0 tag in an Ubuntu 26.04
+container, olddefconfig changes two annotation-visible symbols:
+
+  CONFIG_DRM_MSM_VALIDATE_XML changes from n to absent
+  CONFIG_RUST_IS_AVAILABLE is generated as y
+
+Match the generated config so Ubuntu's annotations check can proceed.
+---
+ debian.qcom-x1e/config/annotations | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/debian.qcom-x1e/config/annotations b/debian.qcom-x1e/config/annotations
+index db6d4d705..910c56132 100644
+--- a/debian.qcom-x1e/config/annotations
++++ b/debian.qcom-x1e/config/annotations
+@@ -3245,7 +3245,7 @@ CONFIG_DRM_MSM_KMS_FBDEV                        policy<{'arm64': 'y'}>
+ CONFIG_DRM_MSM_MDP4                             policy<{'arm64': 'y'}>
+ CONFIG_DRM_MSM_MDP5                             policy<{'arm64': 'y'}>
+ CONFIG_DRM_MSM_MDSS                             policy<{'arm64': 'y'}>
+-CONFIG_DRM_MSM_VALIDATE_XML                     policy<{'arm64': 'n'}>
++CONFIG_DRM_MSM_VALIDATE_XML                     policy<{'arm64': '-'}>
+ CONFIG_DRM_MXS                                  policy<{'arm64': 'y'}>
+ CONFIG_DRM_MXSFB                                policy<{'arm64': 'm'}>
+ CONFIG_DRM_NOUVEAU                              policy<{'arm64': 'm'}>
+@@ -9719,6 +9719,7 @@ CONFIG_RT_MUTEXES                               policy<{'arm64': 'y'}>
+ CONFIG_RUNTIME_TESTING_MENU                     policy<{'arm64': 'y'}>
+ CONFIG_RUSTC_HAS_FILE_AS_C_STR                  policy<{'arm64': 'y'}>
+ CONFIG_RUSTC_HAS_FILE_WITH_NUL                  policy<{'arm64': 'y'}>
+ CONFIG_RUSTC_HAS_SPAN_FILE                      policy<{'arm64': 'y'}>
++CONFIG_RUST_IS_AVAILABLE                        policy<{'arm64': 'y'}>
+ CONFIG_RUSTC_HAS_UNNECESSARY_TRANSMUTES         policy<{'arm64': 'y'}>
+ CONFIG_RUSTC_LLVM_MAJOR_VERSION                 policy<{'arm64': '21'}>
+ CONFIG_RUSTC_LLVM_VERSION                       policy<{'arm64': '210108'}>
+-- 
+2.50.0
+

--- a/patches/jglathe-qcom-x1e-7.1.1/0002-debian-qcom-x1e-use-packaged-stubble-paths.patch
+++ b/patches/jglathe-qcom-x1e-7.1.1/0002-debian-qcom-x1e-use-packaged-stubble-paths.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Surface Pro 11 bring-up <noreply@example.invalid>
+Date: Sat, 27 Jun 2026 00:00:00 +0000
+Subject: [PATCH] debian.qcom-x1e: use packaged stubble paths
+
+Ubuntu's stubble package installs the EFI stub and hardware-id database under
+/usr/lib/stubble and /usr/share/stubble. The jg/ubuntu-qcom-x1e-7.1.1-jg-0
+packaging invokes ukify with /usr/local paths, which are absent in the Docker
+build container even when the stubble package is installed.
+
+Use the packaged paths so the qcom-x1e image package can be assembled.
+---
+ debian/rules.d/2-binary-arch.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/debian/rules.d/2-binary-arch.mk b/debian/rules.d/2-binary-arch.mk
+index 5e36c64d..9c2a49e4 100644
+--- a/debian/rules.d/2-binary-arch.mk
++++ b/debian/rules.d/2-binary-arch.mk
+@@ -176,8 +176,8 @@ endif
+ ifeq ($(do_stubble),true)
+ 	# Build kernel+stub image
+ 	/usr/bin/ukify build --linux=$(build_dir)/$(kernfile) \
+-	        --stub=/usr/local/lib/stubble/stubble.efi \
+-	        --hwids=/usr/local/share/stubble/hwids \
++	        --stub=/usr/lib/stubble/stubble.efi \
++	        --hwids=/usr/share/stubble/hwids \
+ 	        --sbat="@/usr/share/stubble/sbat" \
+ 		$(STUBBLEDTBS) \
+ 	        --output=$(build_dir)/$(kernfile).stubble
+-- 
+2.50.0
+

--- a/patches/jglathe-qcom-x1e-7.1.1/README.md
+++ b/patches/jglathe-qcom-x1e-7.1.1/README.md
@@ -1,0 +1,8 @@
+# Johan G. qcom-x1e 7.1.1 build compatibility patches
+
+These patches are for building Johan G.'s `linux_ms_dev_kit` qcom-x1e 7.1.1
+tag with this repository's Docker kernel builder.
+
+The upstream tag already carries the Surface Pro 11 Wi-Fi `disable-rfkill`
+kernel and Denali DTB changes, so this directory only carries build policy
+compatibility patches needed by Ubuntu's `check-config` step.

--- a/scripts/build-sp11-qcom-x1e-kernel-docker.sh
+++ b/scripts/build-sp11-qcom-x1e-kernel-docker.sh
@@ -57,7 +57,8 @@ Options:
                          Docker volume for --container-work-dir, default
                          $LINUX_WORK_VOLUME. Ignored when --container-work-dir
                          is /work.
-  --build-target TARGET  Kernel package target, default from metadata or script.
+  --build-target TARGET  Kernel package target or quoted target list,
+                         default from metadata or script.
   --patch-dir DIR        Patch directory to pass to the inner build helper.
   --jobs N              Parallel build jobs passed to the inner build helper.
   --min-free-gb N        Free-space guard passed to the inner build helper.
@@ -98,6 +99,7 @@ find_qcom_kernel_debs() {
     -o -name 'linux-modules-*-qcom-x1e_*.deb' \
     -o -name 'linux-modules-extra-*-qcom-x1e_*.deb' \
     -o -name 'linux-headers-*-qcom-x1e_*.deb' \
+    -o -name 'linux-qcom-x1e-headers-*_*.deb' \
     -o -name 'linux-qcom-x1e_*.deb' \
     -o -name 'linux-image-qcom-x1e_*.deb' \
     -o -name 'linux-headers-qcom-x1e_*.deb' \) \
@@ -488,6 +490,7 @@ find_qcom_kernel_debs() {
     -o -name 'linux-modules-*-qcom-x1e_*.deb' \
     -o -name 'linux-modules-extra-*-qcom-x1e_*.deb' \
     -o -name 'linux-headers-*-qcom-x1e_*.deb' \
+    -o -name 'linux-qcom-x1e-headers-*_*.deb' \
     -o -name 'linux-qcom-x1e_*.deb' \
     -o -name 'linux-image-qcom-x1e_*.deb' \
     -o -name 'linux-headers-qcom-x1e_*.deb' \) \

--- a/scripts/build-sp11-qcom-x1e-kernel-docker.sh
+++ b/scripts/build-sp11-qcom-x1e-kernel-docker.sh
@@ -13,6 +13,7 @@ SOURCE_VERSION=""
 GIT_URL=""
 GIT_BRANCH=""
 BUILD_TARGET=""
+PATCH_DIR=""
 JOBS=""
 MIN_FREE_GB=""
 APT_SOURCES_FILE=""
@@ -42,7 +43,7 @@ Options:
   --source-package NAME  apt source package. Usually comes from --metadata.
   --source-version VER   apt source version. Usually comes from --metadata.
   --git-url URL          Kernel git URL for git mode.
-  --git-branch BRANCH    Kernel git branch for git mode.
+  --git-branch BRANCH    Kernel git branch or tag for git mode.
   --image IMAGE          Docker image. Defaults to ubuntu:26.04 for apt mode
                          and ubuntu:25.10 for git mode.
   --platform PLATFORM    Docker platform, default $PLATFORM.
@@ -57,6 +58,7 @@ Options:
                          $LINUX_WORK_VOLUME. Ignored when --container-work-dir
                          is /work.
   --build-target TARGET  Kernel package target, default from metadata or script.
+  --patch-dir DIR        Patch directory to pass to the inner build helper.
   --jobs N              Parallel build jobs passed to the inner build helper.
   --min-free-gb N        Free-space guard passed to the inner build helper.
   --apt-sources FILE     Optional .sources or .list file to add inside container.
@@ -115,6 +117,21 @@ repo_abs_path() {
   case "$1" in
     /*) printf '%s\n' "$1" ;;
     *) printf '%s/%s\n' "$repo_dir" "$1" ;;
+  esac
+}
+
+repo_container_path() {
+  local abs rel
+  abs="$(repo_abs_path "$1")"
+  case "$abs" in
+    "$repo_dir"/*)
+      rel="${abs#"$repo_dir"/}"
+      printf '/repo/%s\n' "$rel"
+      ;;
+    *)
+      echo "Path must be inside this repository so Docker can access it: $1" >&2
+      exit 1
+      ;;
   esac
 }
 
@@ -194,6 +211,11 @@ while [ "$#" -gt 0 ]; do
       BUILD_TARGET="$2"
       shift 2
       ;;
+    --patch-dir)
+      require_arg "$1" "${2:-}"
+      PATCH_DIR="$2"
+      shift 2
+      ;;
     --jobs)
       require_arg "$1" "${2:-}"
       JOBS="$2"
@@ -258,7 +280,12 @@ esac
 
 if [ -z "$IMAGE" ]; then
   case "$SOURCE_MODE" in
-    git) IMAGE="ubuntu:25.10" ;;
+    git)
+      case "$GIT_BRANCH" in
+        jg/ubuntu-qcom-x1e-7.1.1-*) IMAGE="ubuntu:26.04" ;;
+        *) IMAGE="ubuntu:25.10" ;;
+      esac
+      ;;
     *) IMAGE="ubuntu:26.04" ;;
   esac
 fi
@@ -339,6 +366,14 @@ if [ -n "$APT_SOURCES_FILE" ]; then
   fi
 fi
 
+if [ -n "$PATCH_DIR" ]; then
+  patch_dir_abs="$(repo_abs_path "$PATCH_DIR")"
+  if [ ! -d "$patch_dir_abs" ]; then
+    echo "Patch directory not found: $patch_dir_abs" >&2
+    exit 1
+  fi
+fi
+
 mkdir -p "$WORK_DIR"
 work_abs="$(abs_path "$WORK_DIR")"
 
@@ -374,6 +409,7 @@ case "$SOURCE_MODE" in
 esac
 
 [ -n "$BUILD_TARGET" ] && inner_args+=(--build-target "$BUILD_TARGET")
+[ -n "$PATCH_DIR" ] && inner_args+=(--patch-dir "$(repo_container_path "$PATCH_DIR")")
 [ -n "$JOBS" ] && inner_args+=(--jobs "$JOBS")
 [ -n "$MIN_FREE_GB" ] && inner_args+=(--min-free-gb "$MIN_FREE_GB")
 [ "$RESET_SOURCE" = "true" ] && inner_args+=(--reset-source)

--- a/scripts/build-sp11-qcom-x1e-kernel.sh
+++ b/scripts/build-sp11-qcom-x1e-kernel.sh
@@ -39,7 +39,7 @@ Options:
   --source-version VER   apt source version: installed, candidate, or exact.
                          Default $SOURCE_VERSION.
   --git-url URL          Kernel git URL for git mode, default $GIT_URL.
-  --git-branch BRANCH    Kernel git branch for git mode, default $GIT_BRANCH.
+  --git-branch BRANCH    Kernel git branch or tag for git mode, default $GIT_BRANCH.
   --patch-dir DIR        Patch directory, default repo patches/ubuntu-qcom-x1e-7.0.
   --work-dir DIR         Build work directory, default $WORK_DIR.
   --build-target TARGET  Kernel package target, default $BUILD_TARGET.
@@ -391,23 +391,40 @@ ensure_clean_source() {
 }
 
 prepare_git_source() {
-  local safe_branch dir local_commits
+  local safe_branch dir local_commits ref_kind
   safe_branch="${GIT_BRANCH//\//-}"
   dir="$source_parent/git-$safe_branch"
+  ref_kind=""
+
+  if git ls-remote --exit-code --heads "$GIT_URL" "$GIT_BRANCH" >/dev/null 2>&1; then
+    ref_kind="head"
+  elif git ls-remote --exit-code --tags "$GIT_URL" "$GIT_BRANCH" >/dev/null 2>&1; then
+    ref_kind="tag"
+  else
+    echo "Git ref not found as a branch or tag: $GIT_BRANCH" >&2
+    echo "Remote: $GIT_URL" >&2
+    exit 1
+  fi
 
   ensure_clean_source "$dir"
   if [ ! -d "$dir" ]; then
     git clone --branch "$GIT_BRANCH" "$GIT_URL" "$dir"
   else
-    git -C "$dir" fetch origin "$GIT_BRANCH"
-    git -C "$dir" checkout "$GIT_BRANCH"
-    local_commits="$(git -C "$dir" rev-list --count "origin/$GIT_BRANCH..HEAD" 2>/dev/null || echo 0)"
-    if [ "$local_commits" != "0" ]; then
-      echo "Existing source tree has local commits not present in origin/$GIT_BRANCH: $dir" >&2
-      echo "Move them away or rerun with --reset-source." >&2
-      exit 1
+    if [ "$ref_kind" = "head" ]; then
+      git -C "$dir" fetch origin "$GIT_BRANCH"
+      git -C "$dir" checkout "$GIT_BRANCH"
+      local_commits="$(git -C "$dir" rev-list --count "origin/$GIT_BRANCH..HEAD" 2>/dev/null || echo 0)"
+      if [ "$local_commits" != "0" ]; then
+        echo "Existing source tree has local commits not present in origin/$GIT_BRANCH: $dir" >&2
+        echo "Move them away or rerun with --reset-source." >&2
+        exit 1
+      fi
+      git -C "$dir" reset --hard "origin/$GIT_BRANCH"
+    else
+      git -C "$dir" fetch --force origin "refs/tags/$GIT_BRANCH:refs/tags/$GIT_BRANCH"
+      git -C "$dir" checkout --detach "refs/tags/$GIT_BRANCH"
+      git -C "$dir" reset --hard "refs/tags/$GIT_BRANCH"
     fi
-    git -C "$dir" reset --hard "origin/$GIT_BRANCH"
   fi
 
   source_dir="$dir"
@@ -497,6 +514,23 @@ apply_patches() {
   echo "Applying patches from $PATCH_DIR"
   for patch in "$PATCH_DIR"/*.patch; do
     [ -f "$patch" ] || continue
+
+    case "$(basename "$patch")" in
+      0001-wifi-ath12k-add-disable-rfkill-devicetree.patch)
+        if grep -q 'of_property_read_bool(ab->dev->of_node, "disable-rfkill")' \
+          "$source_dir/drivers/net/wireless/ath/ath12k/core.c"; then
+          echo "Already satisfied: $(basename "$patch")"
+          continue
+        fi
+        ;;
+      0002-arm64-dts-qcom-x1-denali-disable-rfkill-for-wifi.patch)
+        if grep -q 'disable-rfkill;' \
+          "$source_dir/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi"; then
+          echo "Already satisfied: $(basename "$patch")"
+          continue
+        fi
+        ;;
+    esac
 
     if git -C "$source_dir" apply --reverse --check "$patch" >/dev/null 2>&1; then
       echo "Already applied: $(basename "$patch")"

--- a/scripts/build-sp11-qcom-x1e-kernel.sh
+++ b/scripts/build-sp11-qcom-x1e-kernel.sh
@@ -42,7 +42,8 @@ Options:
   --git-branch BRANCH    Kernel git branch or tag for git mode, default $GIT_BRANCH.
   --patch-dir DIR        Patch directory, default repo patches/ubuntu-qcom-x1e-7.0.
   --work-dir DIR         Build work directory, default $WORK_DIR.
-  --build-target TARGET  Kernel package target, default $BUILD_TARGET.
+  --build-target TARGET  Kernel package target or quoted target list,
+                         default $BUILD_TARGET.
   --jobs N              Parallel build jobs, default detected CPU count.
   --min-free-gb N        Required free space in work dir, default $MIN_FREE_GB.
   --install-deps        Install common build dependencies and apt build-deps.
@@ -601,6 +602,7 @@ collect_kernel_debs() {
       -o -name 'linux-modules-*-qcom-x1e_*.deb' \
       -o -name 'linux-modules-extra-*-qcom-x1e_*.deb' \
       -o -name 'linux-headers-*-qcom-x1e_*.deb' \
+      -o -name 'linux-qcom-x1e-headers-*_*.deb' \
       -o -name 'linux-qcom-x1e_*.deb' \
       -o -name 'linux-image-qcom-x1e_*.deb' \
       -o -name 'linux-headers-qcom-x1e_*.deb' \)
@@ -610,6 +612,7 @@ collect_kernel_debs() {
       -o -name 'linux-modules-*-qcom-x1e_*.deb' \
       -o -name 'linux-modules-extra-*-qcom-x1e_*.deb' \
       -o -name 'linux-headers-*-qcom-x1e_*.deb' \
+      -o -name 'linux-qcom-x1e-headers-*_*.deb' \
       -o -name 'linux-qcom-x1e_*.deb' \
       -o -name 'linux-image-qcom-x1e_*.deb' \
       -o -name 'linux-headers-qcom-x1e_*.deb' \)
@@ -709,13 +712,50 @@ ensure_kernel_fallback() {
   echo "Found installed fallback qcom-x1e kernel ABI: $fallback_abi"
 }
 
+ensure_header_dependencies_present() {
+  local deb base abi common_pkg common_found
+
+  for deb in "$@"; do
+    base="$(basename "$deb")"
+    case "$base" in
+      linux-headers-*-qcom-x1e_*.deb)
+        abi="${base#linux-headers-}"
+        abi="${abi%%-qcom-x1e_*}"
+        common_pkg="linux-qcom-x1e-headers-${abi}_"
+        common_found="false"
+        for candidate in "$@"; do
+          case "$(basename "$candidate")" in
+            "${common_pkg}"*_all.deb)
+              common_found="true"
+              break
+              ;;
+          esac
+        done
+        if [ "$common_found" != "true" ]; then
+          echo "Missing common qcom-x1e headers package for $base." >&2
+          echo "Expected a local package matching: ${common_pkg}*_all.deb" >&2
+          echo "Rebuild the payload with:" >&2
+          echo "  --build-target \"binary-indep binary-qcom-x1e\"" >&2
+          echo "For boot-only recovery, install the linux-image and linux-modules packages without linux-headers." >&2
+          exit 1
+        fi
+        ;;
+    esac
+  done
+}
+
 write_deb_manifest() {
   collect_kernel_debs > "$work_dir/sp11-kernel-debs.txt"
 }
 
 build_kernel() {
-  local rules_file
+  local rules_file target build_targets=()
   rules_file="$(find_rules_file)"
+  read -r -a build_targets <<<"$BUILD_TARGET"
+  if [ "${#build_targets[@]}" -eq 0 ]; then
+    echo "No build target specified." >&2
+    exit 2
+  fi
 
   (
     cd "$source_dir"
@@ -723,7 +763,9 @@ build_kernel() {
     if [ "$SKIP_CLEAN" != "true" ]; then
       run_rules "$rules_file" clean
     fi
-    run_rules "$rules_file" "$BUILD_TARGET"
+    for target in "${build_targets[@]}"; do
+      run_rules "$rules_file" "$target"
+    done
   )
 }
 
@@ -749,6 +791,7 @@ install_kernel_debs() {
 
   printf 'Installing generated kernel debs:\n'
   printf '  %s\n' "${debs[@]}"
+  ensure_header_dependencies_present "${debs[@]}"
   ensure_kernel_fallback "${debs[@]}"
   as_root apt install --reinstall "${debs[@]}"
 

--- a/scripts/prepare-sp11-image-release-assets.sh
+++ b/scripts/prepare-sp11-image-release-assets.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="build/sp11-ubuntu-live-direct.img"
+OUT_DIR=""
+RELEASE_NAME=""
+VALIDATE_IMAGE="true"
+ALLOW_DIRTY="false"
+PART_SIZE_BYTES="2000000000"
+GITHUB_ASSET_LIMIT_BYTES="2147483648"
+
+MANIFEST_NAME="sp11-live-image-release-manifest.txt"
+OUTLINE_NAME="sp11-live-image-outline.txt"
+
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+
+Prepares a sanitized GitHub Release asset directory for a Surface Pro 11 live
+USB raw disk image. It does not publish anything.
+
+Options:
+  --image PATH           Raw .img file, default $IMAGE.
+  --release-name NAME    Release/tag name. If omitted, derived from image name.
+  --out-dir DIR          Output directory. If omitted, defaults to
+                         build/release/<release-name>.
+  --skip-validate        Do not run the live-image validator. Intended only for
+                         local draft assets.
+  --part-size-bytes N    Maximum compressed part size, default
+                         $PART_SIZE_BYTES. Must be below GitHub's
+                         $GITHUB_ASSET_LIMIT_BYTES byte asset limit.
+  --allow-dirty          Allow preparing assets when the support repository has
+                         uncommitted changes. Intended for local test runs.
+  -h, --help             Show this help.
+
+Output (under build/release/<release-name>/):
+  <image>.img.zst.part-*
+  $OUTLINE_NAME
+  $MANIFEST_NAME
+  SHA256SUMS
+  RELEASE-NOTES.md
+EOF
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required tool: $1" >&2
+    exit 1
+  fi
+}
+
+require_arg() {
+  if [ -z "${2:-}" ]; then
+    echo "Missing value for $1." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+file_size() {
+  stat -f '%z' "$1" 2>/dev/null || stat -c '%s' "$1"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --image)
+      require_arg "$1" "${2:-}"
+      IMAGE="$2"
+      shift 2
+      ;;
+    --release-name)
+      require_arg "$1" "${2:-}"
+      RELEASE_NAME="$2"
+      shift 2
+      ;;
+    --out-dir)
+      require_arg "$1" "${2:-}"
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --skip-validate)
+      VALIDATE_IMAGE="false"
+      shift
+      ;;
+    --part-size-bytes)
+      require_arg "$1" "${2:-}"
+      PART_SIZE_BYTES="$2"
+      shift 2
+      ;;
+    --allow-dirty)
+      ALLOW_DIRTY="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_tool awk
+require_tool git
+require_tool shasum
+require_tool split
+require_tool stat
+require_tool zstd
+if [ "$VALIDATE_IMAGE" = "true" ]; then
+  require_tool docker
+fi
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$repo_dir"
+
+if [ ! -f "$IMAGE" ]; then
+  echo "Image not found: $IMAGE" >&2
+  exit 1
+fi
+
+image_abs="$(cd "$(dirname "$IMAGE")" && pwd -P)/$(basename "$IMAGE")"
+case "$image_abs" in
+  "$repo_dir"/*)
+    ;;
+  *)
+    echo "Image must be inside this repository: $IMAGE" >&2
+    exit 1
+    ;;
+esac
+
+image_base="$(basename "$image_abs")"
+image_stem="${image_base%.img}"
+compressed_base="$image_base.zst"
+
+if [ -z "$RELEASE_NAME" ]; then
+  RELEASE_NAME="$image_stem"
+fi
+
+release_root="build/release"
+if [ -z "$OUT_DIR" ]; then
+  OUT_DIR="$release_root/$RELEASE_NAME"
+fi
+
+case "$OUT_DIR" in
+  "$release_root"/*)
+    out_leaf="${OUT_DIR#"$release_root"/}"
+    ;;
+  *)
+    echo "Refusing output outside $release_root/: $OUT_DIR" >&2
+    exit 1
+    ;;
+esac
+
+case "$out_leaf" in
+  ""|*/*|*..*|.*)
+    echo "Refusing unsafe release output name: $out_leaf" >&2
+    exit 1
+    ;;
+esac
+
+if [ -L "build" ] || [ -L "$release_root" ]; then
+  echo "Refusing symlinked release output root: $release_root" >&2
+  exit 1
+fi
+
+mkdir -p "$release_root"
+release_root_abs="$(cd "$release_root" && pwd -P)"
+expected_release_root="$repo_dir/$release_root"
+if [ "$release_root_abs" != "$expected_release_root" ]; then
+  echo "Refusing release output root outside repository: $release_root_abs" >&2
+  exit 1
+fi
+OUT_DIR="$release_root_abs/$out_leaf"
+OUT_DIR_DISPLAY="$release_root/$out_leaf"
+
+case "$image_abs" in
+  "$OUT_DIR"/*)
+    echo "Refusing output directory that contains the source image: $OUT_DIR_DISPLAY" >&2
+    exit 1
+    ;;
+esac
+
+repo_commit="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+dirty="false"
+if [ -n "$(git status --porcelain --untracked-files=all 2>/dev/null)" ]; then
+  dirty="true"
+fi
+
+if [ "$dirty" = "true" ] && [ "$ALLOW_DIRTY" != "true" ]; then
+  echo "Refusing to prepare public release assets from a dirty support repository." >&2
+  echo "Commit or stash changes first, or pass --allow-dirty for a local test run." >&2
+  exit 1
+fi
+
+case "$PART_SIZE_BYTES" in
+  ''|*[!0-9]*)
+    echo "Invalid --part-size-bytes: $PART_SIZE_BYTES" >&2
+    exit 2
+    ;;
+esac
+if [ "$PART_SIZE_BYTES" -le 0 ] || [ "$PART_SIZE_BYTES" -ge "$GITHUB_ASSET_LIMIT_BYTES" ]; then
+  echo "--part-size-bytes must be greater than 0 and less than $GITHUB_ASSET_LIMIT_BYTES." >&2
+  exit 2
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+outline="$OUT_DIR/$OUTLINE_NAME"
+if [ "$VALIDATE_IMAGE" = "true" ]; then
+  if ! ./scripts/build-sp11-live-usb-image.sh \
+    --validate-image "${image_abs#"$repo_dir"/}" >"$outline" 2>&1; then
+    echo "Image validation failed. See $OUT_DIR_DISPLAY/$OUTLINE_NAME." >&2
+    exit 1
+  fi
+else
+  {
+    echo "Image validation was skipped."
+    echo "Run:"
+    echo "  ./scripts/build-sp11-live-usb-image.sh --validate-image ${image_abs#"$repo_dir"/}"
+  } > "$outline"
+fi
+
+generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+image_size="$(file_size "$image_abs")"
+image_sha="$(shasum -a 256 "$image_abs" | awk '{print $1}')"
+outline_sha="$(shasum -a 256 "$outline" | awk '{print $1}')"
+compressed_tmp="$OUT_DIR/$compressed_base"
+
+zstd -T0 -6 --force -o "$compressed_tmp" "$image_abs"
+compressed_size="$(file_size "$compressed_tmp")"
+compressed_sha="$(shasum -a 256 "$compressed_tmp" | awk '{print $1}')"
+
+split -b "$PART_SIZE_BYTES" "$compressed_tmp" "$OUT_DIR/$compressed_base.part-"
+rm -f "$compressed_tmp"
+
+parts=()
+while IFS= read -r part; do
+  parts+=("$part")
+done < <(find "$OUT_DIR" -maxdepth 1 -type f -name "$compressed_base.part-*" | sort)
+
+if [ "${#parts[@]}" -eq 0 ]; then
+  echo "No compressed image parts were generated." >&2
+  exit 1
+fi
+
+for part in "${parts[@]}"; do
+  part_size="$(file_size "$part")"
+  if [ "$part_size" -ge "$GITHUB_ASSET_LIMIT_BYTES" ]; then
+    echo "Compressed part exceeds GitHub asset limit: $(basename "$part") ($part_size bytes)" >&2
+    exit 1
+  fi
+done
+
+{
+  echo "# Surface Pro 11 Live Image Release Manifest"
+  echo
+  echo "Generated: $generated_at"
+  echo "Release: $RELEASE_NAME"
+  echo "Support repo commit: $repo_commit"
+  echo "Support repo dirty: $dirty"
+  echo "Image source: ${image_abs#"$repo_dir"/}"
+  echo "Image validation: $VALIDATE_IMAGE"
+  echo "Compression: zstd -6"
+  echo "Compressed image: $compressed_base"
+  echo "Compressed image size: $compressed_size bytes"
+  echo "Compressed image SHA256: $compressed_sha"
+  echo "Part size limit: $PART_SIZE_BYTES bytes"
+  echo
+  echo "## Image"
+  echo
+  echo "- $image_base"
+  echo "  - Size: $image_size bytes"
+  echo "  - SHA256: $image_sha"
+  echo
+  echo "## Compressed Parts"
+  echo
+  for part in "${parts[@]}"; do
+    part_base="$(basename "$part")"
+    part_size="$(file_size "$part")"
+    part_sha="$(shasum -a 256 "$part" | awk '{print $1}')"
+    echo "- $part_base"
+    echo "  - Size: $part_size bytes"
+    echo "  - SHA256: $part_sha"
+  done
+  echo
+  echo "## Image Outline"
+  echo
+  echo "- $OUTLINE_NAME"
+  echo "  - SHA256: $outline_sha"
+} > "$OUT_DIR/$MANIFEST_NAME"
+
+(
+  cd "$OUT_DIR"
+  shasum -a 256 "$compressed_base".part-* "$OUTLINE_NAME" "$MANIFEST_NAME" > SHA256SUMS
+)
+
+cat > "$OUT_DIR/RELEASE-NOTES.md" <<RELEASE_NOTES_END
+# Surface Pro 11 Live USB Image
+
+Experimental direct-boot Ubuntu live USB raw disk image for Surface Pro 11.
+
+This image is an optional convenience artifact. It is not signed, is not an
+installer ISO, and should be written only to the intended removable device.
+
+## Verify
+
+\`\`\`bash
+shasum -a 256 -c SHA256SUMS
+zstd --version
+\`\`\`
+
+The manifest records the expected SHA256 for the reconstructed compressed
+archive and the decompressed raw image.
+
+## Reconstruct
+
+\`\`\`bash
+cat $compressed_base.part-* > $compressed_base
+printf '%s  %s\n' '$compressed_sha' '$compressed_base' | shasum -a 256 -c -
+zstd -d --force $compressed_base
+printf '%s  %s\n' '$image_sha' '$image_base' | shasum -a 256 -c -
+\`\`\`
+
+## Write
+
+\`\`\`bash
+sudo dd if=$image_base of=/dev/diskX bs=16M conv=fsync status=progress
+\`\`\`
+
+Replace \`/dev/diskX\` with the correct removable disk. Double-check the target
+before writing; this command overwrites the destination disk.
+
+## Image Outline
+
+The release includes \`$OUTLINE_NAME\`, generated by:
+
+\`\`\`bash
+./scripts/build-sp11-live-usb-image.sh --validate-image $image_base
+\`\`\`
+
+\`\`\`text
+$(cat "$outline")
+\`\`\`
+
+## Provenance
+
+See \`$MANIFEST_NAME\` for image size, checksum, support repository commit, and
+validation status. The raw image is intentionally split into compressed parts
+because GitHub release assets must be smaller than $GITHUB_ASSET_LIMIT_BYTES
+bytes each.
+
+These artifacts were built from recorded inputs; they are not claimed to be
+bit-for-bit reproducible.
+RELEASE_NOTES_END
+
+release_assets=(
+  "$OUTLINE_NAME"
+  "$MANIFEST_NAME"
+  "SHA256SUMS"
+)
+for part in "${parts[@]}"; do
+  release_assets+=("$(basename "$part")")
+done
+
+echo "Prepared release assets in $OUT_DIR_DISPLAY"
+echo
+echo "Review $OUT_DIR_DISPLAY/RELEASE-NOTES.md, then publish with a command like:"
+printf '  (cd %q && gh release create %q --prerelease --title %q --notes-file RELEASE-NOTES.md' \
+  "$OUT_DIR_DISPLAY" "$RELEASE_NAME" "$RELEASE_NAME"
+for asset in "${release_assets[@]}"; do
+  printf ' %q' "$asset"
+done
+printf ')\n'

--- a/scripts/prepare-sp11-kernel-release-assets.sh
+++ b/scripts/prepare-sp11-kernel-release-assets.sh
@@ -159,6 +159,7 @@ fi
 kernel_abi=""
 package_version=""
 seen_headers="false"
+seen_common_headers="false"
 seen_image="false"
 seen_modules="false"
 
@@ -166,20 +167,31 @@ for deb in "${debs[@]}"; do
   base="$(basename "$deb")"
   role=""
   case "$base" in
+    linux-qcom-x1e-headers-*_all.deb) role="common_headers" ;;
     linux-headers-*_arm64.deb) role="headers" ;;
     linux-image-*_arm64.deb) role="image" ;;
     linux-modules-*_arm64.deb) role="modules" ;;
     *)
       echo "Unexpected kernel package filename: $base" >&2
-      echo "Expected linux-{headers,image,modules}-<abi>_<version>_arm64.deb." >&2
+      echo "Expected linux-{headers,image,modules}-<abi>_<version>_arm64.deb or linux-qcom-x1e-headers-<version>_<version>_all.deb." >&2
       exit 1
       ;;
   esac
 
-  without_arch="${base%_arm64.deb}"
-  deb_version="${without_arch##*_}"
-  deb_abi="${without_arch#linux-$role-}"
-  deb_abi="${deb_abi%_$deb_version}"
+  case "$role" in
+    common_headers)
+      without_arch="${base%_all.deb}"
+      deb_version="${without_arch##*_}"
+      deb_abi="${without_arch#linux-qcom-x1e-headers-}"
+      deb_abi="${deb_abi%_$deb_version}-qcom-x1e"
+      ;;
+    *)
+      without_arch="${base%_arm64.deb}"
+      deb_version="${without_arch##*_}"
+      deb_abi="${without_arch#linux-$role-}"
+      deb_abi="${deb_abi%_$deb_version}"
+      ;;
+  esac
 
   if [ -z "$deb_abi" ] || [ -z "$deb_version" ]; then
     echo "Could not parse kernel ABI/version from $base." >&2
@@ -201,6 +213,13 @@ for deb in "${debs[@]}"; do
   fi
 
   case "$role" in
+    common_headers)
+      if [ "$seen_common_headers" = "true" ]; then
+        echo "Duplicate linux-qcom-x1e-headers package in $KERNEL_DEBS_DIR." >&2
+        exit 1
+      fi
+      seen_common_headers="true"
+      ;;
     headers)
       if [ "$seen_headers" = "true" ]; then
         echo "Duplicate linux-headers package in $KERNEL_DEBS_DIR." >&2

--- a/scripts/prepare-sp11-kernel-release-assets.sh
+++ b/scripts/prepare-sp11-kernel-release-assets.sh
@@ -32,7 +32,7 @@ Options:
   --out-dir DIR           Output directory. If omitted, defaults to
                           build/release/<release-name>.
   --source-url URL        Upstream kernel source URL recorded in the manifest.
-  --source-branch NAME    Upstream kernel source branch recorded in the
+  --source-branch NAME    Upstream kernel source branch or tag recorded in the
                           manifest.
   --docker-image IMAGE    Docker image family/digest recorded in the manifest.
                           If omitted, derived from source mode.
@@ -419,8 +419,7 @@ done > "$OUT_DIR/sp11-kernel-debs.txt"
 cat > "$OUT_DIR/RELEASE-NOTES.md" <<EOF
 # Surface Pro 11 qcom-x1e Kernel Packages
 
-Experimental prebuilt qcom-x1e kernel packages for Surface Pro 11 Wi-Fi rfkill
-bring-up.
+Experimental prebuilt qcom-x1e kernel packages for Surface Pro 11.
 
 These packages are optional convenience artifacts. They are unsigned, are not
 an apt repository, and should be used only with a known-good fallback qcom-x1e
@@ -450,6 +449,14 @@ sudo ./scripts/build-sp11-qcom-x1e-kernel.sh \\
 
 See \`sp11-kernel-release-manifest.txt\` for package hashes, source metadata,
 support repository commit, and patch checksums.
+
+Recorded source:
+
+- Source URL: \`${SOURCE_URL:-unknown}\`
+- Source ref: \`${SOURCE_BRANCH:-unknown}\`
+- Source HEAD: \`${source_head:-unknown}\`
+- Docker image: \`$DOCKER_IMAGE\`
+- Patch directory: \`$PATCH_DIR\`
 
 These artifacts were built from recorded inputs; they are not claimed to be
 bit-for-bit reproducible.


### PR DESCRIPTION
## Summary

This PR adds a supported build path for Johan G.'s qcom-x1e 7.1.1 kernel source so the Surface Pro 11 support image can be rebuilt from the `jg/ubuntu-qcom-x1e-7.1.1-jg-0` ref instead of only the Ubuntu concept qcom-x1e 7.0 source.

The JG tree already carries the Surface Pro 11 Wi-Fi `disable-rfkill` kernel and Denali DTB changes, so this PR teaches the build helper to recognize that end state and avoid reapplying the older rfkill patches. It also adds the packaging compatibility patches needed to complete the Ubuntu 26.04 Docker build for this source.

This PR also adds a GitHub-safe release helper for the generated direct live USB raw image. The helper validates the image, captures the image outline, compresses the raw `.img` with `zstd`, splits the compressed archive into uploadable parts below GitHub's release asset limit, and generates checksums, release notes, and a manifest.

## What Changed

- Updated `scripts/build-sp11-qcom-x1e-kernel.sh`
  - Resolves `--git-branch` as either a remote branch or a tag
  - Checks out tag refs detached and resets to the tag
  - Skips the default SP11 rfkill patches when the selected source already contains the `ath12k` `disable-rfkill` hook and Denali `disable-rfkill;` DTB property

- Updated `scripts/build-sp11-qcom-x1e-kernel-docker.sh`
  - Adds `--patch-dir DIR` and passes it through to the inner kernel build helper
  - Validates repo-local patch directories before Docker startup
  - Maps repo-local patch paths into `/repo/...` inside the container
  - Defaults JG 7.1.1 git refs to `ubuntu:26.04`

- Added `patches/jglathe-qcom-x1e-7.1.1/`
  - `0001-debian-qcom-x1e-update-annotations-for-7.1.1-jg-0.patch` updates qcom-x1e annotations for the generated Ubuntu 26.04 config
  - `0002-debian-qcom-x1e-use-packaged-stubble-paths.patch` switches Stubble inputs from `/usr/local` to Ubuntu package paths under `/usr`

- Added common headers handling for JG kernel payloads
  - Supports quoted multi-target builds such as `--build-target "binary-indep binary-qcom-x1e"`
  - Collects `linux-qcom-x1e-headers-*` packages into Docker artifacts and payloads
  - Allows kernel release manifests to include the `_all.deb` common headers package
  - Fails early with a clear install-only message when ABI headers are present without matching common headers

- Added `scripts/prepare-sp11-image-release-assets.sh`
  - Validates `build/sp11-ubuntu-live-direct.img` with the live-image validator
  - Writes `sp11-live-image-outline.txt`, `sp11-live-image-release-manifest.txt`, `SHA256SUMS`, and `RELEASE-NOTES.md`
  - Compresses the raw image with `zstd -6`
  - Splits the compressed archive into GitHub-safe `.zst.part-*` assets
  - Prints a `gh release create` command that uploads only split parts and metadata

- Added decision records
  - `docs/adr/adr-0037-jglathe-qcom-7-1-1-stubble-paths.md` documents why the Stubble path patch is carried as a source-specific packaging patch
  - `docs/adr/adr-0038-split-compressed-live-image-release-assets.md` documents why split compressed GitHub Release assets are the canonical live-image publication format

- Updated docs and release notes generation
  - README and the repeat-kernel-build SOP now include the JG 7.1.1 build command
  - Kernel release asset notes now record the source URL/ref, source HEAD, Docker image, and patch directory

## Build Command

```bash
./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
  --source git \
  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
  --git-branch jg/ubuntu-qcom-x1e-7.1.1-jg-0 \
  --image ubuntu:26.04 \
  --patch-dir patches/jglathe-qcom-x1e-7.1.1 \
  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.1 \
  --copy-to-payload \
  --reset-source \
  --jobs 5
```

## Published Prereleases

- Kernel packages: https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.1.1-jg-0-sp11
- Direct live USB image: https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-ubuntu-live-direct-jg-7.1.1

## Validation

```bash
bash -n scripts/build-sp11-qcom-x1e-kernel.sh scripts/build-sp11-qcom-x1e-kernel-docker.sh scripts/prepare-sp11-kernel-release-assets.sh scripts/prepare-sp11-image-release-assets.sh
git diff --cached --check
```

Additional local validation performed before opening and updating this PR:

- Full Docker ARM64 kernel build completed for `jg/ubuntu-qcom-x1e-7.1.1-jg-0`
- Generated qcom-x1e package set included `linux-headers`, `linux-image`, and `linux-modules` `.deb` files
- Kernel release asset directory prepared with matching patched source archive
- Image release asset directory prepared with `zstd` split parts below GitHub's release asset limit
- Synthetic install-only payload without `linux-qcom-x1e-headers-*` prints the intended preflight error
- Synthetic four-package kernel release set including `linux-qcom-x1e-headers-*_all.deb` is accepted and included in the manifest
- Docker dry-run preserves `--build-target "binary-indep binary-qcom-x1e"` as a single inner argument
- `shasum -a 256 -c SHA256SUMS` passed for the generated kernel and image release assets
- Streamed compressed-part reconstruction SHA256 matched the image release manifest
- Streamed decompressed raw image SHA256 matched the image release manifest


## Notes

- The prebuilt `.deb` files, raw `.img`, compressed image archive, and release output directories are intentionally not committed; they remain generated artifacts.
- The image prerelease uploads split `.zst.part-*` assets instead of the raw `.img` because GitHub rejects assets that are 2,147,483,648 bytes or larger.
- The JG-specific patch directory is intentionally separate from `patches/ubuntu-qcom-x1e-7.0` because this source already includes the Surface Pro 11 rfkill changes.
- The Stubble packaging patch should be revisited when a future JG tag uses Ubuntu's packaged Stubble paths directly.