### PR TITLE
Release SP11 7.2-rc5 v3 with MSHW0485 touchscreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ sp11-kernel-source.env
 *.orig.tar.*
 *.udeb
 
+# Out-of-tree touchscreen modules (built against the current kernel ABI).
+.sp11-kmod-v*/
+*.ko
+
 # Local diagnostics and captured reports.
 sp11-linux-checks/
 report-*/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ list for the upstream Arch status.
 | Bluetooth | ✅ Working | Public address set via raw `AF_BLUETOOTH` socket C helper (`tools/sp11-bt-set-addr.c`) before `bluetooth.service` starts, avoiding the btmgmt D-state hang. Cold boot service succeeds at T+1s. Pairing, audio, and suspend/resume still need validation. See [how-to-bring-up-bluetooth](docs/how-to/how-to-bring-up-bluetooth.md). |
 | Audio — speakers | ⚠️ Partially | Sound card instantiates with generated topology from the CRD template. Both stereo speaker endpoints produce audio through a PipeWire manual sink with reordered `audio.position` labels. The 4-channel PCM is a transport layout, not four independently routable speakers. Music playback showed no audible regression with the 2.4 MHz DMIC kernel, but the manual sink is still required and speakers can sound distorted. See [`how-to-bring-up-audio`](docs/how-to/how-to-bring-up-audio.md) and [ADR-0036](docs/adr/adr-0036-right-speaker-audio-position-reorder.md). |
 | Audio — microphone | ✅ Working with 2.4 MHz DMIC clock | The corrected single-WSA-macro UCM profile exposes two-channel internal microphone capture, and Surface-specific unity gain avoids the shared +16 dB default clipping. Setting the Denali DMIC clock to 2.4 MHz eliminates the continuous feedback/static heard at 4.8 MHz and makes recorded speech dramatically clearer. Capture remains slightly tinny or thin. See [ADR-0044](docs/adr/adr-0044-sp11-ucm-single-wsa-macro-microphone.md) and [ADR-0046](docs/adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md). |
-| Touchscreen | ❌ Not working | Kernel patches and DTB build and compile, but the kernel uses the EFI firmware DTB (Stubble) which has `spi@a88000` as `disabled`, ignoring GRUB's `devicetree` directive. Requires a kernel rebuild with `CONFIG_EFI_ARMSTUB_DTB_LOADER=y` and `dtb=` cmdline — rebuild hangs at boot. See [ADR-0041](docs/adr/adr-0041-sp11-touchscreen-patches.md) for patch set structure, [ADR-0042](docs/adr/adr-0042-sp11-touchscreen-troubleshooting.md) for the full troubleshooting history, diagnostics, and remaining options. |
+| Touchscreen | ✅ Working | MSHW0485 G6 touchscreen over SE2 QSPI (`spi@a88000`) with GPI DMA, on the 7.2-rc5 v3 build (`7.2-rc5-jg-0sp11v3`) with the v3 touchscreen DTS patch and the out-of-tree geocausa `gpi`, `spi-geni-qcom`, and `mshw0485_touch` modules installed as `updates/` overrides. Multi-touch, pinch/zoom, and three-finger gestures work. See [ADR-0049](docs/adr/adr-0049-sp11-7.2-rc5-jg-0sp11v3-touchscreen-build.md) and [ADR-0041](docs/adr/adr-0041-sp11-touchscreen-patches.md). |
 | Pen | ❌ Not working | Not working in live USB. Upstream Arch notes also list pen as not working. |
 | Touchpad | ✅ Working | Type Cover touchpad works after the kernel loads `i2c-hid-of` and the `gpio` keys. Hot-plug may need re-binding. |
 | Suspend/Resume | ⚠️ Partially | Lid suspend works with kernel `6.10+`, but can fail to resume display. |
@@ -101,7 +101,36 @@ mkdir -p build
   --copy-to-payload \
   --reset-source \
   --jobs 8
