### PR TITLE
Release SP11 7.1.3 v2 with 2.4 MHz DMIC and audio UCM v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ mkdir -p build
   --source git --work-dir build/docker-sp11-qcom-x1e-kernel \
   --copy-to-payload --reset-source --jobs 4
 
-# OR: Johan G.'s 7.1.3 tree with the validated 2.4 MHz SP11 DMIC clock
+# OR: SP11 v2 — Johan G.'s 7.1.3 tree with the 2.4 MHz DMIC default
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
   --source git \
   --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
   --git-branch jg/ubuntu-qcom-x1e-7.1.3-jg-1 \
   --image ubuntu:26.04 \
-  --patch-dirs "patches/jglathe-qcom-x1e-7.1.3 patches/sp11-dmic-2p4mhz" \
+  --patch-dirs "patches/jglathe-qcom-x1e-7.1.3 patches/sp11-qcom-x1e-7.1.3-v2" \
   --build-target "binary-indep binary-qcom-x1e" \
-  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.3-sp11 \
-  --linux-work-volume sp11-qcom-x1e-kernel-build-jg-7.1.3-sp11 \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.3-sp11-v2 \
+  --linux-work-volume sp11-qcom-x1e-kernel-build-jg-7.1.3-sp11-v2 \
   --copy-to-payload \
   --reset-source \
   --jobs 4
@@ -92,7 +92,7 @@ mkdir -p build
 `--patch-dirs` accepts a space-separated list; patches from each directory are
 applied in order. The `binary-indep` target is required because the ABI-specific
 headers package depends on `linux-qcom-x1e-headers-<abi>` (e.g.
-`linux-qcom-x1e-headers-7.1.3-jg-1`).
+`linux-qcom-x1e-headers-7.1.3-jg-1sp11v2`).
 
 If a new `jg/ubuntu-qcom-x1e-7.1.3-jg-<n>` tag fails `check-config` with
 `N config options have been changed`, regenerate the annotations patch before
@@ -199,9 +199,9 @@ cd /path/to/linux-surface-pro-11-oe
 sudo reboot
 ```
 
-For the validated build, the directory must contain the matching image,
+For the standard v2 build, the directory must contain the matching image,
 modules, flavour-header, and common-header packages for
-`7.1.3-jg-1dmic2p4`. After reboot, verify the running kernel and authoritative
+`7.1.3-jg-1sp11v2`. After reboot, verify the running kernel and authoritative
 Stubble-provided DMIC clock:
 
 ```bash
@@ -210,7 +210,7 @@ od -An -tu4 -N4 --endian=big \
   /sys/firmware/devicetree/base/soc@0/codec@6d44000/qcom,dmic-sample-rate
 ```
 
-Expected values are `7.1.3-jg-1dmic2p4-qcom-x1e` and `2400000`.
+Expected values are `7.1.3-jg-1sp11v2-qcom-x1e` and `2400000`.
 
 ## Post-Install Bring-Up
 
@@ -263,7 +263,11 @@ sudo reboot
 ```
 
 Alternatively, download the
-[prebuilt audio topology release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-audio-topology-v1).
+[audio topology and UCM v2 release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-audio-topology-v2).
+The corrected v2 UCM should be paired with the
+[7.1.3-jg-1 v2 kernel](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.1.3-jg-1-v2),
+which carries the 2.4 MHz DMIC clock required to eliminate the static observed
+with the earlier 4.8 MHz kernel.
 
 See [`how-to-bring-up-audio`](docs/how-to/how-to-bring-up-audio.md) and
 [ADR-0035](docs/adr/adr-0035-audio-boot-race-alsactl.md) for details.

--- a/docs/adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md
+++ b/docs/adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md
@@ -51,6 +51,13 @@ validation artifact. Future general-purpose builds do not need to retain the
 `dmic2p4` experiment suffix once the accepted property is integrated into
 their normal versioned patch set.
 
+The first standard package set carrying this decision is
+`7.1.3-jg-1sp11v2`, published as
+[`sp11-qcom-x1e-7.1.3-jg-1-v2`](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.1.3-jg-1-v2).
+It uses `patches/sp11-qcom-x1e-7.1.3-v2`; the diagnostic patch set remains
+unchanged for provenance. The matching corrected UCM is published in
+[`sp11-audio-topology-v2`](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-audio-topology-v2).
+
 Keep a known-good kernel installed during the first boot of any newly packaged
 kernel. This is a general rollback precaution and is no longer evidence that
 the 2.4 MHz clock itself is considered experimental.
