### PR TITLE
Move KDE Plasma screenshot to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ubuntu on Surface Pro 11 (Snapdragon X Elite)
 
+![KDE Plasma running on the Surface Pro 11 with the patched qcom-x1e kernel](assets/desktop/2026-07-15-sp11-kde-plasma-desktop.png)
+
 This repository is an experimental Ubuntu bring-up kit for the Microsoft
 Surface Pro 11 with Snapdragon X Elite (`X1E80100`). It uses the Surface Laptop
 7 Ubuntu work as a reference, and ports the Surface Pro 11-specific pieces from
@@ -796,10 +798,6 @@ is stored under `assets/`:
 - [Wi-Fi networks visible in GNOME](assets/wifi/2026-06-14-sp11-wifi-networks-redacted.png)
 - [Browser speed test after Wi-Fi connection](assets/wifi/2026-06-14-sp11-speedtest-redacted.webp)
 - [Bluetooth settings with a paired speaker](assets/bluetooth/2026-06-14-sp11-bluetooth-search-connect-redacted.png)
-
-KDE Plasma running on the Surface Pro 11 with the patched qcom-x1e kernel:
-
-![KDE Plasma running on the Surface Pro 11 with the patched qcom-x1e kernel](assets/desktop/2026-07-15-sp11-kde-plasma-desktop.png)
 
 ## How-To Guides
 


### PR DESCRIPTION
## Summary

Moves the existing KDE Plasma desktop screenshot from the README's Visual Evidence section to directly under the H1 title, so it's the first thing readers see when landing on the repo.

## What Changed

- **README.md**
  - Added the existing screenshot image reference directly under the `# Ubuntu on Surface Pro 11` title.
  - Removed the duplicate reference and its caption text from the Visual Evidence section.
  - The original Visual Evidence bullet list (Wi-Fi, speed test, Bluetooth) is unchanged.

## Validation

```bash
git diff --cached --check
```

## Notes

- Reuses the existing `assets/desktop/2026-07-15-sp11-kde-plasma-desktop.png` committed in #10; no new image assets are added.
- Codex-verified the path resolves, markdown syntax is valid, and no orphaned text remains in the Visual Evidence section.