+
+# OR: SP11 7.2-rc5 v3 — JG 7.2-rc5 baseline with touchscreen + 2.4 MHz DMIC
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --image ubuntu:26.04 \
+  --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v3" \
+  --build-target "binary-indep binary-qcom-x1e" \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.2rc-sp11-v3 \
+  --linux-work-volume sp11-qcom-x1e-kernel-build-jg-7.2rc-sp11-v3 \
+  --copy-to-payload \
+  --reset-source \
+  --jobs 8
 ```
+
+The v3 build enables the MSHW0485 OLED touchscreen in the device tree, but the
+runtime QSPI support ships as out-of-tree modules. After installing the v3
+kernel packages, build the geocausa `gpi`, `spi-geni-qcom`, and
+`mshw0485_touch` modules against the v3 headers, install them as `updates/`
+overrides, and regenerate the initramfs:
+
+```bash
+./scripts/build-sp11-touchscreen-modules.sh --install
+sudo dracut -f /boot/initrd.img-$(uname -r) $(uname -r)
+```
+
+See [ADR-0049](docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
+for the touchscreen decision and [ADR-0041](docs/adr/adr-0041-sp11-touchscreen-patches.md)
+for the patch-set structure.
 
 `--patch-dirs` accepts a space-separated list; patches from each directory are
 applied in order. The `binary-indep` target is required because the ABI-specific

--- a/docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md
+++ b/docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md
@@ -1,0 +1,150 @@
+---
+id: adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build
+title: "ADR0049: JG 7.2-rc5-jg-0sp11v3 Touchscreen Kernel Build"
+# prettier-ignore
+description: Architecture Decision Record (ADR) for the Surface Pro 11 v3 build of Johan G.'s qcom-x1e 7.2-rc5-jg-0 kernel that enables the MSHW0485 OLED touchscreen over SE2 QSPI, and the out-of-tree geocausa modules that provide runtime QSPI support.
+---
+
+# ADR0049: JG 7.2-rc5-jg-0sp11v3 Touchscreen Kernel Build
+
+## Status
+
+Accepted (2026-08-03).
+
+Validated by a complete `binary-indep binary-qcom-x1e` Docker build that
+produced the `7.2-rc5-jg-0sp11v3-qcom-x1e` kernel packages in
+`payload/kernel-debs/`, and by device-side testing: the MSHW0485 G6 touch
+controller initializes over `spi@a88000`, the input device reports as
+`Microsoft Surface G6 Touch`, and multi-touch works. The 2.4 MHz DMIC clock
+fix and the audio capture path from the v2 build remain intact.
+
+## Context
+
+[ADR-0048](adr-0048-jglathe-qcom-7-2-rc5-jg-0sp11v2-build.md) established the
+`7.2-rc5-jg-0sp11v2` build as the recommended Surface Pro 11 kernel, fixing the
+DMIC clock regression from the plain `7.2-rc5-jg-0` build
+([ADR-0047](adr-0047-jglathe-qcom-7-2-rc5-jg-0-build.md)). The touchscreen
+remained non-functional, tracked in
+[ADR-0041](adr-0041-sp11-touchscreen-patches.md) and
+[ADR-0042](adr-0042-sp11-touchscreen-troubleshooting.md): the upstream
+`jg/ubuntu-qcom-x1e-7.2rc` device tree defines the touch controller hardware at
+`spi@a88000` but leaves it disabled, and no driver existed for the MSHW0485
+protocol.
+
+The working configuration was reached cooperatively with the geocausa
+[SP11X1e-touchscreen](https://github.com/geocausa/SP11X1e-touchscreen) project,
+whose Phase 91 baseline provides three out-of-tree modules that the
+7.2-rc5-jg-0 kernel does not carry: a QSPI-aware `gpi` DMA engine driver, a
+`spi-geni-qcom` controller driver that recognizes GENI protocol 9 (QSPI) and
+performs the Linux-integrated QSPI SE preparation, and the `mshw0485_touch`
+HID-SPI client driver.
+
+### Device tree enablement
+
+The touchscreen runs over the SE2 QSPI controller at `0xa88000` (spi10).
+`hamoa.dtsi` already declares the hardware as both `i2c10` and `spi10` (both
+`status = "disabled"`) and provides the `qup_spi10_data_clk` /
+`qup_spi10_cs` pinctrl states. The v3 DTS patch:
+
+- enables GPI DMA instance 1 (`dma-controller@a00000`),
+- keeps `i2c10` disabled,
+- adds the QSPI data pins GPIO 49/50 (`qup1_se2`),
+- attaches the touchscreen child node with GPIO 48 reset, GPIO 51 interrupt,
+  and GPIO 64 power, and
+- enables the `spi@a88000` node.
+
+The upstream driver only probes the node as a SPI slave unless it recognizes
+the resident GENI protocol. The geocausa `spi-geni-qcom` accepts protocol 9 on
+`a88000.spi` as a QSPI controller (`qcom,biosref-qspi`), which is the native
+boot-time protocol of the Surface Pro 11 G6 touch controller.
+
+## Decision
+
+Build the `sp11v3` (touchscreen) variant of the 7.2-rc5-jg-0 baseline as the
+new standard Surface Pro 11 kernel:
+
+1. Apply `patches/sp11-qcom-x1e-7.2-rc5-v3` after
+   `patches/jglathe-qcom-x1e-7.2-rc5`. The set restores the validated 2.4 MHz
+   Denali DMIC clock, enables the touchscreen in the Denali device tree, and
+   gives the result the distinct Debian ABI `7.2-rc5-jg-0sp11v3`, preserving
+   the v2 ABI as a co-installable rollback option.
+2. Build the runtime QSPI support as out-of-tree modules from the geocausa
+   Phase 91 baseline (`gpi`, `spi-geni-qcom`, `mshw0485_touch`) against the
+   `7.2-rc5-jg-0sp11v3` kernel headers, and install them as higher-priority
+   `/lib/modules/<release>/updates/` overrides. `scripts/build-sp11-touchscreen-modules.sh`
+   reproduces the build.
+3. Regenerate the initramfs **after** deploying the updates modules. The stock
+   kernel build embeds its own `gpi.ko.zst` / `spi-geni-qcom.ko.zst` in the
+   initramfs and loads them at early boot; without a rebuild the stock
+   `gpi` module (which has no QSPI TRE support) binds `a00000.dma-controller`
+   permanently and the touch DMA path fails with `CH START completion timeout`.
+4. Generalize the installer's DTB selection from `sp11v2` to any
+   `sp11v[0-9]+` suffix so a v3 build is preferred when it coexists with the
+   plain or v2 build.
+
+## Decision details
+
+The Docker kernel build:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --image ubuntu:26.04 \
+  --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v3" \
+  --build-target "binary-indep binary-qcom-x1e" \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.2rc-sp11-v3 \
+  --linux-work-volume sp11-qcom-x1e-kernel-build-jg-7.2rc-sp11-v3 \
+  --copy-to-payload \
+  --reset-source \
+  --jobs 8
+```
+
+The touchscreen module build, against the installed v3 headers:
+
+```bash
+./scripts/build-sp11-touchscreen-modules.sh --install
+```
+
+The built modules land in `/lib/modules/7.2-rc5-jg-0sp11v3-qcom-x1e/updates/`
+at the same relative paths as the in-tree counterparts:
+
+- `drivers/dma/qcom/gpi.ko`
+- `drivers/spi/spi-geni-qcom.ko`
+- `drivers/input/touchscreen/mshw0485_touch.ko`
+
+After installing the modules, the initramfs must be regenerated so early boot
+loads the geocausa versions instead of the stock ones:
+
+```bash
+dracut -f /boot/initrd.img-$(uname -r) $(uname -r)
+```
+
+The installer DTB selection (`pick_dtb` in `scripts/install-sp11-support.sh`)
+now extracts the numeric suffix after `sp11v` and prefers the newest one:
+
+```bash
+sp11="$(printf '%s\n' "$@" | grep -E 'sp11v[0-9]+' || true)"
+if [ -n "$sp11" ]; then
+  newest_suffix="$(printf '%s\n' "$sp11" | sed -nE 's/.*sp11v([0-9]+).*/\1/p' | sort -n | tail -n 1)"
+  printf '%s\n' "$sp11" | grep -E "sp11v${newest_suffix}" | sort -V | tail -n 1
+else
+  printf '%s\n' "$@" | sort -V | tail -n 1
+fi
+```
+
+## Consequences
+
+- The v3 kernel boots with the touchscreen DTB enabled; the MSHW0485 controller
+  initializes (`touch controller initialized path=hardware`) and the input
+  device reports as `Microsoft Surface G6 Touch`.
+- Multi-touch, pinch/zoom, and three-finger gestures work through the Linux
+  `mshw0485_touch` HID-SPI driver.
+- The 2.4 MHz DMIC clock and the audio capture path from v2 are unchanged and
+  remain working.
+- The touchscreen works only with the geocausa `updates/` modules present and
+  an initramfs that loads them; a stock-kernel-only boot binds the stock `gpi`
+  driver and the touch DMA path fails.
+- The plain `7.2-rc5-jg-0` and `7.2-rc5-jg-0sp11v2` ABIs remain co-installable
+  as rollback options but are no longer the recommended Surface Pro 11 kernels.