@@ -137,6 +144,9 @@ and objective recording comparisons.
 - Validation currently covers one Surface Pro 11 and a subjective listening
   comparison. Additional units and repeatable captured samples would improve
   confidence but are not required to retain 2.4 MHz as the default.
+- Kernel and UCM releases are versioned separately but cross-linked because
+  the UCM corrects routing, gain, and channel count while the kernel clock
+  removes the dominant static.
 
 ## Related
 
@@ -144,3 +154,4 @@ and objective recording comparisons.
 - [ADR-0042: Touchscreen — Kernel Integration Troubleshooting and Remaining Blockers](adr-0042-sp11-touchscreen-troubleshooting.md)
 - [ADR-0044: Surface Pro 11 UCM Uses One WSA Macro and Two Microphone Channels](adr-0044-sp11-ucm-single-wsa-macro-microphone.md)
 - [ADR-0045: Surface Pro 11 2.4 MHz DMIC Clock Test Kernel](adr-0045-sp11-2p4mhz-dmic-clock-test-kernel.md)
+- [`patches/sp11-qcom-x1e-7.1.3-v2/README.md`](../../patches/sp11-qcom-x1e-7.1.3-v2/README.md)

--- a/docs/how-to/how-to-bring-up-audio.md
+++ b/docs/how-to/how-to-bring-up-audio.md
@@ -252,7 +252,7 @@ the desktop portal is creating the noise. The same behavior is present in raw
 ALSA capture.
 
 The 2.4 MHz DMIC clock is now the validated Surface Pro 11 default. The
-co-installable `7.1.3-jg-1dmic2p4-qcom-x1e` kernel eliminated the continuous
+co-installable `7.1.3-jg-1dmic2p4-qcom-x1e` diagnostic kernel eliminated the continuous
 feedback/static heard with 4.8 MHz, made recorded speech dramatically clearer,
 and caused no audible degradation during music playback. Capture remains
 slightly tinny or thin. The kernel uses a Stubble-provided device tree embedded
@@ -261,6 +261,15 @@ Partition does not change the live tree. See
 [ADR-0045](../adr/adr-0045-sp11-2p4mhz-dmic-clock-test-kernel.md) for the test
 build and [ADR-0046](../adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md) for the
 default-setting decision and device-side evidence.
+
+For normal installation, use the
+[`7.1.3-jg-1sp11v2` kernel release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.1.3-jg-1-v2)
+with the
+[`sp11-audio-topology-v2` assets](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-audio-topology-v2).
+The v2 topology binary is unchanged from v1; v2 updates the UCM capture path to
+match the single WSA macro, use two microphone channels, and apply unity
+decoder gain. The kernel remains necessary because UCM changes alone do not
+alter the Denali DMIC clock.
 
 ## References
 

--- a/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
+++ b/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
@@ -132,8 +132,8 @@ Rust 1.85 and LLVM 19 during Ubuntu config validation.
 
 ### Johan G. 7.1.3 source
 
-The `jg/ubuntu-qcom-x1e-7.1.3-jg-1` tag requires Ubuntu 26.04 and the matching
-build-compatibility patches:
+The `jg/ubuntu-qcom-x1e-7.1.3-jg-1` tag requires Ubuntu 26.04, the matching
+build-compatibility patches, and the standard Surface Pro 11 v2 patch set:
 
 ```bash
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
@@ -141,13 +141,14 @@ build-compatibility patches:
   --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
   --git-branch jg/ubuntu-qcom-x1e-7.1.3-jg-1 \
   --image ubuntu:26.04 \
-  --patch-dir patches/jglathe-qcom-x1e-7.1.3 \
+  --patch-dirs "patches/jglathe-qcom-x1e-7.1.3 patches/sp11-qcom-x1e-7.1.3-v2" \
   --build-target "binary-indep binary-qcom-x1e" \
-  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.3 \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.3-sp11-v2 \
+  --linux-work-volume sp11-qcom-x1e-kernel-build-jg-7.1.3-sp11-v2 \
   --copy-to-payload \
   --reset-source \
   --jobs 4 \
-  2>&1 | tee build/sp11-qcom-x1e-kernel-jg-7.1.3-build-$(date +%Y%m%d-%H%M%S).log
+  2>&1 | tee build/sp11-qcom-x1e-kernel-jg-7.1.3-sp11-v2-build-$(date +%Y%m%d-%H%M%S).log
 ```
 
 If `check-config` reports changed options after moving to a newer `jg-*` tag,