--- a/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
+++ b/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
@@ -197,6 +197,43 @@ The output is a matching four-package set
 [ADR0048](../adr/adr-0048-jglathe-qcom-7-2-rc5-jg-0sp11v2-build.md) for the
 DMIC decision and the installer DTB-selection fix.
 
+### Johan G. 7.2-rc5 v3 source (touchscreen)
+
+The Surface Pro 11 v3 build layers the MSHW0485 OLED touchscreen enablement on
+top of the v2 build. It restores the validated 2.4 MHz DMIC clock, enables the
+`spi@a88000` QSPI controller in the Denali device tree, and gives the result
+the distinct `7.2-rc5-jg-0sp11v3` ABI:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --image ubuntu:26.04 \
+  --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v3" \
+  --build-target "binary-indep binary-qcom-x1e" \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.2rc-sp11-v3 \
+  --linux-work-volume sp11-qcom-x1e-kernel-build-jg-7.2rc-sp11-v3 \
+  --copy-to-payload \
+  --reset-source \
+  --jobs 8 \
+  2>&1 | tee build/sp11-qcom-x1e-kernel-jg-7.2rc-sp11-v3-build-$(date +%Y%m%d-%H%M%S).log
+```
+
+The kernel ABI carries the touchscreen device tree, but the runtime QSPI
+support ships as out-of-tree modules from the geocausa Phase 91 baseline
+(`gpi`, `spi-geni-qcom`, `mshw0485_touch`). Build them against the installed
+v3 headers on the device and install as `updates/` overrides, then regenerate
+the initramfs so early boot loads them instead of the stock modules:
+
+```bash
+./scripts/build-sp11-touchscreen-modules.sh --install
+sudo dracut -f /boot/initrd.img-$(uname -r) $(uname -r)
+```
+
+See [ADR0049](../adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md) for
+the touchscreen decision and module/initramfs deployment notes.
+
 5. Rebuild and write the live USB image so `payload/kernel-debs/` is copied to
    `SP11DATA`.
 
@@ -433,5 +470,6 @@ returned to the expected `phy0` hard-blocked state.
 - [ADR023: Docker Kernel Build Case-Sensitive Work Volume](../adr/adr-0023-docker-kernel-build-case-sensitive-work-volume.md)
 - [ADR047: JG 7.2-rc5-jg-0 Kernel Build](../adr/adr-0047-jglathe-qcom-7-2-rc5-jg-0-build.md)
 - [ADR048: JG 7.2-rc5-jg-0sp11v2 Kernel Build](../adr/adr-0048-jglathe-qcom-7-2-rc5-jg-0sp11v2-build.md)
+- [ADR049: JG 7.2-rc5-jg-0sp11v3 Touchscreen Kernel Build](../adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
 - [Surface Pro 11 Wi-Fi rfkill test after qcom-x1e upgrade](../installed-wifi-rfkill-upgrade-test-20260613.md)
 - [Surface Pro 11 Wi-Fi test after Windows firmware and cold boot](../installed-wifi-windows-firmware-cold-boot-test-20260613.md)

--- a/patches/sp11-qcom-x1e-7.2-rc5-v3/0001-arm64-dts-qcom-x1-denali-use-2.4-MHz-DMIC-clock.patch
+++ b/patches/sp11-qcom-x1e-7.2-rc5-v3/0001-arm64-dts-qcom-x1-denali-use-2.4-MHz-DMIC-clock.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Surface Pro 11 bring-up <noreply@example.invalid>
+Date: Sun, 02 Aug 2026 00:00:00 +0100
+Subject: [PATCH 1/2] arm64: dts: qcom: x1-denali: use 2.4 MHz DMIC clock
+
+Device testing on the Surface Pro 11 found that the upstream 4.8 MHz clock
+produces continuous broadband microphone static. The 2.4 MHz clock eliminates
+that static, substantially improves recorded speech, and causes no audible
+speaker-playback regression.
+
+Make the validated 2.4 MHz clock the Denali default on the 7.2-rc5 baseline.
+---
+ arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+--- a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
++++ b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+@@ -865,7 +865,7 @@ &lpass_vamacro {
+ 	pinctrl-names = "default";
+ 
+ 	vdd-micb-supply = <&vreg_l1b_1p8>;
+-	qcom,dmic-sample-rate = <4800000>;
++	qcom,dmic-sample-rate = <2400000>;
+ };
+ 
+ &mdss {
+-- 
+2.50.1

--- a/patches/sp11-qcom-x1e-7.2-rc5-v3/0002-arm64-dts-qcom-x1-denali-enable-mshw0485-touchscreen.patch
+++ b/patches/sp11-qcom-x1e-7.2-rc5-v3/0002-arm64-dts-qcom-x1-denali-enable-mshw0485-touchscreen.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Surface Pro 11 bring-up <noreply@example.invalid>
+Date: Sun, 03 Aug 2026 00:00:00 +0100
+Subject: [PATCH 1/2] arm64: dts: qcom: x1-denali: enable MSHW0485 touchscreen
+
+Enable the Surface Pro 11 OLED touchscreen (Microsoft MSHW0485) as the
+SPI10 QSPI peripheral. Upstream hamoa.dtsi already describes the SE2
+hardware at 0xa88000 as both i2c10 and spi10 (both disabled) and defines
+the qup_spi10_data_clk / qup_spi10_cs pinctrl states. This patch enables
+GPI DMA instance 1, keeps the i2c10 sibling disabled, configures the
+QSPI data GPIOs 49/50, and attaches the touchscreen child.
+
+The QCOM GPI protocol value 4 is the QSPI protocol implemented by this
+repository's paired gpi and spi-geni-qcom modules (see patch series
+"SP11 QSPI GPI DMA" in the geocausa phase 91 baseline).
+---
+ arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi | 47 ++++++++++++++++++++++
+ 1 file changed, 47 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+--- a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
++++ b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+@@ -1303,3 +1303,50 @@
+ &usb_1_ss1_qmpphy_out {
+ 	remote-endpoint = <&retimer_ss1_ss_in>;
+ };
++
++&gpi_dma1 {
++	status = "okay";
++};
++
++&i2c10 {
++	status = "disabled";
++};
++
++&tlmm {
++	g6ts_qspi_data23: g6ts-qspi-data23-state {
++		pins = "gpio49", "gpio50";
++		function = "qup1_se2";
++
++		drive-strength = <6>;
++		bias-disable;
++	};
++};
++
++&spi10 {
++	status = "okay";
++
++	qcom,biosref-qspi;
++	qcom,enable-gsi-dma;
++
++	dmas = <&gpi_dma1 0 2 4>,
++	       <&gpi_dma1 1 2 4>;
++	dma-names = "tx", "rx";
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&qup_spi10_data_clk>,
++		    <&qup_spi10_cs>,
++		    <&g6ts_qspi_data23>;
++
++	touchscreen@0 {
++		compatible = "microsoft,mshw0485";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++
++		interrupt-parent = <&tlmm>;
++		interrupts = <51 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-gpios = <&tlmm 51 GPIO_ACTIVE_LOW>;
++
++		power-gpios = <&tlmm 64 GPIO_ACTIVE_HIGH>;
++		reset-gpios = <&tlmm 48 GPIO_ACTIVE_HIGH>;
++	};
++};
+-- 
+2.50.1

--- a/patches/sp11-qcom-x1e-7.2-rc5-v3/0003-debian-qcom-x1e-name-SP11-v3-build.patch
+++ b/patches/sp11-qcom-x1e-7.2-rc5-v3/0003-debian-qcom-x1e-name-SP11-v3-build.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Surface Pro 11 bring-up <noreply@example.invalid>
+Date: Sun, 03 Aug 2026 00:00:00 +0100
+Subject: [PATCH 2/2] debian.qcom-x1e: name SP11 v3 build
+
+Give the Surface Pro 11 touchscreen build a distinct package version and
+ABI. This keeps the upstream 7.2-rc5-jg-0 and the v2 DMIC packages
+immutable and allows the v3 build to be installed alongside them for
+rollback.
+---
+ debian.qcom-x1e/changelog          | 6 ++++++
+ debian.qcom-x1e/config/annotations | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/debian.qcom-x1e/changelog b/debian.qcom-x1e/changelog
+--- a/debian.qcom-x1e/changelog
++++ b/debian.qcom-x1e/changelog
+@@ -1,3 +1,9 @@
++linux-qcom-x1e (7.2-rc5-jg-0sp11v3) resolute; urgency=medium
++
++  * Surface Pro 11 v3: enable the MSHW0485 QSPI touchscreen.
++
++ -- Surface Pro 11 bring-up <noreply@example.invalid>  Sun, 03 Aug 2026 00:00:00 +0100
++
+ linux-qcom-x1e (7.2-rc5-jg-0) resolute; urgency=medium
+ 
+   * rebased the whole stack to v7.2-rc5
+diff --git a/debian.qcom-x1e/config/annotations b/debian.qcom-x1e/config/annotations
+--- a/debian.qcom-x1e/config/annotations
++++ b/debian.qcom-x1e/config/annotations
+@@ -12882,2 +12882,2 @@
+-CONFIG_VERSION_SIGNATURE                        policy<{'arm64': '"Ubuntu 7.2-rc5-jg-0-qcom-x1e 7.2-rc5"'}>
++CONFIG_VERSION_SIGNATURE                        policy<{'arm64': '"Ubuntu 7.2-rc5-jg-0sp11v3-qcom-x1e 7.2-rc5"'}>
+ CONFIG_VETH                                     policy<{'arm64': 'm'}>
+-- 
+2.50.1

--- a/patches/sp11-qcom-x1e-7.2-rc5-v3/README.md
+++ b/patches/sp11-qcom-x1e-7.2-rc5-v3/README.md
@@ -1,0 +1,51 @@
+# Surface Pro 11 qcom-x1e 7.2-rc5 v3 patches
+
+This patch set enables the Surface Pro 11 OLED touchscreen (Microsoft
+MSHW0485) in the 7.2-rc5 build, retains the validated 2.4 MHz Denali DMIC
+clock, and gives the result the distinct Debian version
+`7.2-rc5-jg-0sp11v3`.
+
+The upstream `jg/ubuntu-qcom-x1e-7.2rc` branch sets `qcom,dmic-sample-rate`
+to 4.8 MHz, which reintroduces the continuous broadband microphone static
+previously eliminated on the 7.1.3 v2 kernel. These patches restore the
+validated 2.4 MHz clock.
+
+The touchscreen runs over the SE2 QSPI controller at `0xa88000` (spi10).
+`hamoa.dtsi` already defines the hardware as both i2c10 and spi10 (both
+disabled) plus the `qup_spi10_data_clk` / `qup_spi10_cs` pinctrl states.
+The v3 DTS patch enables GPI DMA instance 1, keeps i2c10 disabled, adds the
+QSPI data pins GPIO 49/50 (`qup1_se2`), and attaches the touchscreen child
+with GPIO 48 reset, GPIO 51 interrupt, and GPIO 64 power. Runtime QSPI
+support is provided by the paired out-of-tree `gpi`, `spi-geni-qcom`, and
+`mshw0485_touch` modules from the geocausa phase 91 baseline, installed as
+higher-priority `/lib/modules/<release>/updates/` overrides.
+
+Apply it after `patches/jglathe-qcom-x1e-7.2-rc5` so the annotations
+compatibility fix is established before the Surface Pro 11 version signature
+is updated:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --image ubuntu:26.04 \
+  --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v3" \
+  --build-target "binary-indep binary-qcom-x1e" \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-jg-7.2rc-sp11-v3 \
+  --linux-work-volume sp11-qcom-x1e-kernel-build-jg-7.2rc-sp11-v3 \
+  --copy-to-payload \
+  --reset-source \
+  --jobs 8
+```
+
+The output is a matching four-package set:
+
+- `linux-image-7.2-rc5-jg-0sp11v3-qcom-x1e`
+- `linux-modules-7.2-rc5-jg-0sp11v3-qcom-x1e`
+- `linux-headers-7.2-rc5-jg-0sp11v3-qcom-x1e`
+- `linux-qcom-x1e-headers-7.2-rc5-jg-0sp11v3`
+
+Device testing found that 2.4 MHz eliminated the continuous microphone
+feedback/static and made recorded speech dramatically clearer. See
+[ADR-0046](https://github.com/ooaklee/linux-surface-pro-11-oe/blob/main/docs/adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md).

--- a/scripts/build-sp11-touchscreen-modules.sh
+++ b/scripts/build-sp11-touchscreen-modules.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the out-of-tree Surface Pro 11 touchscreen modules (gpi,
+# spi-geni-qcom, mshw0485_touch) from the geocausa Phase 91 baseline against
+# the current kernel's headers, and installs them as higher-priority
+# /lib/modules/<release>/updates/ overrides.
+#
+# The kernel must have been built with the v3 touchscreen DTS patch applied
+# (patches/sp11-qcom-x1e-7.2-rc5-v3), and linux-headers for the running
+# kernel must be installed on this machine.
+
+GIT_URL="https://github.com/geocausa/SP11X1e-touchscreen.git"
+GIT_BRANCH="main"
+SOURCE_DIR="build/SP11X1e-touchscreen"
+OUT_DIR=".sp11-kmod-v3"
+INSTALL="false"
+RELEASE="$(uname -r)"
+KVER_DIR="/lib/modules/${RELEASE}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --source-dir DIR  Directory to clone the geocausa tree into (default $SOURCE_DIR).
+  --out-dir DIR     Where to drop the built modules (default $OUT_DIR).
+  --install         Also install into $KVER_DIR/updates/ and run depmod.
+  --release VER     Target kernel release (default \$(uname -r)).
+  -h, --help        Show this help.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source-dir) SOURCE_DIR="$2"; shift 2 ;;
+    --out-dir) OUT_DIR="$2"; shift 2 ;;
+    --install) INSTALL="true"; shift ;;
+    --release) RELEASE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+KVER_DIR="/lib/modules/${RELEASE}"
+KDIR="${KVER_DIR}/build"
+
+if [ ! -d "${KDIR}" ]; then
+  echo "error: no headers found at ${KDIR}. Install linux-headers-${RELEASE} first." >&2
+  exit 1
+fi
+
+if [ ! -d "${SOURCE_DIR}" ]; then
+  mkdir -p "${SOURCE_DIR}"
+  git clone --depth 1 --branch "${GIT_BRANCH}" "${GIT_URL}" "${SOURCE_DIR}"
+else
+  git -C "${SOURCE_DIR}" fetch --depth 1 origin "${GIT_BRANCH}"
+  git -C "${SOURCE_DIR}" checkout "${GIT_BRANCH}"
+  git -C "${SOURCE_DIR}" pull --ff-only origin "${GIT_BRANCH}"
+fi
+
+# The Phase 91 DMA baseline builds from phase55/modules. The kernel release
+# guard there is tuned for the geocausa baseline kernel; the SP11 v3 build is
+# a deliberately different release, so allow it explicitly.
+make -C "${SOURCE_DIR}/phase55/modules" \
+  KDIR="${KDIR}" \
+  EXPECTED_KERNEL_RELEASE="${RELEASE}" \
+  ALLOW_UNTESTED_KERNEL=1
+
+mkdir -p "${OUT_DIR}"
+for mod in gpi spi-geni-qcom mshw0485_touch; do
+  cp "${SOURCE_DIR}/phase55/modules/${mod}.ko" "${OUT_DIR}/"
+done
+echo "Built modules in ${OUT_DIR}/:"
+ls -la "${OUT_DIR}/"
+
+if [ "$INSTALL" = "true" ]; then
+  if [ "$(id -u)" != "0" ]; then
+    echo "error: --install requires root." >&2
+    exit 1
+  fi
+  UPDATES="${KVER_DIR}/updates"
+  mkdir -p "${UPDATES}/drivers/dma/qcom" "${UPDATES}/drivers/spi" \
+    "${UPDATES}/drivers/input/touchscreen"
+  cp "${OUT_DIR}/gpi.ko" "${UPDATES}/drivers/dma/qcom/"
+  cp "${OUT_DIR}/spi-geni-qcom.ko" "${UPDATES}/drivers/spi/"
+  cp "${OUT_DIR}/mshw0485_touch.ko" "${UPDATES}/drivers/input/touchscreen/"
+  depmod -a "${RELEASE}"
+  echo "Installed updates modules for ${RELEASE}. Reboot to load them."
+fi

--- a/scripts/install-sp11-support.sh
+++ b/scripts/install-sp11-support.sh
@@ -160,13 +160,14 @@ DTB_NAMES=(
 
 # Pick the newest candidate DTB, preferring Surface Pro 11 specific builds.
 # The plain jglathe qcom-x1e builds use the upstream 4.8 MHz DMIC clock; the
-# SP11 builds (suffixed sp11v2) carry the validated 2.4 MHz clock. Plain sort -V
-# ranks the sp11v2 suffix below the plain name, so prefer it explicitly.
+# SP11 builds (suffixed sp11vN) carry the validated 2.4 MHz clock. Plain sort -V
+# ranks the sp11vN suffix below the plain name, so prefer it explicitly.
 pick_dtb() {
-  local sp11
-  sp11="$(printf '%s\n' "$@" | grep -E 'sp11v2' || true)"
+  local sp11 newest_suffix
+  sp11="$(printf '%s\n' "$@" | grep -E 'sp11v[0-9]+' || true)"
   if [ -n "$sp11" ]; then
-    printf '%s\n' "$sp11" | sort -V | tail -n 1
+    newest_suffix="$(printf '%s\n' "$sp11" | sed -nE 's/.*sp11v([0-9]+).*/\1/p' | sort -n | tail -n 1)"
+    printf '%s\n' "$sp11" | grep -E "sp11v${newest_suffix}" | sort -V | tail -n 1
   else
     printf '%s\n' "$@" | sort -V | tail -n 1
   fi


### PR DESCRIPTION
## Summary

- enable the MSHW0485 OLED touchscreen over SE2 QSPI in the `7.2-rc5-jg-0` baseline
- restore the validated 2.4 MHz Denali DMIC clock and package the result as the distinct, co-installable `7.2-rc5-jg-0sp11v3` ABI
- enable GPI DMA instance 1, add the GPIO 49/50 QSPI data pins, and connect the touchscreen reset, interrupt, and power signals
- add `scripts/build-sp11-touchscreen-modules.sh` to build and optionally install the geocausa Phase 91 `gpi`, `spi-geni-qcom`, and `mshw0485_touch` modules as higher-priority `updates/` overrides
- document the required initramfs regeneration so early boot loads the touchscreen modules instead of the stock versions
- generalise installer DTB selection to prefer the newest numeric `sp11vN` build when multiple ABIs are installed
- update the compatibility status, kernel build and deployment guidance, patch-set documentation, and ADR-0049

## Device evidence

On the Surface Pro 11, the MSHW0485 G6 controller initialises over `spi@a88000` and reports as `Microsoft Surface G6 Touch`. Multi-touch, pinch/zoom, and three-finger gestures work. The validated 2.4 MHz DMIC clock and the v2 audio capture path remain intact.

The touchscreen requires the geocausa `updates/` modules and a regenerated initramfs. Without them, the stock `gpi` driver binds first, and the touch DMA path fails with a `CH START completion timeout`.

## Validation

- complete Ubuntu 26.04 ARM64 Docker build completed `binary-indep binary-qcom-x1e`
- build produced the matching image, modules, headers, and ABI headers packages for `7.2-rc5-jg-0sp11v3`
- device testing confirmed the touchscreen initialises over SE2 QSPI
- multi-touch, pinch/zoom, and three-finger gestures work
- 2.4 MHz DMIC behaviour and the v2 audio capture path remain functional