--- a/patches/sp11-qcom-x1e-7.1.3-v2/0001-arm64-dts-qcom-x1-denali-use-2.4-MHz-DMIC-clock.patch
+++ b/patches/sp11-qcom-x1e-7.1.3-v2/0001-arm64-dts-qcom-x1-denali-use-2.4-MHz-DMIC-clock.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Surface Pro 11 bring-up <noreply@example.invalid>
+Date: Sun, 19 Jul 2026 00:00:00 +0100
+Subject: [PATCH 1/2] arm64: dts: qcom: x1-denali: use 2.4 MHz DMIC clock
+
+Device testing on the Surface Pro 11 found that the previous 4.8 MHz clock
+produced continuous broadband microphone static. The 2.4 MHz clock eliminated
+that static, substantially improved recorded speech, and caused no audible
+speaker-playback regression.
+
+Make the validated 2.4 MHz clock the Denali default.
+---
+ arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+--- a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
++++ b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+@@ -863,7 +863,7 @@ &lpass_vamacro {
+ 	pinctrl-names = "default";
+ 
+ 	vdd-micb-supply = <&vreg_l1b_1p8>;
+-	qcom,dmic-sample-rate = <4800000>;
++	qcom,dmic-sample-rate = <2400000>;
+ };
+ 
+ &mdss {
+-- 
+2.50.1
+

--- a/patches/sp11-qcom-x1e-7.1.3-v2/0002-debian-qcom-x1e-name-SP11-v2-build.patch
+++ b/patches/sp11-qcom-x1e-7.1.3-v2/0002-debian-qcom-x1e-name-SP11-v2-build.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Surface Pro 11 bring-up <noreply@example.invalid>
+Date: Sun, 19 Jul 2026 00:00:00 +0100
+Subject: [PATCH 2/2] debian.qcom-x1e: name SP11 v2 build
+
+Give the accepted Surface Pro 11 DMIC configuration a distinct package
+version and ABI. This keeps the original 7.1.3-jg-1 packages immutable and
+allows the v2 build to be installed alongside them for rollback.
+---
+ debian.qcom-x1e/changelog          | 6 ++++++
+ debian.qcom-x1e/config/annotations | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/debian.qcom-x1e/changelog b/debian.qcom-x1e/changelog
+--- a/debian.qcom-x1e/changelog
++++ b/debian.qcom-x1e/changelog
+@@ -1,3 +1,9 @@
++linux-qcom-x1e (7.1.3-jg-1sp11v2) resolute; urgency=medium
++
++  * Surface Pro 11 v2: use the validated 2.4 MHz DMIC clock.
++
++ -- Surface Pro 11 bring-up <noreply@example.invalid>  Sun, 19 Jul 2026 00:00:00 +0100
++
+ linux-qcom-x1e (7.1.3-jg-1) resolute; urgency=medium
+ 
+   * re-added camera-related patches from Bryan O'Donoghue
+diff --git a/debian.qcom-x1e/config/annotations b/debian.qcom-x1e/config/annotations
+--- a/debian.qcom-x1e/config/annotations
++++ b/debian.qcom-x1e/config/annotations
+@@ -12843,7 +12843,7 @@ CONFIG_VEML6040                                 policy<{'arm64': 'm'}>
+ CONFIG_VEML6046X00                              policy<{'arm64': 'm'}>
+ CONFIG_VEML6070                                 policy<{'arm64': 'm'}>
+ CONFIG_VEML6075                                 policy<{'arm64': 'm'}>
+-CONFIG_VERSION_SIGNATURE                        policy<{'arm64': '"Ubuntu 7.1.3-jg-1-qcom-x1e 7.1.3"'}>
++CONFIG_VERSION_SIGNATURE                        policy<{'arm64': '"Ubuntu 7.1.3-jg-1sp11v2-qcom-x1e 7.1.3"'}>
+ CONFIG_VETH                                     policy<{'arm64': 'm'}>
+ CONFIG_VEXPRESS_CONFIG                          policy<{'arm64': 'y'}>
+ CONFIG_VF610_ADC                                policy<{'arm64': 'm'}>
+-- 
+2.50.1
+

--- a/patches/sp11-qcom-x1e-7.1.3-v2/README.md
+++ b/patches/sp11-qcom-x1e-7.1.3-v2/README.md
@@ -1,0 +1,36 @@
+# Surface Pro 11 qcom-x1e 7.1.3 v2 patches
+
+This patch set promotes the device-validated 2.4 MHz Denali DMIC clock to the
+standard Surface Pro 11 build and gives the result the distinct Debian version
+`7.1.3-jg-1sp11v2`.
+
+Apply it after `patches/jglathe-qcom-x1e-7.1.3` so the upstream-tag build
+compatibility fixes and annotations are established before the Surface Pro 11
+version signature is updated:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --git-branch jg/ubuntu-qcom-x1e-7.1.3-jg-1 \
+  --image ubuntu:26.04 \
+  --patch-dirs "patches/jglathe-qcom-x1e-7.1.3 patches/sp11-qcom-x1e-7.1.3-v2" \
+  --build-target "binary-indep binary-qcom-x1e" \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.1.3-sp11-v2 \
+  --linux-work-volume sp11-qcom-x1e-kernel-build-jg-7.1.3-sp11-v2 \
+  --copy-to-payload \
+  --reset-source \
+  --jobs 4
+```
+
+The output is a matching four-package set:
+
+- `linux-image-7.1.3-jg-1sp11v2-qcom-x1e`
+- `linux-modules-7.1.3-jg-1sp11v2-qcom-x1e`
+- `linux-headers-7.1.3-jg-1sp11v2-qcom-x1e`
+- `linux-qcom-x1e-headers-7.1.3-jg-1sp11v2`
+
+The earlier `patches/sp11-dmic-2p4mhz` directory is retained unchanged as the
+reproducible source of the diagnostic `7.1.3-jg-1dmic2p4` build. See
+[ADR-0046](../../docs/adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md) for the
+decision and device-side evidence.

--- a/scripts/prepare-sp11-audio-release-assets.sh
+++ b/scripts/prepare-sp11-audio-release-assets.sh
@@ -22,7 +22,7 @@ It does not publish anything.
 Options:
   --assets-dir DIR      Assets directory containing audio files,
                         default $AUDIO_ASSETS_DIR.
-  --release-name NAME   Release/tag name (required).
+  --release-name NAME   Release/tag name, default sp11-audio-topology-v2.
   --out-dir DIR         Output directory. If omitted, defaults to
                         build/release/<release-name>.
   -h, --help            Show this help.
@@ -51,6 +51,10 @@ require_arg() {
     usage >&2
     exit 2
   fi
+}
+
+file_size() {
+  stat -f '%z' "$1" 2>/dev/null || stat -c '%s' "$1"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -94,7 +98,7 @@ if [ ! -d "$AUDIO_ASSETS_DIR" ]; then
 fi
 
 if [ -z "$RELEASE_NAME" ]; then
-  RELEASE_NAME="sp11-audio-topology-v1"
+  RELEASE_NAME="sp11-audio-topology-v2"
 fi
 
 release_root="build/release"
@@ -165,7 +169,7 @@ mkdir -p "$OUT_DIR"
 total_bytes=0
 for asset in "${assets[@]}"; do
   cp "${AUDIO_ASSETS_DIR}/${asset}" "$OUT_DIR/${asset}"
-  sz=$(stat -c%s "${AUDIO_ASSETS_DIR}/${asset}" 2>/dev/null)
+  sz=$(file_size "${AUDIO_ASSETS_DIR}/${asset}")
   total_bytes=$((total_bytes + (sz > 0 ? sz : 0)))
 done
 
@@ -191,7 +195,7 @@ manifest="$OUT_DIR/$MANIFEST_NAME"
   echo
   for asset in "${assets[@]}"; do
     hash=$(shasum -a 256 "${AUDIO_ASSETS_DIR}/${asset}" | awk '{print $1}')
-    sz=$(stat -c%s "${AUDIO_ASSETS_DIR}/${asset}" 2>/dev/null)
+    sz=$(file_size "${AUDIO_ASSETS_DIR}/${asset}")
     echo "- $asset"
     echo "  - Size: $sz bytes"
     echo "  - SHA256: $hash"
@@ -210,10 +214,26 @@ manifest="$OUT_DIR/$MANIFEST_NAME"
 )
 
 cat > "$OUT_DIR/RELEASE-NOTES.md" <<'EOF'
-# Surface Pro 11 Audio Topology and UCM
+# Surface Pro 11 Audio Topology and UCM v2
 
-Experimental prebuilt AudioReach topology binary and ALSA UCM configuration for
+Prebuilt AudioReach topology binary and corrected ALSA UCM configuration for
 the Microsoft Surface Pro 11 (Snapdragon X Elite, X1E80100).
+
+Pair these files with the
+[`7.1.3-jg-1sp11v2` kernel](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.1.3-jg-1-v2).
+That kernel makes the device-validated 2.4 MHz Denali DMIC clock the default;
+UCM changes alone do not remove the static associated with the earlier 4.8 MHz
+clock.
+
+## Changes since v1
+
+- Keep the same AudioReach topology binary built from upstream commit
+  `d7a5e9d`.
+- Match the Surface Pro 11's single WSA macro instead of including nonexistent
+  WSA2 mixer paths.
+- Expose two-channel internal-microphone capture.
+- Set Surface-specific VA decoder gain to unity (0 dB) instead of the shared
+  +16 dB default that clipped capture.
 
 ## What's included
 
@@ -241,17 +261,19 @@ sudo install -m 0644 -D Surface11-HiFi.conf \
 sudo install -m 0644 -D x1e80100.conf \
   /usr/share/alsa/ucm2/conf.d/x1e80100/x1e80100.conf
 
-# Reboot for topology to load, then restart PipeWire
+# Reboot for the topology and UCM configuration to load
 sudo reboot
 # After reboot:
-systemctl --user restart pipewire wireplumber
+systemctl --user restart pipewire.service pipewire-pulse.service wireplumber.service
 ```
 
 ## Test
 
 ```bash
-# Enable DSP route
-amixer -c0 cset numid=68 'on'
+# Confirm UCM exposes both logical devices
+alsaucm -c hw:0 set _verb HiFi
+alsaucm -c hw:0 list _devices
+wpctl status
 
 # Low-volume 440Hz sine test (4 channels)
 speaker-test -D hw:0,1 -c 4 -t sine -f 440 -l 3
@@ -265,7 +287,11 @@ at commit `d7a5e9d`. See `sp11-audio-topology-manifest.txt` for full metadata.
 
 ## Limitations
 
-- PipeWire ACP auto-profile is `false` — manual sink config may be needed.
+- A manual PipeWire speaker sink is still needed on the tested installation.
+- Microphone capture is dramatically clearer with the linked 2.4 MHz kernel,
+  but speech remains slightly tinny or thin.
+- Speaker playback showed no audible regression with the 2.4 MHz kernel, but
+  the current manual route can still sound distorted.
 - Headphone, HDMI/DP, and external mic DAI links not wired in current DTS.
 - Keep volume at 10-15% for first test; no speaker protection in UCM.
 EOF


### PR DESCRIPTION
## Summary

- promote the device-validated 2.4 MHz Denali DMIC clock into a standard Surface Pro 11 v2 kernel patch set
- package it as the distinct, co-installable `7.1.3-jg-1sp11v2` ABI
- update the main build/install documentation and ADR-0046
- prepare audio topology/UCM v2 notes with corrected single-WSA routing, two-channel capture, and unity decoder gain
- fix macOS audio release generation by using portable file-size detection
- cross-link the kernel v2 and audio v2 releases while preserving all earlier releases

## Device evidence

On the Surface Pro 11, the 2.4 MHz diagnostic kernel eliminated the continuous microphone feedback/static heard at 4.8 MHz, made recorded speech dramatically clearer, and caused no audible music-playback regression. Capture remains slightly tinny or thin, and the manual speaker route can still sound distorted.

## Validation

- clean Ubuntu 26.04 ARM64 Docker build completed `binary-indep binary-qcom-x1e`
- `check-config: all good`
- all four packages report version `7.1.3-jg-1sp11v2`
- packaged Denali OLED DTB reports `qcom,dmic-sample-rate = 2400000`
- audio v2 checksums verify
- topology binary is byte-identical to v1; the functional v2 audio change is UCM

OpenCode review was requested with `openrouter/z-ai/glm-5.2`, but the provider endpoint returned an unexpected server error on both attempts. No substitute model was used.