### PR TITLE
[SP11-50/SP11-51] Harden touchscreen installs and release integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ list for the upstream Arch status.
 | Bluetooth | ✅ Working | Public address set via raw `AF_BLUETOOTH` socket C helper (`tools/sp11-bt-set-addr.c`) before `bluetooth.service` starts, avoiding the btmgmt D-state hang. Cold boot service succeeds at T+1s. Pairing, audio, and suspend/resume still need validation. See [how-to-bring-up-bluetooth](docs/how-to/how-to-bring-up-bluetooth.md). |
 | Audio — speakers | ⚠️ Partially | Sound card instantiates with generated topology from the CRD template. Both stereo speaker endpoints produce audio through a PipeWire manual sink with reordered `audio.position` labels. The 4-channel PCM is a transport layout, not four independently routable speakers. Music playback showed no audible regression with the 2.4 MHz DMIC kernel, but the manual sink is still required and speakers can sound distorted. See [`how-to-bring-up-audio`](docs/how-to/how-to-bring-up-audio.md) and [ADR-0036](docs/adr/adr-0036-right-speaker-audio-position-reorder.md). |
 | Audio — microphone | ✅ Working with 2.4 MHz DMIC clock | The corrected single-WSA-macro UCM profile exposes two-channel internal microphone capture, and Surface-specific unity gain avoids the shared +16 dB default clipping. Setting the Denali DMIC clock to 2.4 MHz eliminates the continuous feedback/static heard at 4.8 MHz and makes recorded speech dramatically clearer. Capture remains slightly tinny or thin. See [ADR-0044](docs/adr/adr-0044-sp11-ucm-single-wsa-macro-microphone.md) and [ADR-0046](docs/adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md). |
-| Touchscreen | ✅ Working | MSHW0485 G6 touchscreen over SE2 QSPI (`spi@a88000`) with GPI DMA, on the 7.2-rc5 v3 build (`7.2-rc5-jg-0sp11v3`) with the v3 touchscreen DTS patch and the out-of-tree geocausa `gpi`, `spi-geni-qcom`, and `mshw0485_touch` modules installed as `updates/` overrides. Multi-touch, pinch/zoom, and three-finger gestures work. See [ADR-0049](docs/adr/adr-0049-sp11-7.2-rc5-jg-0sp11v3-touchscreen-build.md) and [ADR-0041](docs/adr/adr-0041-sp11-touchscreen-patches.md). |
+| Touchscreen | ✅ Working on installed v3 system | MSHW0485 G6 touchscreen over SE2 QSPI (`spi@a88000`) with GPI DMA, on the 7.2-rc5 v3 build (`7.2-rc5-jg-0sp11v3`) with an exact-ABI set of the geocausa `gpi`, `spi-geni-qcom`, and `mshw0485_touch` modules. The guarded installer forces those overrides into the target initramfs and verifies them before reboot. Multi-touch, pinch/zoom, and three-finger gestures work. The live USB still boots the concept ISO's casper kernel and does not gain touch from a payload-only v3 bundle. See [ADR-0050](docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md) and [ADR-0049](docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md). |
 | Pen | ❌ Not working | Not working in live USB. Upstream Arch notes also list pen as not working. |
 | Touchpad | ✅ Working | Type Cover touchpad works after the kernel loads `i2c-hid-of` and the `gpio` keys. Hot-plug may need re-binding. |
 | Suspend/Resume | ⚠️ Partially | Lid suspend works with kernel `6.10+`, but can fail to resume display. |
@@ -118,19 +118,23 @@ mkdir -p build
 ```
 
 The v3 build enables the MSHW0485 OLED touchscreen in the device tree, but the
-runtime QSPI support ships as out-of-tree modules. After installing the v3
-kernel packages, build the geocausa `gpi`, `spi-geni-qcom`, and
-`mshw0485_touch` modules against the v3 headers, install them as `updates/`
-overrides, and regenerate the initramfs:
+runtime QSPI support ships as an exact-ABI out-of-tree module bundle. After the
+v3 kernel and headers are installed, the pinned build helper selects the v3
+headers (even when an older kernel is still running), builds all three modules,
+and delegates installation, initramfs regeneration, and verification to the
+guarded installer:
 
 ```bash
 ./scripts/build-sp11-touchscreen-modules.sh --install
-sudo dracut -f /boot/initrd.img-$(uname -r) $(uname -r)
 ```
 
-See [ADR-0049](docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
-for the touchscreen decision and [ADR-0041](docs/adr/adr-0041-sp11-touchscreen-patches.md)
-for the patch-set structure.
+The validated controller profile leaves the experimental
+`sp11_windows_se_init` parameter off. Do not add it merely because a boot logs
+`Invalid proto 9`; that signature means the stock controller was loaded. Run
+`sudo ./scripts/troubleshoot-sp11-touchscreen.sh` to classify the boot first.
+See [ADR-0050](docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md)
+for the clean-install retrospective and [ADR-0049](docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
+for the kernel decision.
 
 `--patch-dirs` accepts a space-separated list; patches from each directory are
 applied in order. The `binary-indep` target is required because the ABI-specific
@@ -218,7 +222,10 @@ sudo ./scripts/finish-sp11-installed-system.sh --download --reboot
 If networking is unavailable, mount the Windows partition and use Windows
 firmware instead: `--windows-root "$WINROOT"` (see the script `--help`).
 
-Then install the patched kernel payload from the USB:
+Then install the patched kernel payload from the USB. For an `sp11v3` payload,
+keep `gpi.ko`, `spi-geni-qcom.ko`, and `mshw0485_touch.ko` beside the `.deb`
+files; the same command installs the exact-ABI module set and verifies the
+rebuilt initramfs:
 
 ```bash
 cd "$SP11DATA/support"
@@ -228,6 +235,11 @@ sudo reboot
 
 Keep the previous qcom-x1e kernel as a GRUB fallback until the patched kernel
 has booted and Wi-Fi rfkill state has been validated.
+
+The installer refuses an `sp11v3` kernel with a missing or mismatched module
+bundle before invoking `apt`. `--skip-touchscreen-modules` is available for a
+deliberate kernel-development install, but touch will remain unavailable until
+`install-sp11-touchscreen.sh` completes.
 
 For a direct local installation instead of the USB payload flow, place all
 four matching `.deb` packages in one directory and run the same helper against
@@ -258,6 +270,27 @@ Expected values are `7.2-rc5-jg-0sp11v2-qcom-x1e` (or
 `7.1.3-jg-1sp11v2-qcom-x1e`) and `2400000`.
 
 ## Post-Install Bring-Up
+
+### Touchscreen
+
+After rebooting the v3 kernel, run the read-only diagnostic:
+
+```bash
+cd "$SP11DATA/support"
+sudo ./scripts/troubleshoot-sp11-touchscreen.sh
+```
+
+Success requires the v3 device tree, all three loaded module source versions
+to match their selected `updates/` files, and the `Microsoft Surface G6 Touch`
+input device. `Invalid proto 9` indicates a stale stock SPI controller in the
+boot path; `CH START completion timeout` points to a stale or mismatched GPI
+DMA module. The diagnostic reports the corresponding repair command.
+
+The captured Windows controller initialization is intentionally not the
+default. If the diagnostic proves that the correct modules are loaded and the
+Linux-integrated path still fails on a cold boot, reinstall explicitly with
+`--windows-se-init` as an A/B recovery test and retain the known-good kernel
+fallback.
 
 ### Wi-Fi
 
@@ -371,6 +404,7 @@ DTB, firmware, audio, or Bluetooth bring-up. See
 - [Release Prebuilt Kernel Artifacts](docs/how-to/how-to-release-kernel-artifacts.md)
 - [Release Audio Topology Artifacts](scripts/prepare-sp11-audio-release-assets.sh)
 - [Generate a Service Report](docs/how-to/how-to-generate-service-report.md)
+- [Touchscreen Clean-Install and Release Retrospective](docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md)
 - [Troubleshoot Docker Overlay Mount Failures on Linux Build Hosts](docs/how-to/how-to-troubleshoot-linux-docker-overlay.md)
 - [Troubleshoot Docker `exec format error` on x86_64 Linux Build Hosts](docs/how-to/how-to-troubleshoot-docker-exec-format-error.md)
 - [Troubleshoot Kernel Git Clone `fetch-pack` Failures](docs/how-to/how-to-troubleshoot-kernel-git-clone-failures.md)
@@ -425,6 +459,10 @@ The major bring-up decisions are recorded in `docs/adr/`:
 - [ADR0044: Surface Pro 11 UCM Uses One WSA Macro and Two Microphone Channels](docs/adr/adr-0044-sp11-ucm-single-wsa-macro-microphone.md)
 - [ADR0045: Surface Pro 11 2.4 MHz DMIC Clock Test Kernel](docs/adr/adr-0045-sp11-2p4mhz-dmic-clock-test-kernel.md)
 - [ADR0046: Default the Surface Pro 11 DMIC Clock to 2.4 MHz](docs/adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md)
+- [ADR0047: JG 7.2-rc5-jg-0 Kernel Build](docs/adr/adr-0047-jglathe-qcom-7-2-rc5-jg-0-build.md)
+- [ADR0048: JG 7.2-rc5-jg-0sp11v2 Kernel Build](docs/adr/adr-0048-jglathe-qcom-7-2-rc5-jg-0sp11v2-build.md)
+- [ADR0049: JG 7.2-rc5-jg-0sp11v3 Touchscreen Build](docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
+- [ADR0050: Touchscreen Clean-Install and Release Flow](docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md)
 
 ## Windows Firmware
 

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ The major bring-up decisions are recorded in `docs/adr/`:
 - [ADR0048: JG 7.2-rc5-jg-0sp11v2 Kernel Build](docs/adr/adr-0048-jglathe-qcom-7-2-rc5-jg-0sp11v2-build.md)
 - [ADR0049: JG 7.2-rc5-jg-0sp11v3 Touchscreen Build](docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
 - [ADR0050: Touchscreen Clean-Install and Release Flow](docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md)
+- [ADR0051: Remove Broken or Incorrect Releases and Tags](docs/adr/adr-0051-release-and-tag-cleanup.md)
 
 ## Windows Firmware
 

--- a/docs/adr/adr-0038-split-compressed-live-image-release-assets.md
+++ b/docs/adr/adr-0038-split-compressed-live-image-release-assets.md
@@ -12,6 +12,12 @@ description: Architecture Decision Record (ADR) for publishing Surface Pro 11 li
 Accepted — required for publishing the Surface Pro 11 direct-boot live USB
 image through GitHub Releases (2026-06-27).
 
+Release amendment (2026-08-07): the historical
+`sp11-ubuntu-live-direct-jg-7.1.1` release and tag were removed because the tag
+pointed to the parent of the support commit recorded by its manifest. The
+split-image design remains valid, but a future image must bind its tag to the
+exact manifest commit.
+
 ## Context
 
 The Surface Pro 11 bring-up can produce a direct-boot Ubuntu live USB raw disk

--- a/docs/adr/adr-0042-sp11-touchscreen-troubleshooting.md
+++ b/docs/adr/adr-0042-sp11-touchscreen-troubleshooting.md
@@ -17,11 +17,12 @@ ADR-0041 documents the patch set (spi-hid, QSPI mode, GPI DMA, DTS).
 This ADR tracks the **attempts to get those patches working at runtime**
 on a Surface Pro 11 (Microsoft Denali OLED, Snapdragon X Elite).
 
-The release kernel from
-<https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.1.3-jg-0-touch>
-was installed but the touchscreen did not work. Local kernel rebuilds with
-config changes were attempted interactively on the device to diagnose and
-fix the problem.
+The kernel from the former `sp11-qcom-x1e-7.1.3-jg-0-touch` release was
+installed but the touchscreen did not work. The release and tag were removed
+on 2026-08-07: the packages omitted the touchscreen patches, and the tag
+predated and disagreed with the release manifest. Local kernel rebuilds with
+config changes were attempted interactively on the device to diagnose and fix
+the problem.
 
 ### Hardware
 

--- a/docs/adr/adr-0044-sp11-ucm-single-wsa-macro-microphone.md
+++ b/docs/adr/adr-0044-sp11-ucm-single-wsa-macro-microphone.md
@@ -11,6 +11,10 @@ description: Architecture Decision Record (ADR) for matching the Surface Pro 11 
 
 Accepted (2026-07-18).
 
+Release amendment (2026-08-07): `sp11-audio-topology-v1` was removed because
+its Surface UCM profile referenced nonexistent `WSA2` controls and aborted the
+complete `HiFi` verb. The corrected v2 release remains available.
+
 Validated on a Surface Pro 11 running `7.1.3-jg-1-qcom-x1e`. The corrected
 UCM profile opens its `HiFi` verb, lists `Speaker` and `Mic`, and records a
 two-channel, 48 kHz, 16-bit sample from `hw:0,3` with signal on both channels.

--- a/docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md
+++ b/docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md
@@ -18,6 +18,16 @@ controller initializes over `spi@a88000`, the input device reports as
 `Microsoft Surface G6 Touch`, and multi-touch works. The 2.4 MHz DMIC clock
 fix and the audio capture path from the v2 build remain intact.
 
+Deployment amendment (2026-08-06): the original module helper stopped after
+`depmod` and left the required initramfs rebuild as a separate documentation
+step. A community clean install consequently booted the stock SPI controller
+and logged `Invalid proto 9`. The guarded flow now pins the Phase 91 source,
+targets the exact v3 ABI, installs all three modules, forces them into the
+initramfs, and verifies their source versions. The reported
+`sp11_windows_se_init=1` setting is not the general fix and remains opt-in; the
+validated development device works with it disabled. See
+[ADR-0050](adr-0050-sp11-touchscreen-clean-install-release-flow.md).
+
 ## Context
 
 [ADR-0048](adr-0048-jglathe-qcom-7-2-rc5-jg-0sp11v2-build.md) established the
@@ -101,7 +111,8 @@ The Docker kernel build:
   --jobs 8
 ```
 
-The touchscreen module build, against the installed v3 headers:
+The touchscreen module build and guarded install, against the installed v3
+headers:
 
 ```bash
 ./scripts/build-sp11-touchscreen-modules.sh --install
@@ -114,12 +125,10 @@ at the same relative paths as the in-tree counterparts:
 - `drivers/spi/spi-geni-qcom.ko`
 - `drivers/input/touchscreen/mshw0485_touch.ko`
 
-After installing the modules, the initramfs must be regenerated so early boot
-loads the geocausa versions instead of the stock ones:
-
-```bash
-dracut -f /boot/initrd.img-$(uname -r) $(uname -r)
-```
+The installer writes explicit initramfs-tools and dracut inclusion
+configuration, regenerates the exact target ABI, then checks that module
+selection and the initramfs use the geocausa source versions. No separate
+`dracut` or `update-initramfs` command is required.
 
 The installer DTB selection (`pick_dtb` in `scripts/install-sp11-support.sh`)
 now extracts the numeric suffix after `sp11v` and prefers the newest one:

--- a/docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md
+++ b/docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md
@@ -1,0 +1,177 @@
+---
+id: adr-0050-sp11-touchscreen-clean-install-release-flow
+title: "ADR0050: Surface Pro 11 Touchscreen Clean-Install and Release Flow"
+# prettier-ignore
+description: Retrospective and decision record for making the Surface Pro 11 touchscreen module, initramfs, diagnostics, and release flow reproducible on clean and upgraded systems.
+---
+
+# ADR0050: Surface Pro 11 Touchscreen Clean-Install and Release Flow
+
+## Status
+
+Accepted (2026-08-06). The implementation and module identities are validated
+on the existing OLED X1E80100 development device. A clean-install hardware run
+remains a release gate for the next touchscreen bundle.
+
+## Context
+
+The `sp11v3` release was announced after the MSHW0485 touchscreen worked on the
+development Surface. A second OLED X1E80100 user then reported a dead input
+device and this controller error in
+[Ubuntu Discourse post 2077](https://discourse.ubuntu.com/t/ubuntu-concept-snapdragon-x-elite/48800/2077):
+
+```text
+geni_spi a88000.spi: Invalid proto 9
+```
+
+The user added `spi_geni_qcom.sp11_windows_se_init=1`, added module-load files,
+ran `update-initramfs -u`, and rebooted successfully. Those changes were made
+together, so the report did not isolate which change was causal.
+
+Source and device evidence distinguish them:
+
+- The stock Johan G. `spi-geni-qcom` at kernel source commit `8f953dd` rejects
+  protocol 9 with `Invalid proto 9`.
+- The pinned geocausa Phase 91 controller accepts protocol 9 on `a88000.spi`
+  unconditionally. `sp11_windows_se_init` is consulted later to choose a
+  controller-initialization path; it does not enable protocol-9 recognition.
+- The development Surface works with `sp11_windows_se_init=N` and logs
+  `applied Linux-integrated QSPI SE preparation`.
+- Its three loaded module source versions match the `updates/` files, and they
+  load during the initramfs phase before the root filesystem is available.
+- The Phase 91 reference deployment explicitly excludes the experimental
+  Windows controller sequence from its validated baseline.
+
+The 2026-08-06 diagnostic on the development Surface identified loaded and
+selected source versions `A9BE6B3E2AEF71B5F41F865` (`gpi`),
+`3A825FCED27D92B662FFA0E` (`spi_geni_qcom`), and
+`CF6FA888C2B8E129277C297` (`mshw0485_touch`). The patched controller accepted
+protocol 9 at 1.22 seconds and registered the input device at 1.32 seconds;
+the root filesystem was not mounted until 2.25 seconds. That ordering proves
+the working machine already obtained the override stack from its boot image.
+
+The high-confidence root cause is therefore a stale initramfs that loaded the
+stock controller (and potentially stock GPI DMA module) before the root
+filesystem's `updates/` overrides were available. Rebuilding the initramfs was
+the likely decisive action in the community recovery. The Windows-derived
+controller path may still be useful for a future machine-specific A/B test,
+but the report does not establish that it is generally required.
+
+### Why development did not reproduce the failure
+
+The development machine was stateful: it had gone through repeated Phase 91
+deployments, module swaps, and initramfs rebuilds before the v3 release test.
+The v3 modules were already selected in its boot image. The published script,
+however, only copied modules and ran `depmod`; it printed a reboot instruction
+without performing the mandatory initramfs rebuild. Documentation listed a
+separate `dracut` command, but the release had not been validated from a
+pristine stock-module initramfs. This was an upgrade-path test presented as a
+clean-install-capable flow.
+
+### Adjacent release-integrity findings
+
+The same retrospective found two packaging defects in the original release:
+
+1. The public tag `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3` points to commit
+   `1fe13d2` (the v2 tree), while the v3 support changes are in `25bd39c` and
+   merge commit `0a3fbdd`. The release command allowed GitHub to create a tag
+   at the then-current default branch instead of naming the manifest commit.
+2. The published checksum file was regenerated manually after the three `.ko`
+   files were added. It contains an impossible empty-file hash for itself and
+   names `RELEASE-NOTES.md`, which was used as the release body rather than
+   uploaded. Full verification therefore cannot pass.
+
+The kernel and module asset hashes remain individually inspectable, but the
+old tag and bundle must not be used as the template for another release.
+
+## Decision
+
+### Build
+
+- Pin the touchscreen source to an immutable Phase 91 commit.
+- Refuse dirty or wrong-origin source checkouts and support an explicit offline
+  build from the pinned commit.
+- Resolve or require the exact target ABI instead of assuming `uname -r`.
+- Refuse non-`sp11v3` targets by default because successful compilation does
+  not prove that the kernel contains the required touchscreen device tree.
+- Verify headers, `Module.symvers`, replaceable GPI/SPI config, module names,
+  vermagic, aliases, parameters, and source versions before producing a bundle.
+- Record the module source URL, ref, commit, target ABI, source versions, and
+  hashes in a generated manifest.
+
+### Install and boot image
+
+- Install the matched `gpi`, `spi-geni-qcom`, and `mshw0485_touch` set as one
+  exact-ABI operation.
+- Make the initramfs refresh part of the installer, not a follow-up note. Use
+  `update-initramfs` on Ubuntu and a guarded `dracut` fallback.
+- Add explicit initramfs-tools and dracut inclusion configuration for all three
+  modules, run `depmod`, and verify both module selection and initramfs content.
+- Make the kernel `--install-only` flow require the three-module bundle for an
+  `sp11v3` image unless the operator explicitly chooses a kernel-only install.
+- Never unload or replace the live GPI/SPI drivers in place. Install for the
+  target boot and require a reboot.
+- Keep `sp11_windows_se_init=0` as the validated default. Expose `=1` only as
+  an explicit, warned recovery profile.
+
+### Diagnostics
+
+Provide a touchscreen-specific diagnostic that compares selected and loaded
+module source versions, checks the live device tree, firmware and input node,
+and classifies the main signatures:
+
+| Signature | Classification |
+| --- | --- |
+| `Invalid proto 9` | Stock/stale `spi-geni-qcom` loaded; repair module selection and initramfs first |
+| `CH START completion timeout` | Stock or mismatched GPI DMA path likely loaded |
+| No enabled `spi@a88000` / MSHW0485 child | Wrong kernel, ABI, or device tree |
+| Protocol 9 accepted but client init fails | Investigate transport/client state; only then A/B the opt-in cold-init profile |
+| `Microsoft Surface G6 Touch` plus initialized log | Controller, DMA, client, and input registration succeeded |
+
+### Release
+
+- Treat the three modules and their immutable source provenance as first-class
+  release assets.
+- Generate one explicit upload-asset list. Hash exactly that list, excluding
+  `SHA256SUMS` itself and the local notes file, then append the checksum file to
+  the upload list.
+- Create the GitHub release with `--target <support-commit>` and reject an
+  existing tag that resolves elsewhere.
+- Validate tag commit, package ABI/version/roles, module vermagic/source
+  versions/aliases, touchscreen DTB content, checksum coverage, and exact asset
+  equality before publication and again from a fresh download.
+- Publish a new immutable corrective tag rather than moving the existing
+  public v3 tag.
+
+## Validation matrix
+
+The next release must cover:
+
+1. a clean v3 install while an older kernel is running;
+2. a deliberately stale stock-module initramfs, followed by guarded repair;
+3. an already-working v3 reinstall (idempotency);
+4. missing and mismatched module bundles (refusal before package mutation);
+5. both initramfs-tools and dracut paths;
+6. cold power-on, Linux reboot, Windows-to-Linux boot, and suspend/resume;
+7. default Linux-integrated initialization, with the Windows sequence tested
+   separately only if a correctly loaded module still fails.
+
+## Consequences
+
+- The community's reported clean-install failure becomes a detected and
+  repairable module-selection error.
+- A release can no longer claim touchscreen support when it contains only the
+  v3 kernel packages or loose, untracked `.ko` additions.
+- Building modules for experimental ABIs now requires an explicit override.
+- Installation does more validation and may take longer because the exact
+  initramfs is rebuilt and inspected.
+- The original v3 release remains useful historical evidence but needs a
+  corrective successor before being recommended as a reproducible bundle.
+
+## Related
+
+- [ADR0041: Surface Pro 11 Touchscreen Kernel Patch Set](adr-0041-sp11-touchscreen-patches.md)
+- [ADR0042: Surface Pro 11 Touchscreen Integration Troubleshooting](adr-0042-sp11-touchscreen-troubleshooting.md)
+- [ADR0049: JG 7.2-rc5-jg-0sp11v3 Touchscreen Kernel Build](adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
+- [geocausa Phase 91 controller source](https://github.com/geocausa/SP11X1e-touchscreen/blob/6bbcf7a4759a73014047a57e819219dd7f34951a/phase55/modules/spi-geni-qcom.c)
+- [Original v3 GitHub release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc5-jg-0sp11v3)

--- a/docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md
+++ b/docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md
@@ -72,7 +72,7 @@ clean-install-capable flow.
 
 The same retrospective found two packaging defects in the original release:
 
-1. The public tag `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3` points to commit
+1. The now-removed public tag `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3` pointed to commit
    `1fe13d2` (the v2 tree), while the v3 support changes are in `25bd39c` and
    merge commit `0a3fbdd`. The release command allowed GitHub to create a tag
    at the then-current default branch instead of naming the manifest commit.
@@ -81,8 +81,9 @@ The same retrospective found two packaging defects in the original release:
    names `RELEASE-NOTES.md`, which was used as the release body rather than
    uploaded. Full verification therefore cannot pass.
 
-The kernel and module asset hashes remain individually inspectable, but the
-old tag and bundle must not be used as the template for another release.
+The audit captured the manifest and checksum defects before the release and
+tag were removed on 2026-08-07. They must not be used as the template for
+another release.
 
 ## Decision
 
@@ -165,13 +166,14 @@ The next release must cover:
 - Building modules for experimental ABIs now requires an explicit override.
 - Installation does more validation and may take longer because the exact
   initramfs is rebuilt and inspected.
-- The original v3 release remains useful historical evidence but needs a
-  corrective successor before being recommended as a reproducible bundle.
+- The original v3 release and tag were removed on 2026-08-07. This ADR retains
+  the audit evidence; a corrective successor must use a new immutable tag.
 
 ## Related
 
 - [ADR0041: Surface Pro 11 Touchscreen Kernel Patch Set](adr-0041-sp11-touchscreen-patches.md)
 - [ADR0042: Surface Pro 11 Touchscreen Integration Troubleshooting](adr-0042-sp11-touchscreen-troubleshooting.md)
 - [ADR0049: JG 7.2-rc5-jg-0sp11v3 Touchscreen Kernel Build](adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
+- [ADR0051: Remove Broken or Incorrect Releases and Tags](adr-0051-release-and-tag-cleanup.md)
 - [geocausa Phase 91 controller source](https://github.com/geocausa/SP11X1e-touchscreen/blob/6bbcf7a4759a73014047a57e819219dd7f34951a/phase55/modules/spi-geni-qcom.c)
-- [Original v3 GitHub release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc5-jg-0sp11v3)
+- Removed original v3 release and tag: `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3`

--- a/docs/adr/adr-0051-release-and-tag-cleanup.md
+++ b/docs/adr/adr-0051-release-and-tag-cleanup.md
@@ -1,0 +1,280 @@
+---
+id: adr-0051-release-and-tag-cleanup
+title: "ADR0051: Remove Broken or Incorrect Releases and Tags"
+# prettier-ignore
+description: Decision record for auditing the project's GitHub releases and tags, removing artifacts with false functionality or provenance, and preserving valid historical releases.
+---
+
+# ADR0051: Remove Broken or Incorrect Releases and Tags
+
+## Status
+
+Accepted and executed (2026-08-07).
+
+## Context
+
+The touchscreen clean-install retrospective in
+[ADR0050](adr-0050-sp11-touchscreen-clean-install-release-flow.md) found that
+the public `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3` release could not be treated as a
+reproducible release:
+
+- its tag pointed to the v2 support commit rather than the commit recorded by
+  the release manifest or the later v3 merge;
+- its checksum file listed itself with the empty-file hash and named a release
+  notes file that was not uploaded;
+- the touchscreen modules were added without a dedicated immutable provenance
+  manifest; and
+- its install instructions allowed a stock controller to remain in the
+  initramfs, causing a clean installation to report `Invalid proto 9`.
+
+That discovery required a broader question: whether other historical releases
+or tags also made claims that their artifacts, provenance, or tagged source did
+not support. Removing only the most recent release would leave earlier known
+failures available for new users to install.
+
+### Audit scope and method
+
+The audit examined all 11 GitHub releases, all 11 remote tags, and all 12 local
+tags that existed before cleanup. The additional local tag was the unpublished
+`sp11-qcom-x1e-7.2-rc5-jg-0` source marker.
+
+For each release, the audit:
+
+1. listed the release title, target, assets, and published instructions;
+2. resolved the local and remote tag to a commit;
+3. downloaded the small checksum and provenance manifests;
+4. compared the manifest's support commit with the tag target;
+5. compared checksum entries with the actual uploaded asset names;
+6. inspected the tagged tree for the support files claimed by the release;
+7. compared functionality claims with the device evidence and later ADRs; and
+8. distinguished a superseded but valid experiment from an artifact known to
+   be broken or incorrectly identified.
+
+Age or supersession alone was not grounds for deletion. A historical release
+could remain when its claims and known provenance limitations were disclosed,
+its tag matched the support commit named by the manifest, and no device
+evidence showed that its primary purpose failed.
+
+## Findings
+
+### Releases and tags removed
+
+| Release and tag | Finding | Evidence |
+| --- | --- | --- |
+| `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3` | Incorrect tag, invalid checksum set, incomplete touchscreen provenance, and unsafe clean-install instructions | Tag `1fe13d2` was the v2 tree; the manifest recorded `25bd39c`; v3 merged as `0a3fbdd`; `SHA256SUMS` named itself and a missing notes asset; ADR0050 records the clean-install failure |
+| `sp11-qcom-x1e-7.1.3-jg-0-touch` | The released kernel did not contain the touchscreen patches it claimed to provide | Tag `353b9e1` predates the touchscreen change and contains no touchscreen patch paths; the manifest recorded `050c19e`; ADR0042 records that the installed release lacked the patches and touchscreen configuration |
+| `sp11-ubuntu-live-direct-jg-7.1.1` | The tag could not reproduce the image described by its manifest | Tag `8b866b5` pointed to the parent of manifest commit `8f38745`, which added the Johan G. 7.1.1 support used by the image |
+| `sp11-audio-topology-v1` | The included Surface UCM profile was functionally broken and had a corrected successor | Its `HiFi` verb referenced nonexistent `WSA2` controls and aborted before exposing `Speaker` or `Mic`; ADR0044 documents the defect and the v2 correction |
+
+The deleted tag targets and conflicting manifest commits are retained here
+because the public refs no longer provide that audit trail:
+
+- `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3` targeted
+  `1fe13d2e124f40dbeccfca99910375952c8e7a1b`; its manifest recorded
+  `25bd39c8f187ce2b965ce2c5a82145c5596a024f`, and the reviewed v3 change
+  later merged as `0a3fbdd06c9821cd13564325b1921effeaf58cf5`.
+- `sp11-qcom-x1e-7.1.3-jg-0-touch` targeted
+  `353b9e12e6adbbee29e629c4c35332c404643dd6`; its manifest recorded
+  `050c19efc7e66ad03bc9a156f1290a21a21323be`.
+- `sp11-ubuntu-live-direct-jg-7.1.1` targeted
+  `8b866b5619b43c739ef58b09dcdcb8f9848fbf57`; its manifest recorded direct
+  child `8f387451fa45296a6bba3e49cab0f3bec4ac2cfd`.
+- `sp11-audio-topology-v1` targeted the matching support commit
+  `f79eab7a9e276dfd2816a3e048b9b886c9637e61`; it was removed for its
+  functional UCM defect rather than a tag mismatch.
+
+The removed asset inventory consisted of:
+
+- four v3 kernel packages, three touchscreen modules, a patched-source
+  archive, the kernel release manifest, the package list, and `SHA256SUMS`;
+- four 7.1.3 touchscreen kernel packages, a patched-source archive, two
+  kernel metadata files, and `SHA256SUMS`;
+- three split live-image parts, the image outline, the image manifest, and
+  `SHA256SUMS`; and
+- the audio topology binary, two UCM files, the card matcher, `CMakeLists.txt`,
+  release notes, the audio manifest, and `SHA256SUMS`.
+
+The live image itself was not proven corrupt. Its release was removed because
+the tag-to-manifest mismatch made the published source identity incorrect. A
+large binary release must remain traceable even when its runtime output looked
+valid during the original test.
+
+### Releases and tags preserved
+
+The following seven releases were retained:
+
+| Release | Tag/provenance result | Reason retained |
+| --- | --- | --- |
+| `sp11-qcom-x1e-7.0.0-22.22-rfkill1` | Tag and manifest match `dd93fa7` | Bounded Wi-Fi rfkill build with matching source provenance |
+| `sp11-qcom-x1e-7.1.1-jg-0-sp11` | Tag and manifest match `8b866b5`; manifest records `Support repo dirty: true` | Retained legacy Johan G. kernel with bounded claims and disclosed non-clean provenance |
+| `sp11-qcom-x1e-7.1.3-jg-0-sp11` | Tag and manifest match `421e4be`; manifest records `Support repo dirty: true` | Retained legacy kernel without a false touchscreen claim, but not a clean reproducibility example |
+| `sp11-qcom-x1e-7.1.3-jg-1` | Tag and manifest match `320317b` | Reproducible baseline build with bounded experimental claims |
+| `sp11-qcom-x1e-7.1.3-jg-1-dmic-2p4mhz` | Tag and manifest match `b4d6922` | Device-validated diagnostic DMIC build |
+| `sp11-qcom-x1e-7.1.3-jg-1-v2` | Tag and manifest match `c67df67` | Device-validated 2.4 MHz DMIC default kernel |
+| `sp11-audio-topology-v2` | Tag and manifest identify `c67df67` | Corrected single-WSA UCM and validated microphone route |
+
+The local-only `sp11-qcom-x1e-7.2-rc5-jg-0` tag at `ca379d2` was also retained.
+It never had a GitHub release and accurately marks the accepted, validated
+7.2-rc5 build-support change documented by ADR0047. An unpublished source tag
+is not incorrect merely because it has no binary release.
+
+The two retained dirty-manifest releases are legacy artifacts, not templates
+for future publication. Their tags correctly identify the commits recorded by
+their manifests, and their primary claims are not known to be false, but the
+uncommitted build-time support-tree state cannot be reconstructed from the tag.
+Current release tooling refuses dirty support repositories by default.
+
+## Decision
+
+Delete the four broken or incorrectly identified GitHub releases and their
+remote and local tags:
+
+```text
+sp11-qcom-x1e-7.2-rc5-jg-0sp11v3
+sp11-qcom-x1e-7.1.3-jg-0-touch
+sp11-ubuntu-live-direct-jg-7.1.1
+sp11-audio-topology-v1
+```
+
+Use the following criteria for future cleanup decisions. A release and its tag
+must be removed when evidence establishes one or more of these conditions:
+
+- the release's primary functionality was not present or did not work;
+- the tag does not resolve to the support commit recorded by the manifest;
+- the tagged tree lacks the patches, scripts, or instructions claimed by the
+  release;
+- the documented integrity check cannot succeed against the published asset
+  set; or
+- the release creates an unsafe default path that a clean installation cannot
+  reproduce.
+
+Do not delete a release merely because a newer version exists. Preserve useful
+historical experiments when their names, claims, tag targets, and manifests
+remain accurate.
+
+### Deletion procedure
+
+For each selected release:
+
+1. capture the tag target, manifest commit, asset list, and reason for removal
+   in this ADR or a linked retrospective;
+2. delete the GitHub release and its remote tag together with:
+
+   ```bash
+   gh release delete "$tag" \
+     --repo ooaklee/linux-surface-pro-11-oe \
+     --cleanup-tag \
+     --yes
+   ```
+
+   The `--cleanup-tag` flag is mandatory. If post-deletion verification still
+   finds the remote tag, delete that exact ref explicitly with
+   `git push origin --delete "$tag"`;
+3. delete the corresponding local tag;
+4. verify independently that the release, remote tag, and local tag are all
+   absent; and
+5. remove live documentation links or amend historical ADRs to state that the
+   artifact was removed.
+
+Do not move a broken public tag to a corrected commit and do not reuse its
+name. A corrected artifact must receive a new immutable tag so caches, mirrors,
+and prior audit records cannot confuse the two releases.
+
+### Future release gates
+
+Before publishing a new binary release:
+
+- create it with an explicit target support commit;
+- require the manifest support commit and local and remote tag targets to
+  agree;
+- generate checksums from the exact upload list rather than adding assets
+  afterward;
+- validate a fresh download against exact asset membership and semantic
+  package or hardware checks;
+- keep release notes out of `SHA256SUMS` when they are used only as the GitHub
+  release body; and
+- retain a new tag only after the release validator passes.
+
+Touchscreen releases additionally follow the exact-ABI module, DTB,
+initramfs, and provenance gates in ADR0050.
+
+## Execution and verification
+
+The four releases were deleted with GitHub's release cleanup operation, which
+also deleted their remote tags. Their local tags were then deleted explicitly.
+
+Post-cleanup verification established:
+
+- all four release lookups fail because the releases no longer exist;
+- all four remote tag lookups return no matching refs;
+- all four local tag lookups return no matching refs;
+- seven preserved GitHub releases and their seven remote tags remain;
+- eight local tags remain, including the valid local-only 7.2-rc5 source tag;
+- no repository document links directly to any deleted GitHub release; and
+- `git diff --check` passes for the tracked documentation amendments, and the
+  new ADR contains no trailing whitespace.
+
+### Evidence-retention limitation
+
+The release API responses and small manifests were inspected before deletion,
+but a complete redacted raw audit bundle was not committed first. The deleted
+assets can therefore no longer be fetched independently from GitHub. This ADR
+preserves the resolved commits, asset inventory, comparison results, and links
+to corroborating repository history, but not the original API response bodies.
+
+Future release cleanup must commit a privacy-reviewed textual audit appendix
+containing the release JSON, checksum file, and small provenance manifests
+before deleting the remote release. Binary assets remain excluded.
+
+## Consequences
+
+- New users cannot accidentally download artifacts already known to be broken
+  or incorrectly identified.
+- The public release list is shorter but more trustworthy.
+- Historical reasoning remains available in git and the ADRs even though the
+  binary assets are no longer published.
+- Deleting a release removes its assets from normal GitHub access. Those
+  binaries are not recoverable from the git repository unless another copy
+  exists elsewhere.
+- The deleted tags could technically be recreated from their recorded commit
+  IDs, but their names are retired and must not be reused for replacement
+  releases.
+- Valid older releases remain available; cleanup does not imply that only the
+  newest release may be retained.
+
+## Alternatives Considered
+
+### Leave broken releases published with a warning
+
+Rejected. Existing download links, cached instructions, and direct asset URLs
+can bypass an edited warning. A known-broken kernel or boot image remains a
+risk while its release assets are public.
+
+### Move the existing tags to corrected commits
+
+Rejected. Moving a public tag destroys the stable relationship between a name
+and the source previously downloaded under that name. It also leaves mirrors
+and caches with conflicting histories.
+
+### Delete every historical release
+
+Rejected. Several older releases have matching tag provenance and bounded,
+validated purposes. Removing correct artifacts would discard useful rollback
+and diagnostic options without improving the accuracy of the remaining
+release set.
+
+### Keep the live image because its runtime validation passed
+
+Rejected. Runtime validation does not repair incorrect source provenance. A
+published image must be bound to the exact support commit recorded by its
+manifest.
+
+## Related
+
+- [ADR0026: Prebuilt Kernel Release Artifacts](adr-0026-prebuilt-kernel-release-artifacts.md)
+- [ADR0038: Split Compressed Live Image Release Assets](adr-0038-split-compressed-live-image-release-assets.md)
+- [ADR0042: Surface Pro 11 Touchscreen Integration Troubleshooting](adr-0042-sp11-touchscreen-troubleshooting.md)
+- [ADR0044: Surface Pro 11 UCM Uses One WSA Macro and Two Microphone Channels](adr-0044-sp11-ucm-single-wsa-macro-microphone.md)
+- [ADR0047: JG 7.2-rc5-jg-0 Kernel Build](adr-0047-jglathe-qcom-7-2-rc5-jg-0-build.md)
+- [ADR0050: Surface Pro 11 Touchscreen Clean-Install and Release Flow](adr-0050-sp11-touchscreen-clean-install-release-flow.md)
+- [Release Prebuilt Kernel Artifacts](../how-to/how-to-release-kernel-artifacts.md)

--- a/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
+++ b/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
@@ -223,16 +223,24 @@ the distinct `7.2-rc5-jg-0sp11v3` ABI:
 The kernel ABI carries the touchscreen device tree, but the runtime QSPI
 support ships as out-of-tree modules from the geocausa Phase 91 baseline
 (`gpi`, `spi-geni-qcom`, `mshw0485_touch`). Build them against the installed
-v3 headers on the device and install as `updates/` overrides, then regenerate
-the initramfs so early boot loads them instead of the stock modules:
+v3 headers on the device. The pinned helper installs them as `updates/`
+overrides, regenerates the exact target initramfs with the available Ubuntu
+backend, and verifies that it contains the custom source versions:
 
 ```bash
 ./scripts/build-sp11-touchscreen-modules.sh --install
-sudo dracut -f /boot/initrd.img-$(uname -r) $(uname -r)
 ```
 
+If multiple v3 header trees are installed, pass `--release VER`. The script
+refuses plain and v2 ABIs by default because compiling successfully against
+their headers does not add the required MSHW0485 device-tree node. The default
+uses the validated Linux-integrated controller path; reserve
+`--windows-se-init` for a diagnosed cold-boot A/B test.
+
 See [ADR0049](../adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md) for
-the touchscreen decision and module/initramfs deployment notes.
+the touchscreen kernel decision and
+[ADR0050](../adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md) for
+the clean-install deployment and release-integrity decision.
 
 5. Rebuild and write the live USB image so `payload/kernel-debs/` is copied to
    `SP11DATA`.

--- a/docs/how-to/how-to-reinstall-patched-kernel-from-usb.md
+++ b/docs/how-to/how-to-reinstall-patched-kernel-from-usb.md
@@ -29,6 +29,8 @@ same way.
 
 - Root access on the Surface Pro 11.
 - The patched kernel `.deb` packages, from one of the sources below.
+- For an `sp11v3` touchscreen kernel, the release's matching `gpi.ko`,
+  `spi-geni-qcom.ko`, and `mshw0485_touch.ko` files in the same directory.
 - A checkout of this repository on the Surface — either the live USB
   `SP11DATA/support` directory, or a `git clone` — so the guarded installer and
   its post-install support helper are available.
@@ -105,6 +107,21 @@ sha256sum -c SHA256SUMS --ignore-missing
 # Expect: each linux-*.deb line printed as "OK"
 ```
 
+For an `sp11v3` release, download the entire published asset set rather than
+only `linux-*.deb`; the kernel and three touchscreen modules are one matched
+transaction. Validate that fresh directory before installation:
+
+```bash
+gh release download "$TAG" \
+  --repo ooaklee/linux-surface-pro-11-oe \
+  --dir "$DEBS"
+
+./scripts/validate-sp11-touchscreen-release.sh \
+  --dir "$DEBS" \
+  --tag "$TAG" \
+  --remote https://github.com/ooaklee/linux-surface-pro-11-oe.git
+```
+
 ## 2. Install the patched kernel
 
 Run the guarded installer from your repository checkout, pointing `--work-dir`
@@ -128,7 +145,10 @@ cd "$SP11DATA/support"
   your fallback),
 - installs the kernel `.deb` packages with `apt`, then
 - runs `install-sp11-support.sh --installed-system`, which re-selects the
-  rfkill-capable Denali OLED DTB and re-injects it into GRUB and initramfs.
+  rfkill-capable Denali OLED DTB and re-injects it into GRUB and initramfs, and
+- for `sp11v3`, refuses a missing or mismatched three-module touchscreen bundle
+  before package installation, then installs and verifies it in the exact
+  target initramfs.
 
 It elevates with `sudo` as needed. If `--work-dir` points to a directory under
 your home (e.g. `~/Downloads`), you may see a harmless `_apt` sandbox warning:
@@ -148,9 +168,13 @@ Installed Surface Pro 11 support helpers into /
 
 ### Minimal fallback (no repository checkout)
 
+Do not use this fallback for an `sp11v3` touchscreen release: direct `dpkg`
+does not install or verify the required out-of-tree module bundle. Obtain the
+repository checkout and use the guarded flow above.
+
 If you only have the `.deb` files and not a checkout of this repo, install them
-directly. This skips the fallback-kernel guard, so make sure a known-good
-qcom-x1e kernel is still installed first:
+directly only for a kernel-only release. This skips the fallback-kernel guard,
+so make sure a known-good qcom-x1e kernel is still installed first:
 
 ```bash
 sudo dpkg -i "$DEBS"/linux-*.deb
@@ -190,6 +214,12 @@ Verify the running kernel:
 ```bash
 uname -r
 # 7.0.0-22-qcom-x1e
+```
+
+For an `sp11v3` kernel, also verify the complete touchscreen boot path:
+
+```bash
+sudo ./scripts/troubleshoot-sp11-touchscreen.sh
 ```
 
 ## Privacy and Safety

--- a/docs/how-to/how-to-release-kernel-artifacts.md
+++ b/docs/how-to/how-to-release-kernel-artifacts.md
@@ -33,6 +33,9 @@ This procedure follows [ADR026](../adr/adr-0026-prebuilt-kernel-release-artifact
 - Corresponding source assets for the binary packages. Use Debian source
   package artifacts for apt-source builds, or a patched source archive for
   git-fallback builds.
+- For an `sp11v3` release, the exact-ABI `gpi.ko`, `spi-geni-qcom.ko`, and
+  `mshw0485_touch.ko` bundle produced by
+  `scripts/build-sp11-touchscreen-modules.sh`, including its build manifest.
 - GitHub CLI (`gh`) authenticated for the target repository.
 - A human review that the selected source assets are sufficient for the binary
   packages being released.
@@ -98,12 +101,36 @@ Before publishing, review that archive for the intended source state. The
 helper can enforce that a source file exists, but it cannot prove the source
 asset is legally or technically sufficient.
 
+For an `sp11v3` release, build the touchscreen bundle against the release ABI
+and preserve the generated provenance manifest:
+
+```bash
+./scripts/build-sp11-touchscreen-modules.sh \
+  --release 7.2-rc5-jg-0sp11v3-qcom-x1e \
+  --out-dir build/sp11v3-touchscreen-modules
+```
+
 4. Prepare release assets.
 
 ```bash
 ./scripts/prepare-sp11-kernel-release-assets.sh \
   --release-name sp11-qcom-x1e-7.0.0-22.22-rfkill1 \
   --source-asset build/release-source/sp11-qcom-x1e-7.0.0-22.22-rfkill1-patched-source.tar.xz
+```
+
+An `sp11v3` release must also supply the ABI-matched module directory and its
+immutable source provenance. Publish it under a new corrective tag; do not
+move the existing public v3 tag:
+
+```bash
+./scripts/prepare-sp11-kernel-release-assets.sh \
+  --kernel-debs-dir payload/kernel-debs \
+  --patch-dir patches/sp11-qcom-x1e-7.2-rc5-v3 \
+  --release-name sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1 \
+  --source-asset build/release-source/sp11-v3-patched-source.tar.xz \
+  --touchscreen-modules-dir build/sp11v3-touchscreen-modules \
+  --touchscreen-source-url https://github.com/geocausa/SP11X1e-touchscreen.git \
+  --touchscreen-source-ref 6bbcf7a4759a73014047a57e819219dd7f34951a
 ```
 
 The helper writes an ignored directory under:
@@ -130,6 +157,8 @@ Check that the directory contains:
 - `sp11-kernel-release-manifest.txt`,
 - `sp11-kernel-debs.txt`,
 - the corresponding source asset,
+- for `sp11v3`, all three touchscreen modules and
+  `sp11-touchscreen-modules-manifest.txt`,
 - `RELEASE-NOTES.md`.
 
 6. Verify checksums from inside the generated release directory.
@@ -139,6 +168,21 @@ cd build/release/sp11-qcom-x1e-7.0.0-22.22-rfkill1
 shasum -a 256 -c SHA256SUMS
 cd -
 ```
+
+Then run the semantic validator. It checks package identities, exact asset and
+checksum coverage, tag provenance, module metadata, and the packaged Denali
+OLED touchscreen device tree:
+
+```bash
+./scripts/validate-sp11-touchscreen-release.sh \
+  --dir build/release/<release-name> \
+  --tag <release-name> \
+  --remote origin
+```
+
+For a pre-tag local rehearsal, omit `--tag` and `--remote`. Run the full command
+after creating the tag and again against a fresh directory containing exactly
+the downloaded release assets.
 
 7. Review the generated publish command.
 
@@ -163,7 +207,9 @@ gh release view sp11-qcom-x1e-7.0.0-22.22-rfkill1 --json tagName,isPrerelease,as
 ```
 
 Confirm the release is marked as a prerelease and that every uploaded binary or
-source asset is listed in `SHA256SUMS`.
+source asset is listed in `SHA256SUMS`. Download the assets into a new empty
+directory and rerun `validate-sp11-touchscreen-release.sh` with `--tag` and
+`--remote origin`.
 
 ## Expected Output
 
@@ -176,6 +222,8 @@ The local release directory should contain a flat asset set:
 - `sp11-kernel-release-manifest.txt`,
 - `sp11-kernel-debs.txt`,
 - one or more corresponding source assets,
+- for `sp11v3`, `gpi.ko`, `spi-geni-qcom.ko`, `mshw0485_touch.ko`, and their
+  provenance manifest,
 - `RELEASE-NOTES.md`.
 
 The published GitHub release should include the `.deb` packages, checksums,
@@ -189,6 +237,7 @@ Run these checks before publishing:
 ```bash
 git status --short
 shasum -a 256 -c build/release/<release-name>/SHA256SUMS
+./scripts/validate-sp11-touchscreen-release.sh --dir build/release/<release-name>
 rg -n "/Users/|/home/|Workspace|GH_TOKEN|GITHUB_TOKEN|API_TOKEN|password|secret|BSSID|SSID|([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}" \
   build/release/<release-name> README.md docs scripts
 ```

--- a/patches/sp11-qcom-x1e-7.2-rc5-v3/README.md
+++ b/patches/sp11-qcom-x1e-7.2-rc5-v3/README.md
@@ -18,7 +18,11 @@ QSPI data pins GPIO 49/50 (`qup1_se2`), and attaches the touchscreen child
 with GPIO 48 reset, GPIO 51 interrupt, and GPIO 64 power. Runtime QSPI
 support is provided by the paired out-of-tree `gpi`, `spi-geni-qcom`, and
 `mshw0485_touch` modules from the geocausa phase 91 baseline, installed as
-higher-priority `/lib/modules/<release>/updates/` overrides.
+higher-priority `/lib/modules/<release>/updates/` overrides. Use
+`scripts/build-sp11-touchscreen-modules.sh --install`; it pins the Phase 91
+source, targets the exact v3 ABI, rebuilds the initramfs, and verifies that the
+three overrides—not the stock SPI/GPI modules—are embedded. See ADR-0050 for
+the clean-install failure retrospective.
 
 Apply it after `patches/jglathe-qcom-x1e-7.2-rc5` so the annotations
 compatibility fix is established before the Surface Pro 11 version signature

--- a/payload/README.md
+++ b/payload/README.md
@@ -12,10 +12,16 @@ payload/
       x1e80100/
         microsoft/
           Denali/
-  debs/
+  kernel-debs/
+    linux-*.deb
+    gpi.ko                  # required with an sp11v3 touchscreen kernel
+    spi-geni-qcom.ko        # exact same kernel ABI as the .deb set
+    mshw0485_touch.ko
   notes/
 ```
 
 The image builder copies this directory as `/payload` on the USB data
-partition. Use it for local firmware bundles, kernel `.deb` files, and notes
-needed while testing offline.
+partition. Use it for local firmware bundles, kernel artifacts, and notes
+needed while testing offline. Keep all three touchscreen modules beside the
+matching `sp11v3` kernel packages in `payload/kernel-debs/`; the guarded kernel
+installer discovers that bundle and refuses an incomplete touchscreen install.

--- a/scripts/build-sp11-live-usb-image.sh
+++ b/scripts/build-sp11-live-usb-image.sh
@@ -78,6 +78,7 @@ expect_kernel_debs="${SP11_EXPECT_KERNEL_DEBS:-false}"
 layout="$(mktemp)"
 dtb_copy="$(mktemp)"
 boot_copy="$(mktemp)"
+touchscreen_bundle="false"
 
 echo "== Image =="
 ls -lh "$image"
@@ -164,6 +165,16 @@ elif [ -n "$payload_inode" ]; then
       echo "Missing .deb files under /payload/kernel-debs on SP11DATA." >&2
       exit 1
     fi
+    if awk '$3 ~ /sp11v3.*\.deb$/ { found = 1 } END { exit found ? 0 : 1 }' "$kernel_debs_listing"; then
+      touchscreen_bundle="true"
+      for module in gpi.ko spi-geni-qcom.ko mshw0485_touch.ko; do
+        if ! awk -v module="$module" '$3 == module { found = 1 } END { exit found ? 0 : 1 }' \
+          "$kernel_debs_listing"; then
+          echo "Incomplete sp11v3 payload: missing /payload/kernel-debs/$module." >&2
+          exit 1
+        fi
+      done
+    fi
   fi
 fi
 
@@ -177,6 +188,16 @@ install_helper_inode="$(
 if [ -z "$install_helper_inode" ]; then
   echo "Missing /support/scripts/install-sp11-support.sh on SP11DATA." >&2
   exit 1
+fi
+
+if [ "$touchscreen_bundle" = "true" ]; then
+  touchscreen_helper_inode="$(
+    awk '$0 ~ /support\/scripts\/install-sp11-touchscreen\.sh$/ { sub(/:/, "", $2); print $2; exit }' "$support_listing"
+  )"
+  if [ -z "$touchscreen_helper_inode" ]; then
+    echo "The sp11v3 payload is missing /support/scripts/install-sp11-touchscreen.sh." >&2
+    exit 1
+  fi
 fi
 
 install_helper_copy="$(mktemp)"

--- a/scripts/build-sp11-qcom-x1e-kernel.sh
+++ b/scripts/build-sp11-qcom-x1e-kernel.sh
@@ -18,6 +18,8 @@ PREPARE_ONLY="false"
 RESET_SOURCE="false"
 ALLOW_NON_ARM64="false"
 ALLOW_NO_FALLBACK="false"
+TOUCHSCREEN_MODULES_DIR=""
+SKIP_TOUCHSCREEN_MODULES="false"
 SKIP_CLEAN="false"
 NO_FAKEROOT="false"
 JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
@@ -59,6 +61,14 @@ Options:
   --no-fakeroot         Run debian/rules directly when running as root.
   --allow-non-arm64     Allow prepare/build on a non-aarch64 host.
   --allow-no-fallback   Allow install with no older qcom-x1e kernel fallback.
+  --touchscreen-modules-dir DIR
+                        Directory containing the matching gpi.ko,
+                        spi-geni-qcom.ko, and mshw0485_touch.ko. For an
+                        sp11v3 install, defaults to the kernel work directory
+                        or its touchscreen-modules/ child.
+  --skip-touchscreen-modules
+                        Allow an sp11v3 kernel-only install. Touch will not
+                        work until the matching module bundle is installed.
   -h, --help            Show this help.
 
 The build can take hours and needs substantial free disk space. Keep an older
@@ -183,6 +193,19 @@ while [ "$#" -gt 0 ]; do
       ALLOW_NO_FALLBACK="true"
       shift
       ;;
+    --touchscreen-modules-dir)
+      if [ -z "${2:-}" ]; then
+        echo "Missing value for $1." >&2
+        usage >&2
+        exit 2
+      fi
+      TOUCHSCREEN_MODULES_DIR="$2"
+      shift 2
+      ;;
+    --skip-touchscreen-modules)
+      SKIP_TOUCHSCREEN_MODULES="true"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -194,6 +217,11 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+if [ "$SKIP_TOUCHSCREEN_MODULES" = "true" ] && [ -n "$TOUCHSCREEN_MODULES_DIR" ]; then
+  echo "--skip-touchscreen-modules cannot be combined with --touchscreen-modules-dir." >&2
+  exit 2
+fi
 
 case "$SOURCE_MODE" in
   apt|git)
@@ -687,6 +715,99 @@ deb_kernel_abi() {
   esac
 }
 
+touchscreen_target_release() {
+  local deb abi found=""
+
+  for deb in "$@"; do
+    abi="$(deb_kernel_abi "$deb")"
+    case "$abi" in
+      *sp11v3*-qcom-x1e)
+        if [ -n "$found" ] && [ "$found" != "$abi" ]; then
+          echo "Mixed touchscreen kernel ABIs in one install: $found and $abi." >&2
+          return 1
+        fi
+        found="$abi"
+        ;;
+    esac
+  done
+
+  printf '%s\n' "$found"
+}
+
+resolve_touchscreen_modules_dir() {
+  local candidate
+  local -a candidates=()
+
+  if [ -n "$TOUCHSCREEN_MODULES_DIR" ]; then
+    candidates+=("$TOUCHSCREEN_MODULES_DIR")
+  else
+    candidates+=("$work_dir/touchscreen-modules" "$work_dir")
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    [ -d "$candidate" ] || continue
+    if [ -s "$candidate/gpi.ko" ] && \
+      [ -s "$candidate/spi-geni-qcom.ko" ] && \
+      [ -s "$candidate/mshw0485_touch.ko" ]; then
+      (cd "$candidate" && pwd -P)
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+validate_touchscreen_modules_dir() {
+  local directory="$1"
+  local release="$2"
+  local index module_path actual_name vermagic module_release srcversion
+  local -a module_files=(gpi.ko spi-geni-qcom.ko mshw0485_touch.ko)
+  local -a module_names=(gpi spi_geni_qcom mshw0485_touch)
+
+  require_tool modinfo
+  require_tool grep
+
+  for index in "${!module_files[@]}"; do
+    module_path="$directory/${module_files[index]}"
+    if [ ! -f "$module_path" ] || [ -L "$module_path" ]; then
+      echo "Touchscreen module must be a regular, non-symlinked file: $module_path" >&2
+      return 1
+    fi
+
+    actual_name="$(modinfo -F name "$module_path" 2>/dev/null || true)"
+    if [ "$actual_name" != "${module_names[index]}" ]; then
+      echo "Unexpected module name in ${module_files[index]}: ${actual_name:-unknown}; expected ${module_names[index]}." >&2
+      return 1
+    fi
+
+    vermagic="$(modinfo -F vermagic "$module_path" 2>/dev/null || true)"
+    module_release="${vermagic%%[[:space:]]*}"
+    if [ "$module_release" != "$release" ]; then
+      echo "${module_files[index]} targets ${module_release:-unknown}, expected $release." >&2
+      return 1
+    fi
+
+    srcversion="$(modinfo -F srcversion "$module_path" 2>/dev/null || true)"
+    if [[ ! "$srcversion" =~ ^[0-9A-Fa-f]+$ ]]; then
+      echo "${module_files[index]} has no valid source-version identity." >&2
+      return 1
+    fi
+  done
+
+  if ! modinfo -p "$directory/spi-geni-qcom.ko" 2>/dev/null |
+       grep -q '^sp11_windows_se_init:'; then
+    echo "spi-geni-qcom.ko is not the required SP11 controller override." >&2
+    return 1
+  fi
+  if ! modinfo -F alias "$directory/mshw0485_touch.ko" 2>/dev/null |
+       grep -q 'microsoft,mshw0485'; then
+    echo "mshw0485_touch.ko lacks the Surface Pro 11 device-tree alias." >&2
+    return 1
+  fi
+
+  echo "Verified the exact-ABI touchscreen module bundle before package installation."
+}
+
 installed_kernel_abis() {
   local status pkg abi
 
@@ -816,7 +937,7 @@ build_kernel() {
 install_kernel_debs() {
   require_tool dpkg-query
 
-  local debs=()
+  local debs=() touchscreen_release="" touchscreen_dir=""
   if [ -f "$work_dir/sp11-kernel-debs.txt" ]; then
     while IFS= read -r deb; do
       [ -f "$deb" ] && debs+=("$deb")
@@ -837,6 +958,35 @@ install_kernel_debs() {
   printf '  %s\n' "${debs[@]}"
   ensure_header_dependencies_present "${debs[@]}"
   ensure_kernel_fallback "${debs[@]}"
+
+  touchscreen_release="$(touchscreen_target_release "${debs[@]}")"
+  if [ -n "$touchscreen_release" ]; then
+    if [ "$SKIP_TOUCHSCREEN_MODULES" = "true" ]; then
+      echo "Warning: installing $touchscreen_release without its required touchscreen module bundle." >&2
+      echo "Touch will remain unavailable until install-sp11-touchscreen.sh completes." >&2
+    else
+      touchscreen_dir="$(resolve_touchscreen_modules_dir || true)"
+      if [ -z "$touchscreen_dir" ]; then
+        echo "Refusing an incomplete $touchscreen_release installation." >&2
+        echo "The v3 kernel device tree requires a matching module bundle containing:" >&2
+        echo "  - gpi.ko" >&2
+        echo "  - spi-geni-qcom.ko" >&2
+        echo "  - mshw0485_touch.ko" >&2
+        echo "Place them in $work_dir, use --touchscreen-modules-dir DIR, or explicitly pass --skip-touchscreen-modules." >&2
+        exit 1
+      fi
+      if [ ! -x "$repo_dir/scripts/install-sp11-touchscreen.sh" ]; then
+        echo "Missing guarded touchscreen installer: $repo_dir/scripts/install-sp11-touchscreen.sh" >&2
+        exit 1
+      fi
+      validate_touchscreen_modules_dir "$touchscreen_dir" "$touchscreen_release" || exit 1
+      echo "Found matching touchscreen module bundle: $touchscreen_dir"
+    fi
+  elif [ -n "$TOUCHSCREEN_MODULES_DIR" ]; then
+    echo "--touchscreen-modules-dir was supplied, but this transaction has no sp11v3 kernel image." >&2
+    exit 1
+  fi
+
   as_root apt install --reinstall "${debs[@]}"
 
   if [ -x "$repo_dir/scripts/install-sp11-support.sh" ]; then
@@ -844,6 +994,12 @@ install_kernel_debs() {
   elif command -v /usr/local/sbin/sp11-grub-inject-dtb >/dev/null 2>&1; then
     as_root update-grub
     as_root /usr/local/sbin/sp11-grub-inject-dtb
+  fi
+
+  if [ -n "$touchscreen_release" ] && [ "$SKIP_TOUCHSCREEN_MODULES" != "true" ]; then
+    as_root "$repo_dir/scripts/install-sp11-touchscreen.sh" \
+      --modules-dir "$touchscreen_dir" \
+      --release "$touchscreen_release"
   fi
 }
 

--- a/scripts/build-sp11-touchscreen-modules.sh
+++ b/scripts/build-sp11-touchscreen-modules.sh
@@ -1,90 +1,308 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Builds the out-of-tree Surface Pro 11 touchscreen modules (gpi,
-# spi-geni-qcom, mshw0485_touch) from the geocausa Phase 91 baseline against
-# the current kernel's headers, and installs them as higher-priority
-# /lib/modules/<release>/updates/ overrides.
-#
-# The kernel must have been built with the v3 touchscreen DTS patch applied
-# (patches/sp11-qcom-x1e-7.2-rc5-v3), and linux-headers for the running
-# kernel must be installed on this machine.
+# Build the Surface Pro 11 OLED touchscreen module set from an immutable
+# geocausa Phase 91 revision. Installation is delegated to the guarded
+# installer, which also rebuilds and verifies the target initramfs.
 
 GIT_URL="https://github.com/geocausa/SP11X1e-touchscreen.git"
-GIT_BRANCH="main"
+# Phase 91 release merge. The later ddb79dd revision used for the original v3
+# artifacts changes documentation only; the module sources are identical.
+GIT_REF="6bbcf7a4759a73014047a57e819219dd7f34951a"
 SOURCE_DIR="build/SP11X1e-touchscreen"
 OUT_DIR=".sp11-kmod-v3"
+RELEASE=""
 INSTALL="false"
-RELEASE="$(uname -r)"
-KVER_DIR="/lib/modules/${RELEASE}"
+OFFLINE="false"
+ALLOW_UNSUPPORTED_RELEASE="false"
+WINDOWS_SE_INIT="false"
 
 usage() {
   cat <<EOF
 Usage: $0 [options]
 
+Builds the pinned geocausa Phase 91 gpi, spi-geni-qcom, and
+mshw0485_touch modules for a Surface Pro 11 touchscreen kernel.
+
 Options:
-  --source-dir DIR  Directory to clone the geocausa tree into (default $SOURCE_DIR).
-  --out-dir DIR     Where to drop the built modules (default $OUT_DIR).
-  --install         Also install into $KVER_DIR/updates/ and run depmod.
-  --release VER     Target kernel release (default \$(uname -r)).
-  -h, --help        Show this help.
+  --release VER       Target kernel release. By default, use the running v3
+                      release or the sole installed sp11v3 release.
+  --source-dir DIR    Managed geocausa checkout, default $SOURCE_DIR.
+  --source-url URL    Source repository, default $GIT_URL.
+  --source-ref REF    Immutable source commit, default $GIT_REF.
+  --out-dir DIR       Module output directory, default $OUT_DIR.
+  --offline           Do not fetch; require source-ref in the local checkout.
+  --install           Install, rebuild the exact target initramfs, and verify.
+  --windows-se-init   Opt in to the experimental captured Windows cold-init
+                      controller path. The validated default leaves it off.
+  --allow-unsupported-release
+                      Build for a release without an sp11v3 ABI marker. This
+                      cannot make a kernel without the touchscreen DT usable.
+  -h, --help          Show this help.
 EOF
 }
 
-while [ $# -gt 0 ]; do
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"
+}
+
+require_arg() {
+  if [ -z "${2:-}" ]; then
+    echo "Missing value for $1." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+resolve_release() {
+  local running candidate
+  local -a candidates=()
+
+  if [ -n "$RELEASE" ]; then
+    printf '%s\n' "$RELEASE"
+    return 0
+  fi
+
+  running="$(uname -r)"
+  case "$running" in
+    *sp11v3*-qcom-x1e)
+      if [ -d "/lib/modules/$running/build" ]; then
+        printf '%s\n' "$running"
+        return 0
+      fi
+      ;;
+  esac
+
+  for candidate in /lib/modules/*sp11v3*-qcom-x1e; do
+    [ -d "$candidate/build" ] || continue
+    candidates+=("${candidate##*/}")
+  done
+
+  if [ "${#candidates[@]}" -eq 1 ]; then
+    printf '%s\n' "${candidates[0]}"
+    return 0
+  fi
+
+  if [ "${#candidates[@]}" -eq 0 ]; then
+    die "no installed sp11v3 kernel with matching headers; pass --release VER"
+  fi
+
+  echo "Multiple installed sp11v3 header trees found:" >&2
+  printf '  - %s\n' "${candidates[@]}" >&2
+  die "choose the exact target with --release VER"
+}
+
+while [ "$#" -gt 0 ]; do
   case "$1" in
-    --source-dir) SOURCE_DIR="$2"; shift 2 ;;
-    --out-dir) OUT_DIR="$2"; shift 2 ;;
-    --install) INSTALL="true"; shift ;;
-    --release) RELEASE="$2"; shift 2 ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    --release)
+      require_arg "$1" "${2:-}"
+      RELEASE="$2"
+      shift 2
+      ;;
+    --source-dir)
+      require_arg "$1" "${2:-}"
+      SOURCE_DIR="$2"
+      shift 2
+      ;;
+    --source-url)
+      require_arg "$1" "${2:-}"
+      GIT_URL="$2"
+      shift 2
+      ;;
+    --source-ref)
+      require_arg "$1" "${2:-}"
+      GIT_REF="$2"
+      shift 2
+      ;;
+    --out-dir)
+      require_arg "$1" "${2:-}"
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --offline)
+      OFFLINE="true"
+      shift
+      ;;
+    --install)
+      INSTALL="true"
+      shift
+      ;;
+    --windows-se-init)
+      WINDOWS_SE_INIT="true"
+      shift
+      ;;
+    --allow-unsupported-release)
+      ALLOW_UNSUPPORTED_RELEASE="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
   esac
 done
 
-KVER_DIR="/lib/modules/${RELEASE}"
-KDIR="${KVER_DIR}/build"
+if [ "$WINDOWS_SE_INIT" = "true" ] && [ "$INSTALL" != "true" ]; then
+  die "--windows-se-init only applies with --install"
+fi
+if [[ ! "$GIT_REF" =~ ^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$ ]]; then
+  die "--source-ref must be an immutable 40- or 64-character hexadecimal commit"
+fi
+GIT_REF="${GIT_REF,,}"
 
-if [ ! -d "${KDIR}" ]; then
-  echo "error: no headers found at ${KDIR}. Install linux-headers-${RELEASE} first." >&2
-  exit 1
+case "$(uname -m)" in
+  aarch64|arm64) ;;
+  *) die "module build requires an ARM64 host" ;;
+esac
+
+RELEASE="$(resolve_release)"
+case "$RELEASE" in
+  *sp11v3*-qcom-x1e) ;;
+  *)
+    if [ "$ALLOW_UNSUPPORTED_RELEASE" != "true" ]; then
+      die "$RELEASE is not an sp11v3 touchscreen ABI; pass --allow-unsupported-release only for development"
+    fi
+    echo "Warning: building for unsupported release $RELEASE." >&2
+    ;;
+esac
+
+KVER_DIR="/lib/modules/$RELEASE"
+KDIR="$KVER_DIR/build"
+[ -d "$KDIR" ] || die "no headers found at $KDIR; install linux-headers-$RELEASE"
+[ -s "$KDIR/Module.symvers" ] || die "missing or empty $KDIR/Module.symvers"
+[ -r "$KDIR/include/config/kernel.release" ] || die "missing $KDIR/include/config/kernel.release"
+header_release="$(<"$KDIR/include/config/kernel.release")"
+[ "$header_release" = "$RELEASE" ] || die "header tree is for $header_release, not $RELEASE"
+
+config=""
+for candidate in "$KDIR/.config" "/boot/config-$RELEASE"; do
+  if [ -r "$candidate" ]; then
+    config="$candidate"
+    break
+  fi
+done
+[ -n "$config" ] || die "cannot find the exact kernel configuration for $RELEASE"
+grep -qx 'CONFIG_MODULES=y' "$config" || die "CONFIG_MODULES is not enabled for $RELEASE"
+grep -qx 'CONFIG_QCOM_GPI_DMA=m' "$config" || die "CONFIG_QCOM_GPI_DMA must be a replaceable module"
+grep -qx 'CONFIG_SPI_QCOM_GENI=m' "$config" || die "CONFIG_SPI_QCOM_GENI must be a replaceable module"
+if grep -qx 'CONFIG_MODULE_SIG_FORCE=y' "$config"; then
+  die "CONFIG_MODULE_SIG_FORCE rejects these unsigned experimental modules"
 fi
 
-if [ ! -d "${SOURCE_DIR}" ]; then
-  mkdir -p "${SOURCE_DIR}"
-  git clone --depth 1 --branch "${GIT_BRANCH}" "${GIT_URL}" "${SOURCE_DIR}"
+require_tool git
+require_tool install
+require_tool make
+require_tool modinfo
+require_tool sha256sum
+
+if [ -e "$SOURCE_DIR" ] && [ ! -d "$SOURCE_DIR/.git" ]; then
+  die "source directory exists but is not a git checkout: $SOURCE_DIR"
+fi
+
+new_checkout="false"
+if [ ! -d "$SOURCE_DIR/.git" ]; then
+  [ "$OFFLINE" != "true" ] || die "offline source checkout not found: $SOURCE_DIR"
+  mkdir -p "$(dirname "$SOURCE_DIR")"
+  git clone --filter=blob:none --no-checkout "$GIT_URL" "$SOURCE_DIR"
+  new_checkout="true"
+fi
+
+actual_origin="$(git -C "$SOURCE_DIR" remote get-url origin 2>/dev/null || true)"
+[ "$actual_origin" = "$GIT_URL" ] || die "source origin is $actual_origin, expected $GIT_URL"
+if [ "$new_checkout" != "true" ] && \
+  [ -n "$(git -C "$SOURCE_DIR" status --porcelain --untracked-files=normal)" ]; then
+  die "source checkout has local changes; use a clean checkout: $SOURCE_DIR"
+fi
+
+if [ "$OFFLINE" = "true" ]; then
+  source_commit="$(git -C "$SOURCE_DIR" rev-parse --verify "$GIT_REF^{commit}" 2>/dev/null || true)"
+  [ -n "$source_commit" ] || die "source ref $GIT_REF is unavailable in offline checkout"
 else
-  git -C "${SOURCE_DIR}" fetch --depth 1 origin "${GIT_BRANCH}"
-  git -C "${SOURCE_DIR}" checkout "${GIT_BRANCH}"
-  git -C "${SOURCE_DIR}" pull --ff-only origin "${GIT_BRANCH}"
+  git -C "$SOURCE_DIR" fetch --depth 1 origin "$GIT_REF"
+  source_commit="$(git -C "$SOURCE_DIR" rev-parse --verify 'FETCH_HEAD^{commit}')"
+fi
+git -C "$SOURCE_DIR" checkout --detach "$source_commit"
+if [ -n "$(git -C "$SOURCE_DIR" status --porcelain --untracked-files=normal)" ]; then
+  die "source checkout is not clean after selecting $source_commit"
 fi
 
-# The Phase 91 DMA baseline builds from phase55/modules. The kernel release
-# guard there is tuned for the geocausa baseline kernel; the SP11 v3 build is
-# a deliberately different release, so allow it explicitly.
-make -C "${SOURCE_DIR}/phase55/modules" \
-  KDIR="${KDIR}" \
-  EXPECTED_KERNEL_RELEASE="${RELEASE}" \
+module_source="$SOURCE_DIR/phase55/modules"
+[ -f "$module_source/Makefile" ] || die "pinned source lacks $module_source/Makefile"
+
+# Phase 91's Makefile guard names its original 7.1.3 validation kernel. We
+# supply and independently verify the exact target release here; the guarded
+# installer performs the runtime and initramfs checks before declaring success.
+make -C "$module_source" \
+  KDIR="$KDIR" \
+  EXPECTED_KERNEL_RELEASE="$RELEASE" \
   ALLOW_UNTESTED_KERNEL=1
 
-mkdir -p "${OUT_DIR}"
-for mod in gpi spi-geni-qcom mshw0485_touch; do
-  cp "${SOURCE_DIR}/phase55/modules/${mod}.ko" "${OUT_DIR}/"
+mkdir -p "$OUT_DIR"
+for module in gpi spi-geni-qcom mshw0485_touch; do
+  built="$module_source/$module.ko"
+  [ -s "$built" ] || die "build did not produce $built"
+  actual_name="$(modinfo -F name "$built")"
+  case "$module:$actual_name" in
+    gpi:gpi|spi-geni-qcom:spi_geni_qcom|mshw0485_touch:mshw0485_touch) ;;
+    *) die "$module.ko has unexpected module name $actual_name" ;;
+  esac
+  actual_release="$(modinfo -F vermagic "$built" | awk '{print $1}')"
+  [ "$actual_release" = "$RELEASE" ] || die "$module.ko was built for $actual_release, not $RELEASE"
+  [ -n "$(modinfo -F srcversion "$built")" ] || die "$module.ko has no srcversion"
+  install -m 0644 "$built" "$OUT_DIR/$module.ko"
 done
-echo "Built modules in ${OUT_DIR}/:"
-ls -la "${OUT_DIR}/"
+
+modinfo -p "$OUT_DIR/spi-geni-qcom.ko" | grep -q '^sp11_windows_se_init:' || \
+  die "spi-geni-qcom.ko lacks the expected SP11 controller parameter"
+modinfo -F alias "$OUT_DIR/mshw0485_touch.ko" | grep -q 'microsoft,mshw0485' || \
+  die "mshw0485_touch.ko lacks the Surface Pro 11 device-tree alias"
+
+manifest="$OUT_DIR/sp11-touchscreen-modules-manifest.txt"
+{
+  echo "# Surface Pro 11 Touchscreen Module Build Manifest"
+  echo
+  echo "Source URL: $GIT_URL"
+  echo "Source ref: $GIT_REF"
+  echo "Source commit: $source_commit"
+  echo "Target release: $RELEASE"
+  echo "Windows SE init default: disabled"
+  echo
+  echo "## Modules"
+  for module in gpi spi-geni-qcom mshw0485_touch; do
+    file="$OUT_DIR/$module.ko"
+    echo
+    echo "- $module.ko"
+    echo "  - Name: $(modinfo -F name "$file")"
+    echo "  - Srcversion: $(modinfo -F srcversion "$file")"
+    echo "  - Vermagic: $(modinfo -F vermagic "$file")"
+    echo "  - SHA256: $(sha256sum "$file" | awk '{print $1}')"
+  done
+} > "$manifest"
+
+echo "Built and verified touchscreen modules for $RELEASE in $OUT_DIR/."
+echo "Pinned source commit: $source_commit"
 
 if [ "$INSTALL" = "true" ]; then
-  if [ "$(id -u)" != "0" ]; then
-    echo "error: --install requires root." >&2
-    exit 1
+  installer="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/install-sp11-touchscreen.sh"
+  [ -x "$installer" ] || die "missing guarded installer: $installer"
+  install_args=(--modules-dir "$OUT_DIR" --release "$RELEASE")
+  if [ "$WINDOWS_SE_INIT" = "true" ]; then
+    install_args+=(--windows-se-init)
   fi
-  UPDATES="${KVER_DIR}/updates"
-  mkdir -p "${UPDATES}/drivers/dma/qcom" "${UPDATES}/drivers/spi" \
-    "${UPDATES}/drivers/input/touchscreen"
-  cp "${OUT_DIR}/gpi.ko" "${UPDATES}/drivers/dma/qcom/"
-  cp "${OUT_DIR}/spi-geni-qcom.ko" "${UPDATES}/drivers/spi/"
-  cp "${OUT_DIR}/mshw0485_touch.ko" "${UPDATES}/drivers/input/touchscreen/"
-  depmod -a "${RELEASE}"
-  echo "Installed updates modules for ${RELEASE}. Reboot to load them."
+  if [ "$(id -u)" -eq 0 ]; then
+    "$installer" "${install_args[@]}"
+  else
+    require_tool sudo
+    sudo "$installer" "${install_args[@]}"
+  fi
 fi

--- a/scripts/install-sp11-support.sh
+++ b/scripts/install-sp11-support.sh
@@ -67,6 +67,8 @@ install -m 0755 "$repo_dir/scripts/sp11-bluetooth-mac.sh" "$(target /usr/local/s
 install -m 0755 "$repo_dir/scripts/troubleshoot-sp11-audio.sh" "$(target /usr/local/sbin/troubleshoot-sp11-audio)"
 install -m 0755 "$repo_dir/scripts/troubleshoot-sp11-bluetooth.sh" "$(target /usr/local/sbin/troubleshoot-sp11-bluetooth)"
 install -m 0755 "$repo_dir/scripts/troubleshoot-sp11-wifi-rfkill.sh" "$(target /usr/local/sbin/troubleshoot-sp11-wifi-rfkill)"
+install -m 0755 "$repo_dir/scripts/install-sp11-touchscreen.sh" "$(target /usr/local/sbin/install-sp11-touchscreen)"
+install -m 0755 "$repo_dir/scripts/troubleshoot-sp11-touchscreen.sh" "$(target /usr/local/sbin/troubleshoot-sp11-touchscreen)"
 install -m 0755 "$repo_dir/scripts/sp11-pipewire-speaker-sink.sh" "$(target /usr/local/sbin/sp11-pipewire-speaker-sink)"
 install -m 0755 "$repo_dir/scripts/sp11-audio-topology.sh" "$(target /usr/local/sbin/sp11-audio-topology)"
 install -m 0755 "$repo_dir/scripts/sp11-enable-wsa-routing.sh" "$(target /usr/local/sbin/sp11-enable-wsa-routing)"

--- a/scripts/install-sp11-touchscreen.sh
+++ b/scripts/install-sp11-touchscreen.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM="${0##*/}"
+MODULES_DIR=""
+REQUESTED_RELEASE=""
+TARGET_ROOT="/"
+WINDOWS_SE_INIT="false"
+
+usage() {
+  cat <<EOF
+Usage: sudo $PROGRAM --modules-dir DIR [options]
+
+Install the matched Surface Pro 11 touchscreen module set for one exact kernel
+ABI and rebuild that ABI's initramfs.
+
+Required:
+  --modules-dir DIR    Directory containing gpi.ko, spi-geni-qcom.ko, and
+                       mshw0485_touch.ko.
+
+Options:
+  --release RELEASE   Expected kernel release. By default it is inferred from
+                       the common module vermagic. A supplied value must match.
+  --root DIR          Installed-system root (default /). Non-live roots must be
+                       runnable with chroot so their own initramfs tool is used.
+  --windows-se-init   Opt in to the experimental captured Windows cold-init
+                       controller sequence. The validated default is off.
+  -h, --help           Show this help.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+warn() {
+  echo "warning: $*" >&2
+}
+
+require_value() {
+  if [ -z "${2:-}" ]; then
+    echo "error: $1 requires a value" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --modules-dir)
+      require_value "$1" "${2:-}"
+      MODULES_DIR="$2"
+      shift 2
+      ;;
+    --modules-dir=*)
+      MODULES_DIR="${1#*=}"
+      [ -n "$MODULES_DIR" ] || die "--modules-dir cannot be empty"
+      shift
+      ;;
+    --release)
+      require_value "$1" "${2:-}"
+      REQUESTED_RELEASE="$2"
+      shift 2
+      ;;
+    --release=*)
+      REQUESTED_RELEASE="${1#*=}"
+      [ -n "$REQUESTED_RELEASE" ] || die "--release cannot be empty"
+      shift
+      ;;
+    --root)
+      require_value "$1" "${2:-}"
+      TARGET_ROOT="$2"
+      shift 2
+      ;;
+    --root=*)
+      TARGET_ROOT="${1#*=}"
+      [ -n "$TARGET_ROOT" ] || die "--root cannot be empty"
+      shift
+      ;;
+    --windows-se-init)
+      WINDOWS_SE_INIT="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[ -n "$MODULES_DIR" ] || {
+  usage >&2
+  exit 2
+}
+
+for tool in modinfo depmod install realpath sha256sum cmp mktemp grep awk find od tr; do
+  command -v "$tool" >/dev/null 2>&1 || die "required command not found: $tool"
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+  die "installation mutates the target system and must be run as root"
+fi
+
+MODULES_DIR="$(realpath -e -- "$MODULES_DIR")" || die "cannot resolve --modules-dir"
+[ -d "$MODULES_DIR" ] || die "not a directory: $MODULES_DIR"
+TARGET_ROOT="$(realpath -e -- "$TARGET_ROOT")" || die "cannot resolve --root"
+[ -d "$TARGET_ROOT" ] || die "not a directory: $TARGET_ROOT"
+
+root_path() {
+  local absolute="$1"
+  printf '%s%s' "${TARGET_ROOT%/}" "$absolute"
+}
+
+module_files=(gpi.ko spi-geni-qcom.ko mshw0485_touch.ko)
+module_names=(gpi spi_geni_qcom mshw0485_touch)
+module_relpaths=(
+  updates/drivers/dma/qcom/gpi.ko
+  updates/drivers/spi/spi-geni-qcom.ko
+  updates/drivers/input/touchscreen/mshw0485_touch.ko
+)
+module_sources=()
+COMMON_RELEASE=""
+
+for index in "${!module_files[@]}"; do
+  source_path="$MODULES_DIR/${module_files[index]}"
+  [ -f "$source_path" ] || die "required module is missing: $source_path"
+
+  actual_name="$(modinfo -F name "$source_path" 2>/dev/null || true)"
+  [ "$actual_name" = "${module_names[index]}" ] ||
+    die "${module_files[index]} has module name '${actual_name:-unknown}', expected '${module_names[index]}'"
+
+  vermagic="$(modinfo -F vermagic "$source_path" 2>/dev/null || true)"
+  module_release="${vermagic%%[[:space:]]*}"
+  [ -n "$module_release" ] || die "cannot read vermagic from $source_path"
+
+  if [ -z "$COMMON_RELEASE" ]; then
+    COMMON_RELEASE="$module_release"
+  elif [ "$module_release" != "$COMMON_RELEASE" ]; then
+    die "module vermagic releases differ: $COMMON_RELEASE and $module_release"
+  fi
+  module_sources+=("$source_path")
+done
+
+case "$COMMON_RELEASE" in
+  ""|*[!A-Za-z0-9._+~-]*|[!A-Za-z0-9]*)
+    die "unsafe kernel release inferred from vermagic: '$COMMON_RELEASE'"
+    ;;
+esac
+
+if [ -n "$REQUESTED_RELEASE" ] && [ "$REQUESTED_RELEASE" != "$COMMON_RELEASE" ]; then
+  die "--release '$REQUESTED_RELEASE' does not match module vermagic '$COMMON_RELEASE'"
+fi
+RELEASE="$COMMON_RELEASE"
+
+case "$RELEASE" in
+  *sp11v3*-qcom-x1e) ;;
+  *) die "$RELEASE is not an sp11v3 touchscreen kernel ABI" ;;
+esac
+
+if ! modinfo -p "${module_sources[1]}" 2>/dev/null |
+  grep -q '^sp11_windows_se_init:'; then
+  die "spi-geni-qcom.ko lacks sp11_windows_se_init; this is not the required SP11 override"
+fi
+if ! modinfo -F alias "${module_sources[2]}" 2>/dev/null |
+  grep -q 'microsoft,mshw0485'; then
+  die "mshw0485_touch.ko lacks the microsoft,mshw0485 device-tree alias"
+fi
+for index in "${!module_files[@]}"; do
+  srcversion="$(modinfo -F srcversion "${module_sources[index]}" 2>/dev/null || true)"
+  [ -n "$srcversion" ] || die "${module_files[index]} has no source-version identity"
+done
+
+MODULE_TREE="$(root_path "/lib/modules/$RELEASE")"
+[ -d "$MODULE_TREE" ] || die "target kernel module tree does not exist: $MODULE_TREE"
+[ -d "$(root_path /etc)" ] || die "target root lacks /etc: $TARGET_ROOT"
+[ -d "$(root_path /boot)" ] || die "target root lacks /boot: $TARGET_ROOT"
+
+config=""
+for candidate in \
+  "$(root_path "/lib/modules/$RELEASE/build/.config")" \
+  "$(root_path "/boot/config-$RELEASE")"; do
+  if [ -r "$candidate" ]; then
+    config="$candidate"
+    break
+  fi
+done
+[ -n "$config" ] || die "cannot find the exact target kernel configuration for $RELEASE"
+grep -qx 'CONFIG_MODULES=y' "$config" || die "CONFIG_MODULES is not enabled for $RELEASE"
+grep -qx 'CONFIG_QCOM_GPI_DMA=m' "$config" || die "CONFIG_QCOM_GPI_DMA must be a replaceable module"
+grep -qx 'CONFIG_SPI_QCOM_GENI=m' "$config" || die "CONFIG_SPI_QCOM_GENI must be a replaceable module"
+if grep -qx 'CONFIG_MODULE_SIG_FORCE=y' "$config"; then
+  die "CONFIG_MODULE_SIG_FORCE rejects the unsigned touchscreen modules"
+fi
+
+case "$(uname -m)" in
+  aarch64|arm64) ;;
+  *) die "touchscreen installation must run on an ARM64 system" ;;
+esac
+
+compatible="$(tr '\0' ' ' < /proc/device-tree/compatible 2>/dev/null || true)"
+case " $compatible " in
+  *" microsoft,denali-oled "*) ;;
+  *) die "running hardware is not the supported Surface Pro 11 OLED (microsoft,denali-oled)" ;;
+esac
+
+secure_boot_enabled="false"
+if command -v mokutil >/dev/null 2>&1 &&
+  mokutil --sb-state 2>/dev/null | grep -qi 'SecureBoot enabled'; then
+  secure_boot_enabled="true"
+else
+  for variable in /sys/firmware/efi/efivars/SecureBoot-*; do
+    [ -r "$variable" ] || continue
+    byte="$(od -An -t u1 -j 4 -N 1 "$variable" 2>/dev/null | tr -d ' ')"
+    [ "$byte" = 1 ] && secure_boot_enabled="true"
+  done
+fi
+[ "$secure_boot_enabled" != "true" ] || die "Secure Boot is enabled; these experimental modules are unsigned"
+
+touch_dtb=""
+for candidate in \
+  "$(root_path "/lib/firmware/$RELEASE/device-tree/qcom/x1e80100-microsoft-denali-oled.dtb")" \
+  "$(root_path "/usr/lib/linux-image-$RELEASE/qcom/x1e80100-microsoft-denali-oled.dtb")" \
+  "$(root_path "/boot/dtbs/$RELEASE/qcom/x1e80100-microsoft-denali-oled.dtb")"; do
+  if [ -f "$candidate" ] && grep -a -q 'microsoft,mshw0485' "$candidate"; then
+    touch_dtb="$candidate"
+    break
+  fi
+done
+[ -n "$touch_dtb" ] || die "the target ABI has no Denali OLED DTB with microsoft,mshw0485"
+
+firmware_found="false"
+for candidate in \
+  /lib/firmware/qcom/x1e80100/qupv3fw.elf.zst \
+  /lib/firmware/qcom/x1e80100/qupv3fw.elf.xz \
+  /lib/firmware/qcom/x1e80100/qupv3fw.elf; do
+  [ -f "$(root_path "$candidate")" ] && firmware_found="true"
+done
+[ "$firmware_found" = "true" ] || die "target root lacks qcom/x1e80100/qupv3fw.elf firmware"
+
+REFRESH_TOOL=""
+REFRESH_COMMAND=""
+if [ "$TARGET_ROOT" = "/" ]; then
+  if command -v update-initramfs >/dev/null 2>&1; then
+    REFRESH_TOOL="update-initramfs"
+    REFRESH_COMMAND="$(command -v update-initramfs)"
+  elif command -v dracut >/dev/null 2>&1; then
+    REFRESH_TOOL="dracut"
+    REFRESH_COMMAND="$(command -v dracut)"
+  else
+    die "neither update-initramfs nor dracut is installed"
+  fi
+else
+  command -v chroot >/dev/null 2>&1 || die "--root requires chroot"
+  [ -x "$(root_path /bin/sh)" ] || die "target root has no executable /bin/sh"
+  if ! chroot "$TARGET_ROOT" /bin/sh -c ':' >/dev/null 2>&1; then
+    die "target root is not runnable with chroot; refusing a partial offline install"
+  fi
+  if [ -x "$(root_path /usr/sbin/update-initramfs)" ]; then
+    REFRESH_TOOL="update-initramfs"
+    REFRESH_COMMAND="/usr/sbin/update-initramfs"
+  elif [ -x "$(root_path /usr/bin/dracut)" ]; then
+    REFRESH_TOOL="dracut"
+    REFRESH_COMMAND="/usr/bin/dracut"
+  elif [ -x "$(root_path /usr/sbin/dracut)" ]; then
+    REFRESH_TOOL="dracut"
+    REFRESH_COMMAND="/usr/sbin/dracut"
+  else
+    die "target root contains neither update-initramfs nor dracut"
+  fi
+fi
+
+if command -v lsinitramfs >/dev/null 2>&1; then
+  INITRD_INSPECTOR="lsinitramfs"
+elif command -v lsinitrd >/dev/null 2>&1; then
+  INITRD_INSPECTOR="lsinitrd"
+else
+  die "post-install verification requires lsinitramfs or lsinitrd"
+fi
+if command -v unmkinitramfs >/dev/null 2>&1; then
+  INITRD_EXTRACTOR="unmkinitramfs"
+elif command -v lsinitrd >/dev/null 2>&1; then
+  INITRD_EXTRACTOR="lsinitrd"
+else
+  die "exact initramfs module verification requires unmkinitramfs or lsinitrd"
+fi
+
+if [ "$WINDOWS_SE_INIT" = "true" ]; then
+  warn "--windows-se-init enables an experimental captured Windows cold-init path"
+  warn "the validated Phase 91 Linux-integrated profile uses sp11_windows_se_init=0"
+  SE_INIT_VALUE=1
+  PROFILE="windows-cold-init-opt-in"
+else
+  SE_INIT_VALUE=0
+  PROFILE="linux-integrated"
+fi
+
+work_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf -- "$work_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+cat > "$work_dir/sp11-touchscreen.modprobe" <<EOF
+# Generated by $PROGRAM for $RELEASE.
+# Keep the validated Linux-integrated controller path unless explicitly testing
+# the captured Windows cold-init fallback.
+softdep spi_geni_qcom pre: gpi
+softdep mshw0485_touch pre: spi_geni_qcom
+options spi_geni_qcom sp11_windows_se_init=$SE_INIT_VALUE
+EOF
+
+cat > "$work_dir/sp11-touchscreen.modules-load" <<'EOF'
+# Surface Pro 11 touchscreen transport order.
+gpi
+spi_geni_qcom
+mshw0485_touch
+EOF
+
+cat > "$work_dir/sp11-touchscreen.initramfs-hook" <<'EOF'
+#!/bin/sh
+set -eu
+
+PREREQ=""
+prereqs() { printf '%s\n' "$PREREQ"; }
+
+case "${1:-}" in
+  prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+release="${version:-}"
+[ -n "$release" ] || {
+  echo "sp11-touchscreen hook: initramfs kernel version is unavailable" >&2
+  exit 1
+}
+
+marker="/etc/sp11-touchscreen/releases/$release"
+[ -f "$marker" ] || exit 0
+
+for relative in \
+  updates/drivers/dma/qcom/gpi.ko \
+  updates/drivers/spi/spi-geni-qcom.ko \
+  updates/drivers/input/touchscreen/mshw0485_touch.ko; do
+  source_path="/lib/modules/$release/$relative"
+  if [ ! -f "$source_path" ]; then
+    echo "sp11-touchscreen hook: required override missing: $source_path" >&2
+    exit 1
+  fi
+  copy_file module "$source_path" "$source_path" || {
+    result=$?
+    [ "$result" -eq 1 ] || exit "$result"
+  }
+done
+
+manual_add_modules gpi spi_geni_qcom mshw0485_touch
+EOF
+
+cat > "$work_dir/sp11-touchscreen.dracut" <<'EOF'
+# Surface Pro 11 QSPI touchscreen transport and client. depmod selects the
+# exact updates/ overrides installed for the initramfs kernel release.
+force_drivers+=" gpi spi_geni_qcom mshw0485_touch "
+EOF
+
+{
+  printf 'release=%s\n' "$RELEASE"
+  printf 'profile=%s\n' "$PROFILE"
+  for index in "${!module_files[@]}"; do
+    checksum="$(sha256sum "${module_sources[index]}" | awk '{print $1}')"
+    printf '%s_sha256=%s\n' "${module_names[index]}" "$checksum"
+  done
+} > "$work_dir/release-marker"
+
+echo "Installing Surface Pro 11 touchscreen support for exact ABI: $RELEASE"
+for index in "${!module_files[@]}"; do
+  destination="$MODULE_TREE/${module_relpaths[index]}"
+  install -d -m 0755 "$(dirname "$destination")"
+  install -m 0644 "${module_sources[index]}" "$destination"
+done
+
+install -d -m 0755 \
+  "$(root_path /etc/modprobe.d)" \
+  "$(root_path /etc/modules-load.d)" \
+  "$(root_path /etc/initramfs-tools/hooks)" \
+  "$(root_path /etc/dracut.conf.d)" \
+  "$(root_path /etc/sp11-touchscreen/releases)"
+install -m 0644 "$work_dir/sp11-touchscreen.modprobe" \
+  "$(root_path /etc/modprobe.d/sp11-touchscreen.conf)"
+install -m 0644 "$work_dir/sp11-touchscreen.modules-load" \
+  "$(root_path /etc/modules-load.d/sp11-touchscreen.conf)"
+install -m 0755 "$work_dir/sp11-touchscreen.initramfs-hook" \
+  "$(root_path /etc/initramfs-tools/hooks/sp11-touchscreen)"
+install -m 0644 "$work_dir/sp11-touchscreen.dracut" \
+  "$(root_path /etc/dracut.conf.d/91-sp11-touchscreen.conf)"
+install -m 0644 "$work_dir/release-marker" \
+  "$(root_path "/etc/sp11-touchscreen/releases/$RELEASE")"
+
+depmod -b "$TARGET_ROOT" -a "$RELEASE"
+
+for index in "${!module_files[@]}"; do
+  selected="$(modinfo -b "$TARGET_ROOT" -k "$RELEASE" -n "${module_names[index]}" 2>/dev/null || true)"
+  expected_suffix="/lib/modules/$RELEASE/${module_relpaths[index]}"
+  case "$selected" in
+    *"$expected_suffix"|*"/usr$expected_suffix") ;;
+    *) die "depmod selects '${selected:-nothing}' for ${module_names[index]}, expected updates/${module_relpaths[index]#updates/}" ;;
+  esac
+  cmp -s "${module_sources[index]}" "$MODULE_TREE/${module_relpaths[index]}" ||
+    die "installed module differs from source: ${module_files[index]}"
+  echo "Verified disk selection: ${module_names[index]} -> $selected"
+done
+
+INITRD="$(root_path "/boot/initrd.img-$RELEASE")"
+if [ "$REFRESH_TOOL" = "update-initramfs" ]; then
+  if [ -e "$INITRD" ]; then
+    action=-u
+  else
+    action=-c
+  fi
+  if [ "$TARGET_ROOT" = "/" ]; then
+    "$REFRESH_COMMAND" "$action" -k "$RELEASE"
+  else
+    chroot "$TARGET_ROOT" "$REFRESH_COMMAND" "$action" -k "$RELEASE"
+  fi
+else
+  if [ "$TARGET_ROOT" = "/" ]; then
+    "$REFRESH_COMMAND" --force "/boot/initrd.img-$RELEASE" "$RELEASE"
+  else
+    chroot "$TARGET_ROOT" "$REFRESH_COMMAND" --force "/boot/initrd.img-$RELEASE" "$RELEASE"
+  fi
+fi
+
+[ -s "$INITRD" ] || die "initramfs was not created or updated: $INITRD"
+initrd_listing="$work_dir/initrd.list"
+if [ "$INITRD_INSPECTOR" = "lsinitramfs" ]; then
+  lsinitramfs "$INITRD" > "$initrd_listing" || die "lsinitramfs could not inspect $INITRD"
+else
+  lsinitrd "$INITRD" > "$initrd_listing" || die "lsinitrd could not inspect $INITRD"
+fi
+
+for relative in "${module_relpaths[@]}"; do
+  initrd_path="lib/modules/$RELEASE/$relative"
+  if ! grep -Fq "$initrd_path" "$initrd_listing" &&
+     ! grep -Fq "usr/$initrd_path" "$initrd_listing"; then
+    die "initramfs does not contain exact override path: $initrd_path"
+  fi
+  echo "Verified initramfs path: $initrd_path"
+done
+
+initrd_extract="$work_dir/initrd-extracted"
+mkdir -p "$initrd_extract"
+if [ "$INITRD_EXTRACTOR" = "unmkinitramfs" ]; then
+  unmkinitramfs "$INITRD" "$initrd_extract" || die "unmkinitramfs could not extract $INITRD"
+else
+  (
+    cd "$initrd_extract"
+    lsinitrd --unpack "$INITRD"
+  ) || die "lsinitrd could not extract $INITRD"
+fi
+
+for index in "${!module_files[@]}"; do
+  expected_relative="lib/modules/$RELEASE/${module_relpaths[index]}"
+  embedded="$(
+    find "$initrd_extract" -type f \
+      \( -path "*/$expected_relative" -o -path "*/usr/$expected_relative" \
+         -o -path "*/$expected_relative.*" -o -path "*/usr/$expected_relative.*" \) \
+      -print -quit
+  )"
+  [ -n "$embedded" ] || die "cannot locate extracted initramfs override for ${module_files[index]}"
+  source_srcversion="$(modinfo -F srcversion "${module_sources[index]}")"
+  embedded_srcversion="$(modinfo -F srcversion "$embedded" 2>/dev/null || true)"
+  [ "$embedded_srcversion" = "$source_srcversion" ] ||
+    die "initramfs ${module_files[index]} srcversion ${embedded_srcversion:-unknown} differs from $source_srcversion"
+
+  unexpected="$(
+    find "$initrd_extract" -type f -name "${module_files[index]}*" \
+      ! -path "*/${module_relpaths[index]}" \
+      ! -path "*/${module_relpaths[index]}.*" -print -quit
+  )"
+  [ -z "$unexpected" ] || die "initramfs also contains a stock/duplicate ${module_files[index]}: $unexpected"
+  echo "Verified initramfs srcversion: ${module_names[index]} -> $embedded_srcversion"
+done
+
+echo
+echo "Surface Pro 11 touchscreen modules installed successfully."
+echo "Profile: $PROFILE (sp11_windows_se_init=$SE_INIT_VALUE)"
+if [ "$TARGET_ROOT" = "/" ] && [ "$(uname -r)" = "$RELEASE" ]; then
+  echo "Reboot is required; the currently loaded modules were not replaced in memory."
+else
+  echo "Boot the exact kernel release '$RELEASE' to activate the installed stack."
+fi

--- a/scripts/prepare-sp11-kernel-release-assets.sh
+++ b/scripts/prepare-sp11-kernel-release-assets.sh
@@ -13,6 +13,16 @@ ALLOW_DIRTY="false"
 ALLOW_MISSING_SOURCE="false"
 SOURCE_ASSETS=()
 SOURCE_ASSET_COUNT=0
+TOUCHSCREEN_MODULES_DIR=""
+TOUCHSCREEN_SOURCE_URL=""
+TOUCHSCREEN_SOURCE_REF=""
+TOUCHSCREEN_ENABLED="false"
+TOUCHSCREEN_MODULE_FILES=(
+  "gpi.ko"
+  "spi-geni-qcom.ko"
+  "mshw0485_touch.ko"
+)
+TOUCHSCREEN_MODULE_MANIFEST="sp11-touchscreen-modules-manifest.txt"
 
 usage() {
   cat <<EOF
@@ -38,6 +48,16 @@ Options:
                           If omitted, derived from source mode.
   --source-asset PATH     Corresponding source artifact to copy into the
                           release directory. Can be repeated.
+  --touchscreen-modules-dir DIR
+                          Optional directory containing gpi.ko,
+                          spi-geni-qcom.ko, and mshw0485_touch.ko, plus the
+                          build manifest when produced by the build helper.
+  --touchscreen-source-url URL
+                          Source repository URL for the touchscreen modules.
+                          Required with --touchscreen-modules-dir.
+  --touchscreen-source-ref COMMIT
+                          Immutable 40- or 64-character source commit for the
+                          touchscreen modules. Required with their directory.
   --allow-dirty           Allow preparing assets when the support repository has
                           uncommitted changes. Intended for local test runs.
   --allow-missing-source  Allow a local draft without source artifacts. The
@@ -58,6 +78,20 @@ require_arg() {
     echo "Missing value for $1." >&2
     usage >&2
     exit 2
+  fi
+}
+
+file_size() {
+  local path="$1"
+  local size=""
+
+  if size="$(stat -c '%s' -- "$path" 2>/dev/null)"; then
+    printf '%s\n' "$size"
+  elif size="$(stat -f '%z' "$path" 2>/dev/null)"; then
+    printf '%s\n' "$size"
+  else
+    echo "Could not determine file size: $path" >&2
+    return 1
   fi
 }
 
@@ -109,6 +143,21 @@ while [ "$#" -gt 0 ]; do
       SOURCE_ASSET_COUNT=$((SOURCE_ASSET_COUNT + 1))
       shift 2
       ;;
+    --touchscreen-modules-dir)
+      require_arg "$1" "${2:-}"
+      TOUCHSCREEN_MODULES_DIR="$2"
+      shift 2
+      ;;
+    --touchscreen-source-url)
+      require_arg "$1" "${2:-}"
+      TOUCHSCREEN_SOURCE_URL="$2"
+      shift 2
+      ;;
+    --touchscreen-source-ref)
+      require_arg "$1" "${2:-}"
+      TOUCHSCREEN_SOURCE_REF="$2"
+      shift 2
+      ;;
     --allow-dirty)
       ALLOW_DIRTY="true"
       shift
@@ -133,6 +182,26 @@ require_tool awk
 require_tool git
 require_tool shasum
 require_tool stat
+
+if [ -n "$TOUCHSCREEN_MODULES_DIR" ]; then
+  TOUCHSCREEN_ENABLED="true"
+  require_tool grep
+  require_tool modinfo
+
+  if [ -z "$TOUCHSCREEN_SOURCE_URL" ] || [ -z "$TOUCHSCREEN_SOURCE_REF" ]; then
+    echo "--touchscreen-modules-dir requires --touchscreen-source-url and --touchscreen-source-ref." >&2
+    exit 2
+  fi
+
+  if [[ ! "$TOUCHSCREEN_SOURCE_REF" =~ ^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$ ]]; then
+    echo "Touchscreen source ref must be an immutable 40- or 64-character hexadecimal commit." >&2
+    exit 2
+  fi
+  TOUCHSCREEN_SOURCE_REF="${TOUCHSCREEN_SOURCE_REF,,}"
+elif [ -n "$TOUCHSCREEN_SOURCE_URL" ] || [ -n "$TOUCHSCREEN_SOURCE_REF" ]; then
+  echo "--touchscreen-source-url and --touchscreen-source-ref require --touchscreen-modules-dir." >&2
+  exit 2
+fi
 
 repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "$repo_dir"
@@ -249,6 +318,135 @@ if [ "$seen_headers" != "true" ] || [ "$seen_image" != "true" ] || [ "$seen_modu
   exit 1
 fi
 
+case "$kernel_abi" in
+  *sp11v3*-qcom-x1e)
+    if [ "$TOUCHSCREEN_ENABLED" != "true" ]; then
+      echo "Refusing an incomplete $kernel_abi release without its three touchscreen modules." >&2
+      echo "Pass --touchscreen-modules-dir and immutable touchscreen source provenance." >&2
+      exit 1
+    fi
+    ;;
+esac
+
+declare -A touchscreen_module_names=()
+declare -A touchscreen_module_vermagic=()
+declare -A touchscreen_module_srcversions=()
+declare -A touchscreen_module_sizes=()
+declare -A touchscreen_module_shas=()
+
+if [ "$TOUCHSCREEN_ENABLED" = "true" ]; then
+  if [ ! -d "$TOUCHSCREEN_MODULES_DIR" ] || [ -L "$TOUCHSCREEN_MODULES_DIR" ]; then
+    echo "Touchscreen modules directory not found or is a symlink: $TOUCHSCREEN_MODULES_DIR" >&2
+    exit 1
+  fi
+
+  touchscreen_entries=()
+  while IFS= read -r entry; do
+    [ "$entry" = "$TOUCHSCREEN_MODULE_MANIFEST" ] && continue
+    touchscreen_entries+=("$entry")
+  done < <(find "$TOUCHSCREEN_MODULES_DIR" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
+
+  expected_touchscreen_entries="$(printf '%s\n' "${TOUCHSCREEN_MODULE_FILES[@]}" | sort)"
+  actual_touchscreen_entries="$(printf '%s\n' "${touchscreen_entries[@]}" | sort)"
+  if [ "${#touchscreen_entries[@]}" -ne "${#TOUCHSCREEN_MODULE_FILES[@]}" ] || \
+     [ "$actual_touchscreen_entries" != "$expected_touchscreen_entries" ]; then
+    echo "Touchscreen modules directory must contain exactly: ${TOUCHSCREEN_MODULE_FILES[*]}" >&2
+    exit 1
+  fi
+
+  input_touchscreen_manifest="$TOUCHSCREEN_MODULES_DIR/$TOUCHSCREEN_MODULE_MANIFEST"
+  if [ -f "$input_touchscreen_manifest" ]; then
+    input_source_url="$(awk -F': ' '$1 == "Source URL" { print $2; exit }' "$input_touchscreen_manifest")"
+    input_source_commit="$(awk -F': ' '$1 == "Source commit" { print $2; exit }' "$input_touchscreen_manifest")"
+    input_target_release="$(awk -F': ' '$1 == "Target release" { print $2; exit }' "$input_touchscreen_manifest")"
+    [ "$input_source_url" = "$TOUCHSCREEN_SOURCE_URL" ] || {
+      echo "Touchscreen build manifest source URL does not match --touchscreen-source-url." >&2
+      exit 1
+    }
+    [ "$input_source_commit" = "$TOUCHSCREEN_SOURCE_REF" ] || {
+      echo "Touchscreen build manifest source commit does not match --touchscreen-source-ref." >&2
+      exit 1
+    }
+    [ "$input_target_release" = "$kernel_abi" ] || {
+      echo "Touchscreen build manifest targets $input_target_release, expected $kernel_abi." >&2
+      exit 1
+    }
+  elif [ -e "$input_touchscreen_manifest" ]; then
+    echo "Touchscreen build manifest is not a regular file: $input_touchscreen_manifest" >&2
+    exit 1
+  fi
+
+  common_touchscreen_vermagic_abi=""
+  for module_file in "${TOUCHSCREEN_MODULE_FILES[@]}"; do
+    module_path="$TOUCHSCREEN_MODULES_DIR/$module_file"
+    if [ ! -f "$module_path" ] || [ -L "$module_path" ]; then
+      echo "Touchscreen module must be a regular, non-symlinked file: $module_path" >&2
+      exit 1
+    fi
+
+    case "$module_file" in
+      gpi.ko) expected_module_name="gpi" ;;
+      spi-geni-qcom.ko) expected_module_name="spi_geni_qcom" ;;
+      mshw0485_touch.ko) expected_module_name="mshw0485_touch" ;;
+    esac
+
+    if ! module_name="$(modinfo -F name "$module_path")"; then
+      echo "Could not read module name from $module_path." >&2
+      exit 1
+    fi
+    if [ "$module_name" != "$expected_module_name" ]; then
+      echo "Unexpected module name in $module_file: $module_name (expected $expected_module_name)." >&2
+      exit 1
+    fi
+
+    if ! module_vermagic="$(modinfo -F vermagic "$module_path")"; then
+      echo "Could not read vermagic from $module_path." >&2
+      exit 1
+    fi
+    module_vermagic_abi="${module_vermagic%% *}"
+    if [ -z "$module_vermagic" ] || [ "$module_vermagic_abi" != "$kernel_abi" ]; then
+      echo "Module $module_file targets ${module_vermagic_abi:-unknown}, expected kernel ABI $kernel_abi." >&2
+      exit 1
+    fi
+    if [ -z "$common_touchscreen_vermagic_abi" ]; then
+      common_touchscreen_vermagic_abi="$module_vermagic_abi"
+    elif [ "$module_vermagic_abi" != "$common_touchscreen_vermagic_abi" ]; then
+      echo "Touchscreen modules do not share a common vermagic ABI." >&2
+      exit 1
+    fi
+
+    if ! module_srcversion="$(modinfo -F srcversion "$module_path")"; then
+      echo "Could not read srcversion from $module_path." >&2
+      exit 1
+    fi
+    if [[ ! "$module_srcversion" =~ ^[0-9A-Fa-f]+$ ]]; then
+      echo "Module $module_file has a missing or invalid srcversion." >&2
+      exit 1
+    fi
+
+    touchscreen_module_names["$module_file"]="$module_name"
+    touchscreen_module_vermagic["$module_file"]="$module_vermagic"
+    touchscreen_module_srcversions["$module_file"]="$module_srcversion"
+    touchscreen_module_sizes["$module_file"]="$(file_size "$module_path")"
+    touchscreen_module_shas["$module_file"]="$(shasum -a 256 "$module_path" | awk '{print $1}')"
+  done
+
+  if ! spi_parameters="$(modinfo -p "$TOUCHSCREEN_MODULES_DIR/spi-geni-qcom.ko")"; then
+    echo "Could not read parameters from spi-geni-qcom.ko." >&2
+    exit 1
+  fi
+  if ! grep -q '^sp11_windows_se_init:' <<<"$spi_parameters"; then
+    echo "spi-geni-qcom.ko is missing the required sp11_windows_se_init parameter." >&2
+    exit 1
+  fi
+
+  if ! modinfo -F alias "$TOUCHSCREEN_MODULES_DIR/mshw0485_touch.ko" |
+       grep -q 'microsoft,mshw0485'; then
+    echo "mshw0485_touch.ko is missing the microsoft,mshw0485 device-tree alias." >&2
+    exit 1
+  fi
+fi
+
 version_deb="${debs[0]}"
 for deb in "${debs[@]}"; do
   case "$(basename "$deb")" in
@@ -336,6 +534,11 @@ if [ "$dirty" = "true" ] && [ "$ALLOW_DIRTY" != "true" ]; then
   exit 1
 fi
 
+if ! git check-ref-format "refs/tags/$RELEASE_NAME" >/dev/null 2>&1; then
+  echo "Release name is not a valid Git tag: $RELEASE_NAME" >&2
+  exit 1
+fi
+
 if [ -z "$DOCKER_IMAGE" ]; then
   case "$source_mode" in
     git) DOCKER_IMAGE="ubuntu:25.10" ;;
@@ -359,6 +562,83 @@ if [ "$SOURCE_ASSET_COUNT" -gt 0 ]; then
   done
 fi
 
+if [ "$SOURCE_ASSET_COUNT" -gt 0 ]; then
+  if git show-ref --verify --quiet "refs/tags/$RELEASE_NAME"; then
+    local_tag_commit="$(git rev-parse "refs/tags/$RELEASE_NAME^{commit}")"
+    if [ "$local_tag_commit" != "$repo_commit" ]; then
+      echo "Refusing release: local tag $RELEASE_NAME points to $local_tag_commit, not support repo HEAD $repo_commit." >&2
+      exit 1
+    fi
+  fi
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    remote_tag_output=""
+    remote_tag_status=0
+    remote_tag_output="$(
+      git ls-remote --exit-code --tags origin \
+        "refs/tags/$RELEASE_NAME" "refs/tags/$RELEASE_NAME^{}" 2>/dev/null
+    )" || remote_tag_status=$?
+
+    if [ "$remote_tag_status" -eq 0 ]; then
+      remote_tag_commit="$(printf '%s\n' "$remote_tag_output" | awk '$2 ~ /\^\{\}$/ { print $1; exit }')"
+      if [ -z "$remote_tag_commit" ]; then
+        remote_tag_commit="$(printf '%s\n' "$remote_tag_output" | awk 'NF >= 2 { print $1; exit }')"
+      fi
+      if [ -n "$remote_tag_commit" ] && [ "$remote_tag_commit" != "$repo_commit" ]; then
+        echo "Refusing release: remote tag $RELEASE_NAME points to $remote_tag_commit, not support repo HEAD $repo_commit." >&2
+        exit 1
+      fi
+    elif [ "$remote_tag_status" -ne 2 ]; then
+      echo "Refusing a publishable release because remote tag $RELEASE_NAME could not be checked on origin." >&2
+      echo "Restore remote access and rerun so an existing tag cannot be reused accidentally." >&2
+      exit 1
+    fi
+  fi
+fi
+
+upload_assets=()
+declare -A claimed_output_names=()
+
+claim_output_name() {
+  local name="$1"
+  local origin="$2"
+
+  if [ -n "${claimed_output_names[$name]+x}" ]; then
+    echo "Refusing colliding release asset name $name from $origin; already used by ${claimed_output_names[$name]}." >&2
+    exit 1
+  fi
+  claimed_output_names["$name"]="$origin"
+}
+
+append_upload_asset() {
+  local name="$1"
+  local origin="$2"
+
+  claim_output_name "$name" "$origin"
+  upload_assets+=("$name")
+}
+
+claim_output_name "SHA256SUMS" "generated checksum file"
+claim_output_name "RELEASE-NOTES.md" "generated release notes"
+
+for deb in "${debs[@]}"; do
+  append_upload_asset "$(basename "$deb")" "$deb"
+done
+
+for source_asset in "${SOURCE_ASSETS[@]}"; do
+  append_upload_asset "$(basename "$source_asset")" "$source_asset"
+done
+
+if [ "$TOUCHSCREEN_ENABLED" = "true" ]; then
+  for module_file in "${TOUCHSCREEN_MODULE_FILES[@]}"; do
+    append_upload_asset "$module_file" "$TOUCHSCREEN_MODULES_DIR/$module_file"
+  done
+  append_upload_asset "$TOUCHSCREEN_MODULE_MANIFEST" "generated touchscreen module manifest"
+fi
+
+append_upload_asset "sp11-kernel-release-manifest.txt" "generated kernel release manifest"
+append_upload_asset "sp11-kernel-debs.txt" "generated kernel package list"
+
 rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR"
 
@@ -372,7 +652,39 @@ if [ "$SOURCE_ASSET_COUNT" -gt 0 ]; then
   done
 fi
 
+if [ "$TOUCHSCREEN_ENABLED" = "true" ]; then
+  for module_file in "${TOUCHSCREEN_MODULE_FILES[@]}"; do
+    cp "$TOUCHSCREEN_MODULES_DIR/$module_file" "$OUT_DIR/"
+  done
+fi
+
 generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+if [ "$TOUCHSCREEN_ENABLED" = "true" ]; then
+  {
+    echo "# Surface Pro 11 Touchscreen Module Provenance"
+    echo
+    echo "Generated: $generated_at"
+    echo "Release: $RELEASE_NAME"
+    echo "Kernel ABI: $kernel_abi"
+    echo "Touchscreen source URL: $TOUCHSCREEN_SOURCE_URL"
+    echo "Touchscreen source commit: $TOUCHSCREEN_SOURCE_REF"
+    echo "Support repo commit: $repo_commit"
+    echo "Support repo dirty: $dirty"
+    echo "Required SPI parameter: sp11_windows_se_init"
+    echo
+    echo "## Modules"
+    echo
+    for module_file in "${TOUCHSCREEN_MODULE_FILES[@]}"; do
+      echo "- $module_file"
+      echo "  - Module name: ${touchscreen_module_names[$module_file]}"
+      echo "  - Size: ${touchscreen_module_sizes[$module_file]} bytes"
+      echo "  - SHA256: ${touchscreen_module_shas[$module_file]}"
+      echo "  - Vermagic: ${touchscreen_module_vermagic[$module_file]}"
+      echo "  - Srcversion: ${touchscreen_module_srcversions[$module_file]}"
+    done
+  } > "$OUT_DIR/$TOUCHSCREEN_MODULE_MANIFEST"
+fi
 
 {
   echo "# Surface Pro 11 qcom-x1e Kernel Release Manifest"
@@ -394,7 +706,7 @@ generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   echo
   for deb in "${debs[@]}"; do
     base="$(basename "$deb")"
-    size="$(stat -f '%z' "$deb" 2>/dev/null || stat -c '%s' "$deb")"
+    size="$(file_size "$deb")"
     sha="$(shasum -a 256 "$deb" | awk '{print $1}')"
     echo "- $base"
     echo "  - Size: $size bytes"
@@ -408,11 +720,32 @@ generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   else
     for source_asset in "${SOURCE_ASSETS[@]}"; do
       base="$(basename "$source_asset")"
-      size="$(stat -f '%z' "$source_asset" 2>/dev/null || stat -c '%s' "$source_asset")"
+      size="$(file_size "$source_asset")"
       sha="$(shasum -a 256 "$source_asset" | awk '{print $1}')"
       echo "- $base"
       echo "  - Size: $size bytes"
       echo "  - SHA256: $sha"
+    done
+  fi
+  echo
+  echo "## Touchscreen Modules"
+  echo
+  if [ "$TOUCHSCREEN_ENABLED" != "true" ]; then
+    echo "No touchscreen module bundle included."
+  else
+    echo "- Provenance manifest: $TOUCHSCREEN_MODULE_MANIFEST"
+    echo "- Kernel ABI: $kernel_abi"
+    echo "- Source URL: $TOUCHSCREEN_SOURCE_URL"
+    echo "- Source commit: $TOUCHSCREEN_SOURCE_REF"
+    echo "- Required SPI parameter: sp11_windows_se_init"
+    echo
+    for module_file in "${TOUCHSCREEN_MODULE_FILES[@]}"; do
+      echo "- $module_file"
+      echo "  - Module name: ${touchscreen_module_names[$module_file]}"
+      echo "  - Size: ${touchscreen_module_sizes[$module_file]} bytes"
+      echo "  - SHA256: ${touchscreen_module_shas[$module_file]}"
+      echo "  - Vermagic: ${touchscreen_module_vermagic[$module_file]}"
+      echo "  - Srcversion: ${touchscreen_module_srcversions[$module_file]}"
     done
   fi
   echo
@@ -430,33 +763,55 @@ for deb in "${debs[@]}"; do
   basename "$deb"
 done > "$OUT_DIR/sp11-kernel-debs.txt"
 
-(
-  cd "$OUT_DIR"
-  shasum -a 256 ./* > SHA256SUMS
-)
-
 cat > "$OUT_DIR/RELEASE-NOTES.md" <<EOF
 # Surface Pro 11 qcom-x1e Kernel Packages
 
 Experimental prebuilt qcom-x1e kernel packages for Surface Pro 11.
 
-These packages are optional convenience artifacts. They are unsigned, are not
-an apt repository, and should be used only with a known-good fallback qcom-x1e
-kernel still installed.
+These artifacts are optional conveniences. They are unsigned, are not an apt
+repository, and should be used only with a known-good fallback qcom-x1e kernel
+still installed.
 
 ## Verify
 
+Download \`SHA256SUMS\` and every asset named in it, then run:
+
 \`\`\`bash
-shasum -a 256 -c SHA256SUMS
+(cd /path/to/downloaded-release-assets && shasum -a 256 -c SHA256SUMS)
 \`\`\`
 
+EOF
+
+if [ "$TOUCHSCREEN_ENABLED" = "true" ]; then
+  cat >> "$OUT_DIR/RELEASE-NOTES.md" <<EOF
 ## Install Flow
 
-1. Download the \`.deb\` files and \`SHA256SUMS\`.
-2. Verify checksums.
-3. Copy the \`.deb\` files into local \`payload/kernel-debs/\`.
-4. Rebuild and write the Surface Pro 11 USB image.
-5. On the Surface, install using:
+The kernel packages and touchscreen modules are one ABI-matched set. Install
+both from the same downloaded asset directory, and keep the fallback kernel
+until the new kernel and touchscreen have both been tested.
+
+\`\`\`bash
+ASSET_DIR=/absolute/path/to/downloaded-release-assets
+cd /path/to/linux-surface-pro-11-oe
+
+sudo ./scripts/build-sp11-qcom-x1e-kernel.sh \\
+  --work-dir "\$ASSET_DIR" \\
+  --install-only
+\`\`\`
+
+The unified installer finds the three modules beside the packages and installs
+them for \`$kernel_abi\`. It refuses an incomplete sp11v3 transaction rather
+than silently installing a kernel whose touchscreen cannot initialize. Reboot
+after it completes, then test both the new kernel and touchscreen.
+
+EOF
+else
+  cat >> "$OUT_DIR/RELEASE-NOTES.md" <<EOF
+## Install Flow
+
+1. Copy the verified \`.deb\` files into local \`payload/kernel-debs/\`.
+2. Rebuild and write the Surface Pro 11 USB image.
+3. On the Surface, install using:
 
 \`\`\`bash
 sudo ./scripts/build-sp11-qcom-x1e-kernel.sh \\
@@ -464,6 +819,10 @@ sudo ./scripts/build-sp11-qcom-x1e-kernel.sh \\
   --install-only
 \`\`\`
 
+EOF
+fi
+
+cat >> "$OUT_DIR/RELEASE-NOTES.md" <<EOF
 ## Provenance
 
 See \`sp11-kernel-release-manifest.txt\` for package hashes, source metadata,
@@ -476,10 +835,35 @@ Recorded source:
 - Source HEAD: \`${source_head:-unknown}\`
 - Docker image: \`$DOCKER_IMAGE\`
 - Patch directory: \`$PATCH_DIR\`
+EOF
+
+if [ "$TOUCHSCREEN_ENABLED" = "true" ]; then
+  cat >> "$OUT_DIR/RELEASE-NOTES.md" <<EOF
+- Touchscreen source URL: \`$TOUCHSCREEN_SOURCE_URL\`
+- Touchscreen source commit: \`$TOUCHSCREEN_SOURCE_REF\`
+- Touchscreen manifest: \`$TOUCHSCREEN_MODULE_MANIFEST\`
+EOF
+fi
+
+cat >> "$OUT_DIR/RELEASE-NOTES.md" <<EOF
 
 These artifacts were built from recorded inputs; they are not claimed to be
 bit-for-bit reproducible.
 EOF
+
+for asset in "${upload_assets[@]}"; do
+  if [ ! -f "$OUT_DIR/$asset" ]; then
+    echo "Expected upload asset was not generated: $asset" >&2
+    exit 1
+  fi
+done
+
+(
+  cd "$OUT_DIR"
+  shasum -a 256 "${upload_assets[@]}" > SHA256SUMS
+  shasum -a 256 -c SHA256SUMS
+)
+upload_assets+=("SHA256SUMS")
 
 echo "Prepared release assets in $OUT_DIR_DISPLAY"
 echo
@@ -487,23 +871,10 @@ if [ "$SOURCE_ASSET_COUNT" -eq 0 ]; then
   echo "No source assets were included, so this is a local draft only."
   echo "Rerun with --source-asset before publishing binaries."
 else
-  release_assets=()
-  for deb in "${debs[@]}"; do
-    release_assets+=("$(basename "$deb")")
-  done
-  release_assets+=(
-    "SHA256SUMS"
-    "sp11-kernel-release-manifest.txt"
-    "sp11-kernel-debs.txt"
-  )
-  for source_asset in "${SOURCE_ASSETS[@]}"; do
-    release_assets+=("$(basename "$source_asset")")
-  done
-
   echo "Review $OUT_DIR_DISPLAY/RELEASE-NOTES.md, then publish with a command like:"
-  printf '  (cd %q && gh release create %q --prerelease --title %q --notes-file RELEASE-NOTES.md' \
-    "$OUT_DIR_DISPLAY" "$RELEASE_NAME" "$RELEASE_NAME"
-  for asset in "${release_assets[@]}"; do
+  printf '  (cd %q && gh release create %q --target %q --prerelease --title %q --notes-file RELEASE-NOTES.md' \
+    "$OUT_DIR_DISPLAY" "$RELEASE_NAME" "$repo_commit" "$RELEASE_NAME"
+  for asset in "${upload_assets[@]}"; do
     printf ' %q' "$asset"
   done
   printf ')\n'

--- a/scripts/troubleshoot-sp11-touchscreen.sh
+++ b/scripts/troubleshoot-sp11-touchscreen.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+PROGRAM="${0##*/}"
+TARGET_ROOT="/"
+RELEASE=""
+DMESG_FILE=""
+INITRD_OVERRIDE=""
+FAILURES=0
+WARNINGS=0
+
+usage() {
+  cat <<EOF
+Usage: $PROGRAM [options]
+
+Read-only diagnostics for the Surface Pro 11 MSHW0485 QSPI touchscreen.
+
+Options:
+  --release RELEASE   Kernel ABI to inspect (default: running kernel).
+  --root DIR          Filesystem root to inspect (default /). With a non-live
+                       root, supply --release; live dmesg checks are skipped.
+  --dmesg FILE        Read a saved kernel log instead of the current boot log.
+  --initrd FILE       Inspect this initramfs instead of the standard ABI path.
+  -h, --help           Show this help.
+
+Exit status is zero only when no failure is detected. Warnings alone do not
+change the exit status.
+EOF
+}
+
+fail() {
+  echo "[FAIL] $*"
+  FAILURES=$((FAILURES + 1))
+}
+
+warn() {
+  echo "[WARN] $*"
+  WARNINGS=$((WARNINGS + 1))
+}
+
+ok() {
+  echo "[ OK ] $*"
+}
+
+info() {
+  echo "[INFO] $*"
+}
+
+usage_error() {
+  echo "error: $*" >&2
+  usage >&2
+  exit 2
+}
+
+require_value() {
+  [ -n "${2:-}" ] || usage_error "$1 requires a value"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --release)
+      require_value "$1" "${2:-}"
+      RELEASE="$2"
+      shift 2
+      ;;
+    --release=*)
+      RELEASE="${1#*=}"
+      [ -n "$RELEASE" ] || usage_error "--release cannot be empty"
+      shift
+      ;;
+    --root)
+      require_value "$1" "${2:-}"
+      TARGET_ROOT="$2"
+      shift 2
+      ;;
+    --root=*)
+      TARGET_ROOT="${1#*=}"
+      [ -n "$TARGET_ROOT" ] || usage_error "--root cannot be empty"
+      shift
+      ;;
+    --dmesg)
+      require_value "$1" "${2:-}"
+      DMESG_FILE="$2"
+      shift 2
+      ;;
+    --dmesg=*)
+      DMESG_FILE="${1#*=}"
+      [ -n "$DMESG_FILE" ] || usage_error "--dmesg cannot be empty"
+      shift
+      ;;
+    --initrd)
+      require_value "$1" "${2:-}"
+      INITRD_OVERRIDE="$2"
+      shift 2
+      ;;
+    --initrd=*)
+      INITRD_OVERRIDE="${1#*=}"
+      [ -n "$INITRD_OVERRIDE" ] || usage_error "--initrd cannot be empty"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage_error "unknown argument: $1"
+      ;;
+  esac
+done
+
+command -v realpath >/dev/null 2>&1 || {
+  echo "error: required command not found: realpath" >&2
+  exit 2
+}
+TARGET_ROOT="$(realpath -e -- "$TARGET_ROOT" 2>/dev/null)" ||
+  usage_error "cannot resolve --root"
+[ -d "$TARGET_ROOT" ] || usage_error "not a directory: $TARGET_ROOT"
+
+if [ -z "$RELEASE" ]; then
+  [ "$TARGET_ROOT" = "/" ] || usage_error "--release is required with a non-live --root"
+  RELEASE="$(uname -r)"
+fi
+case "$RELEASE" in
+  ""|*[!A-Za-z0-9._+~-]*|[!A-Za-z0-9]*)
+    usage_error "unsafe kernel release: '$RELEASE'"
+    ;;
+esac
+
+root_path() {
+  local absolute="$1"
+  printf '%s%s' "${TARGET_ROOT%/}" "$absolute"
+}
+
+module_files=(gpi.ko spi-geni-qcom.ko mshw0485_touch.ko)
+module_names=(gpi spi_geni_qcom mshw0485_touch)
+module_relpaths=(
+  updates/drivers/dma/qcom/gpi.ko
+  updates/drivers/spi/spi-geni-qcom.ko
+  updates/drivers/input/touchscreen/mshw0485_touch.ko
+)
+
+echo "Surface Pro 11 touchscreen diagnostic"
+echo "Root: $TARGET_ROOT"
+echo "Kernel release: $RELEASE"
+if [ "$TARGET_ROOT" = "/" ]; then
+  echo "Running release: $(uname -r)"
+fi
+echo
+
+if ! command -v modinfo >/dev/null 2>&1; then
+  fail "modinfo is unavailable; module identity cannot be checked"
+else
+  echo "Disk module selection"
+  for index in "${!module_names[@]}"; do
+    expected="$(root_path "/lib/modules/$RELEASE/${module_relpaths[index]}")"
+    selected="$(modinfo -b "$TARGET_ROOT" -k "$RELEASE" -n "${module_names[index]}" 2>/dev/null || true)"
+    if [ ! -f "$expected" ]; then
+      fail "missing override: $expected"
+    fi
+    expected_suffix="/lib/modules/$RELEASE/${module_relpaths[index]}"
+    case "$selected" in
+      *"$expected_suffix"|*"/usr$expected_suffix")
+        ok "${module_names[index]} selects the updates/ override: $selected"
+        ;;
+      "")
+        fail "${module_names[index]} is not selectable for $RELEASE"
+        ;;
+      *)
+        fail "${module_names[index]} selects a stock or unexpected module: $selected"
+        ;;
+    esac
+
+    if [ -f "$expected" ]; then
+      vermagic="$(modinfo -F vermagic "$expected" 2>/dev/null || true)"
+      disk_release="${vermagic%%[[:space:]]*}"
+      if [ "$disk_release" = "$RELEASE" ]; then
+        ok "${module_files[index]} vermagic matches $RELEASE"
+      else
+        fail "${module_files[index]} vermagic '${disk_release:-unknown}' does not match $RELEASE"
+      fi
+    fi
+  done
+  echo
+fi
+
+echo "Loaded-versus-disk identity"
+if [ "$TARGET_ROOT" != "/" ] || [ "$RELEASE" != "$(uname -r)" ]; then
+  warn "loaded-module comparison is unavailable for an offline or non-running release"
+else
+  for index in "${!module_names[@]}"; do
+    module="${module_names[index]}"
+    expected="/lib/modules/$RELEASE/${module_relpaths[index]}"
+    sys_module="/sys/module/$module"
+    if [ ! -d "$sys_module" ]; then
+      fail "$module is not loaded"
+      continue
+    fi
+    loaded_srcversion=""
+    disk_srcversion=""
+    [ -r "$sys_module/srcversion" ] && read -r loaded_srcversion < "$sys_module/srcversion"
+    [ -f "$expected" ] && disk_srcversion="$(modinfo -F srcversion "$expected" 2>/dev/null || true)"
+    if [ -n "$loaded_srcversion" ] && [ -n "$disk_srcversion" ]; then
+      if [ "$loaded_srcversion" = "$disk_srcversion" ]; then
+        ok "$module loaded srcversion matches the selected disk override ($disk_srcversion)"
+      else
+        fail "$module loaded srcversion $loaded_srcversion differs from disk $disk_srcversion; reboot or initramfs repair is required"
+      fi
+    else
+      warn "$module is loaded, but srcversion metadata is unavailable for a conclusive comparison"
+    fi
+  done
+fi
+echo
+
+echo "Controller profile"
+if command -v modinfo >/dev/null 2>&1; then
+  spi_override="$(root_path "/lib/modules/$RELEASE/${module_relpaths[1]}")"
+  if [ -f "$spi_override" ] &&
+     modinfo -p "$spi_override" 2>/dev/null | grep -q '^sp11_windows_se_init:'; then
+    ok "selected SPI override exposes sp11_windows_se_init"
+  else
+    fail "selected SPI module lacks sp11_windows_se_init and is probably stock"
+  fi
+fi
+parameter_path="$(root_path /sys/module/spi_geni_qcom/parameters/sp11_windows_se_init)"
+if [ -r "$parameter_path" ]; then
+  read -r se_value < "$parameter_path"
+  case "$se_value" in
+    N|0|n)
+      ok "sp11_windows_se_init=$se_value (normal validated Linux-integrated profile)"
+      ;;
+    Y|1|y)
+      warn "sp11_windows_se_init=$se_value (experimental Windows cold-init opt-in)"
+      ;;
+    *)
+      warn "sp11_windows_se_init has unexpected value '$se_value'"
+      ;;
+  esac
+elif [ "$TARGET_ROOT" = "/" ] && [ "$RELEASE" = "$(uname -r)" ]; then
+  fail "loaded SPI module has no sp11_windows_se_init parameter; stale stock module is likely"
+else
+  warn "live sp11_windows_se_init value is unavailable for this root/release"
+fi
+echo
+
+echo "Firmware"
+firmware_found=""
+for candidate in \
+  /lib/firmware/qcom/x1e80100/qupv3fw.elf.zst \
+  /lib/firmware/qcom/x1e80100/qupv3fw.elf.xz \
+  /lib/firmware/qcom/x1e80100/qupv3fw.elf; do
+  if [ -f "$(root_path "$candidate")" ]; then
+    firmware_found="$candidate"
+    break
+  fi
+done
+if [ -n "$firmware_found" ]; then
+  ok "QUP firmware present: $firmware_found"
+else
+  fail "missing QUP firmware: /lib/firmware/qcom/x1e80100/qupv3fw.elf[.zst|.xz]"
+fi
+echo
+
+echo "Live device tree and client"
+DT_BASE=""
+for candidate in /sys/firmware/devicetree/base /proc/device-tree; do
+  if [ -d "$(root_path "$candidate")" ]; then
+    DT_BASE="$(root_path "$candidate")"
+    break
+  fi
+done
+if [ -z "$DT_BASE" ]; then
+  if [ "$TARGET_ROOT" = "/" ] && [ "$RELEASE" = "$(uname -r)" ]; then
+    fail "live device tree is unavailable; SPI10 and MSHW0485 nodes cannot be verified"
+  else
+    warn "live device tree is unavailable; SPI10 and MSHW0485 nodes were not checked"
+  fi
+else
+  spi_node="$(find "$DT_BASE" -type d -name 'spi@a88000' -print -quit 2>/dev/null || true)"
+  if [ -z "$spi_node" ]; then
+    fail "device tree lacks the QSPI controller node spi@a88000"
+  else
+    status="okay"
+    if [ -r "$spi_node/status" ]; then
+      status="$(tr -d '\000' < "$spi_node/status" 2>/dev/null || true)"
+    fi
+    case "$status" in
+      okay|ok|"") ok "device-tree QSPI controller is enabled: $spi_node" ;;
+      *) fail "device-tree QSPI controller status is '$status': $spi_node" ;;
+    esac
+
+    touch_compatible="$(find "$spi_node" -type f -name compatible -exec grep -a -l 'microsoft,mshw0485' {} + 2>/dev/null | head -n 1 || true)"
+    if [ -n "$touch_compatible" ]; then
+      ok "device tree contains microsoft,mshw0485: ${touch_compatible%/compatible}"
+    else
+      fail "device tree lacks a microsoft,mshw0485 child below spi@a88000"
+    fi
+  fi
+fi
+
+if [ "$TARGET_ROOT" = "/" ] && [ "$RELEASE" = "$(uname -r)" ]; then
+  if find -L /sys/bus/spi/devices -maxdepth 3 -type f \( -name modalias -o -name uevent \) \
+      -exec grep -a -q -E 'mshw0485|MSHW0485' {} \; -print -quit 2>/dev/null |
+      grep -q .; then
+    ok "MSHW0485 is registered on the live SPI bus"
+  else
+    fail "MSHW0485 is not registered on the live SPI bus"
+  fi
+  if [ -r /proc/bus/input/devices ] &&
+     grep -q 'Microsoft Surface G6 Touch' /proc/bus/input/devices; then
+    ok "Microsoft Surface G6 Touch is present in /proc/bus/input/devices"
+  else
+    fail "Microsoft Surface G6 Touch is absent from /proc/bus/input/devices"
+  fi
+else
+  warn "live SPI client registration is unavailable for this root/release"
+fi
+echo
+
+echo "Initramfs contents"
+if [ -n "$INITRD_OVERRIDE" ]; then
+  INITRD="$(realpath -e -- "$INITRD_OVERRIDE" 2>/dev/null || true)"
+else
+  INITRD="$(root_path "/boot/initrd.img-$RELEASE")"
+fi
+if [ -z "$INITRD" ] || [ ! -s "$INITRD" ]; then
+  fail "initramfs is missing or empty: ${INITRD_OVERRIDE:-$(root_path "/boot/initrd.img-$RELEASE")}"
+elif [ ! -r "$INITRD" ]; then
+  fail "initramfs is not readable: $INITRD (rerun with sudo to verify its module paths)"
+else
+  listing_file="$(mktemp)"
+  trap 'rm -f -- "$listing_file"' EXIT HUP INT TERM
+  listing_ok="false"
+  if command -v lsinitramfs >/dev/null 2>&1 &&
+     lsinitramfs "$INITRD" > "$listing_file" 2>/dev/null; then
+    info "inspected $INITRD with lsinitramfs"
+    listing_ok="true"
+  elif command -v lsinitrd >/dev/null 2>&1 &&
+       lsinitrd "$INITRD" > "$listing_file" 2>/dev/null; then
+    info "inspected $INITRD with lsinitrd"
+    listing_ok="true"
+  else
+    fail "neither lsinitramfs nor lsinitrd could inspect $INITRD"
+  fi
+  if [ "$listing_ok" = "true" ]; then
+    for relative in "${module_relpaths[@]}"; do
+      initrd_path="lib/modules/$RELEASE/$relative"
+      if grep -Fq "$initrd_path" "$listing_file" ||
+         grep -Fq "usr/$initrd_path" "$listing_file"; then
+        ok "initramfs contains override path: $initrd_path"
+      else
+        fail "initramfs lacks override path: $initrd_path"
+      fi
+    done
+  fi
+fi
+echo
+
+echo "Current-boot kernel log classification"
+log_file=""
+temporary_log=""
+if [ -n "$DMESG_FILE" ]; then
+  log_file="$(realpath -e -- "$DMESG_FILE" 2>/dev/null || true)"
+  [ -n "$log_file" ] && [ -r "$log_file" ] || fail "cannot read --dmesg file: $DMESG_FILE"
+elif [ "$TARGET_ROOT" = "/" ] && [ "$RELEASE" = "$(uname -r)" ]; then
+  temporary_log="$(mktemp)"
+  if dmesg > "$temporary_log" 2>/dev/null; then
+    log_file="$temporary_log"
+  elif command -v journalctl >/dev/null 2>&1 &&
+       journalctl -k -b --no-pager > "$temporary_log" 2>/dev/null; then
+    log_file="$temporary_log"
+  else
+    warn "current kernel log is unreadable; rerun with sudo or supply --dmesg FILE"
+  fi
+else
+  warn "kernel log classification skipped for an offline or non-running release"
+fi
+
+if [ -n "$log_file" ] && [ -r "$log_file" ]; then
+  if grep -q -E 'geni_spi a88000\.spi: Invalid proto 9' "$log_file"; then
+    fail "Invalid proto 9: the booted initramfs loaded the stock SPI controller instead of the SP11 override"
+  elif grep -q -E 'a88000\.spi: SP11: accepting protocol 9 as QSPI controller' "$log_file"; then
+    ok "patched SPI controller accepted QSPI protocol 9"
+  else
+    warn "no SPI protocol-9 acceptance marker was found"
+  fi
+
+  if grep -q -E 'CH START completion timeout' "$log_file"; then
+    fail "GPI CH START timeout: stale/stock GPI DMA or an incomplete initramfs override is likely"
+  elif grep -q -E 'SP11: QSPI using GPI DMA descriptor mode' "$log_file"; then
+    ok "QSPI is using GPI DMA descriptor mode"
+  else
+    warn "no GPI DMA success marker was found"
+  fi
+
+  if grep -q -E 'sync_state\(\) pending due to a88000\.spi' "$log_file"; then
+    fail "deferred sync_state dependencies remain blocked by a88000.spi"
+  fi
+  if grep -q -E '(Direct firmware load|failed to load).*(qupv3fw|qup.*fw)' "$log_file"; then
+    fail "kernel log reports a QUP firmware load failure"
+  fi
+
+  if grep -q -E 'touch controller initialized path=hardware' "$log_file"; then
+    ok "MSHW0485 controller completed hardware initialization"
+  elif grep -q -E 'Microsoft Surface G6 Touch' "$log_file"; then
+    warn "input device registered, but the final hardware-initialized marker is absent"
+  else
+    fail "kernel log has no Microsoft Surface G6 Touch initialization marker"
+  fi
+fi
+[ -z "$temporary_log" ] || rm -f -- "$temporary_log"
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+  echo "Result: FAIL ($FAILURES failure(s), $WARNINGS warning(s))"
+  exit 1
+fi
+echo "Result: PASS ($WARNINGS warning(s))"
+exit 0

--- a/scripts/validate-sp11-touchscreen-release.sh
+++ b/scripts/validate-sp11-touchscreen-release.sh
@@ -1,0 +1,699 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+RELEASE_DIR=""
+TAG=""
+REMOTE=""
+ERROR_COUNT=0
+CHECK_COUNT=0
+TEMP_DIRS=()
+
+usage() {
+  cat <<EOF
+Usage: $0 --dir DIR [--tag TAG] [--remote REMOTE]
+
+Validates a prepared or downloaded Surface Pro 11 qcom-x1e kernel release
+directory without changing it.
+
+Options:
+  --dir DIR        Flat directory containing the release assets (required).
+  --tag TAG        Compare the manifest support commit with this Git tag.
+  --remote REMOTE  Also compare with TAG on this Git remote name or URL.
+                   Requires --tag.
+  -h, --help       Show this help.
+EOF
+}
+
+error() {
+  echo "ERROR: $*" >&2
+  ERROR_COUNT=$((ERROR_COUNT + 1))
+}
+
+checked() {
+  CHECK_COUNT=$((CHECK_COUNT + 1))
+}
+
+die() {
+  error "$*"
+  exit 1
+}
+
+require_arg() {
+  if [ -z "${2:-}" ]; then
+    echo "Missing value for $1." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+have_tool() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+cleanup() {
+  local path
+  for path in "${TEMP_DIRS[@]}"; do
+    if [ -n "$path" ] && [ -d "$path" ]; then
+      rm -rf -- "$path"
+    fi
+  done
+}
+trap cleanup EXIT HUP INT TERM
+
+sha256_file() {
+  local path="$1"
+  if have_tool sha256sum; then
+    sha256sum -- "$path" | awk '{print $1}'
+  elif have_tool shasum; then
+    shasum -a 256 -- "$path" | awk '{print $1}'
+  else
+    return 127
+  fi
+}
+
+manifest_values() {
+  local file="$1"
+  local label="$2"
+  awk -v prefix="$label: " 'index($0, prefix) == 1 { print substr($0, length(prefix) + 1) }' "$file"
+}
+
+single_manifest_value() {
+  local file="$1"
+  local label="$2"
+  local values=()
+  local value
+
+  while IFS= read -r value; do
+    values+=("$value")
+  done < <(manifest_values "$file" "$label")
+
+  if [ "${#values[@]}" -ne 1 ] || [ -z "${values[0]:-}" ]; then
+    return 1
+  fi
+  printf '%s\n' "${values[0]}"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dir)
+      require_arg "$1" "${2:-}"
+      RELEASE_DIR="$2"
+      shift 2
+      ;;
+    --tag)
+      require_arg "$1" "${2:-}"
+      TAG="$2"
+      shift 2
+      ;;
+    --remote)
+      require_arg "$1" "${2:-}"
+      REMOTE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[ -n "$RELEASE_DIR" ] || die "--dir is required."
+[ -z "$REMOTE" ] || [ -n "$TAG" ] || die "--remote requires --tag."
+[ -d "$RELEASE_DIR" ] || die "release directory not found: $RELEASE_DIR"
+[ ! -L "$RELEASE_DIR" ] || die "release directory must not be a symlink: $RELEASE_DIR"
+
+if ! RELEASE_DIR="$(cd "$RELEASE_DIR" 2>/dev/null && pwd -P)"; then
+  die "could not resolve release directory: $RELEASE_DIR"
+fi
+
+for tool in awk basename find grep sort; do
+  have_tool "$tool" || error "missing required tool: $tool"
+done
+if ! have_tool sha256sum && ! have_tool shasum; then
+  error "missing required checksum tool: sha256sum or shasum"
+fi
+
+declare -A CHECKSUM_HASHES=()
+declare -A CHECKSUM_FILES=()
+declare -A DIRECTORY_FILES=()
+checksum_manifest="$RELEASE_DIR/SHA256SUMS"
+
+if [ ! -f "$checksum_manifest" ] || [ -L "$checksum_manifest" ]; then
+  error "missing regular, non-symlinked SHA256SUMS."
+else
+  line_number=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_number=$((line_number + 1))
+    line="${line%$'\r'}"
+    [ -n "$line" ] || continue
+
+    if [[ ! "$line" =~ ^([0-9A-Fa-f]{64})[[:space:]]+\*?(.+)$ ]]; then
+      error "SHA256SUMS:$line_number is not a valid SHA-256 entry."
+      continue
+    fi
+
+    expected_hash="${BASH_REMATCH[1],,}"
+    asset_name="${BASH_REMATCH[2]}"
+    asset_name="${asset_name#./}"
+
+    case "$asset_name" in
+      ""|.|..|/*|*/*)
+        error "SHA256SUMS:$line_number has unsafe or non-flat path: $asset_name"
+        continue
+        ;;
+    esac
+
+    if [ -n "${CHECKSUM_FILES[$asset_name]+x}" ]; then
+      error "SHA256SUMS lists $asset_name more than once."
+      continue
+    fi
+    CHECKSUM_FILES["$asset_name"]=1
+    CHECKSUM_HASHES["$asset_name"]="$expected_hash"
+
+    case "$asset_name" in
+      SHA256SUMS)
+        error "SHA256SUMS must not list itself."
+        continue
+        ;;
+      RELEASE-NOTES.md)
+        error "SHA256SUMS must not list local RELEASE-NOTES.md; release notes are not an uploaded asset."
+        continue
+        ;;
+    esac
+
+    asset_path="$RELEASE_DIR/$asset_name"
+    if [ ! -f "$asset_path" ] || [ -L "$asset_path" ]; then
+      error "checksum entry is missing a regular, non-symlinked asset: $asset_name"
+      continue
+    fi
+    if ! actual_hash="$(sha256_file "$asset_path")"; then
+      error "could not calculate SHA-256 for $asset_name."
+      continue
+    fi
+    actual_hash="${actual_hash,,}"
+    if [ "$actual_hash" != "$expected_hash" ]; then
+      error "checksum mismatch for $asset_name: expected $expected_hash, got $actual_hash"
+    else
+      checked
+    fi
+  done < "$checksum_manifest"
+fi
+
+while IFS= read -r -d '' entry; do
+  name="$(basename "$entry")"
+  if [ -L "$entry" ]; then
+    error "release directory contains a symlink: $name"
+    continue
+  fi
+  if [ ! -f "$entry" ]; then
+    error "release directory must be flat and contain files only; unexpected entry: $name"
+    continue
+  fi
+  DIRECTORY_FILES["$name"]=1
+  case "$name" in
+    SHA256SUMS|RELEASE-NOTES.md) ;;
+    *)
+      if [ -z "${CHECKSUM_FILES[$name]+x}" ]; then
+        error "upload asset is not represented in SHA256SUMS: $name"
+      fi
+      ;;
+  esac
+done < <(find "$RELEASE_DIR" -mindepth 1 -maxdepth 1 -print0)
+
+declare -A ROLE_FILES=()
+declare -A ROLE_ABIS=()
+declare -A ROLE_VERSIONS=()
+declare -A ROLE_COUNTS=([image]=0 [modules]=0 [headers]=0 [common_headers]=0)
+deb_files=()
+
+record_package() {
+  local role="$1"
+  local path="$2"
+  local abi="$3"
+  local version="$4"
+  local count=$((ROLE_COUNTS[$role] + 1))
+  ROLE_COUNTS["$role"]="$count"
+  if [ "$count" -eq 1 ]; then
+    ROLE_FILES["$role"]="$path"
+    ROLE_ABIS["$role"]="$abi"
+    ROLE_VERSIONS["$role"]="$version"
+  else
+    error "duplicate $role package: $(basename "$path")"
+  fi
+}
+
+while IFS= read -r -d '' deb; do
+  deb_files+=("$deb")
+  base="$(basename "$deb")"
+  role=""
+  abi=""
+  version=""
+
+  case "$base" in
+    linux-qcom-x1e-headers-*_all.deb)
+      role="common_headers"
+      stem="${base%_all.deb}"
+      version="${stem##*_}"
+      package_part="${stem%_$version}"
+      common_release="${package_part#linux-qcom-x1e-headers-}"
+      abi="$common_release-qcom-x1e"
+      ;;
+    linux-headers-*_arm64.deb)
+      role="headers"
+      stem="${base%_arm64.deb}"
+      version="${stem##*_}"
+      package_part="${stem%_$version}"
+      abi="${package_part#linux-headers-}"
+      ;;
+    linux-image-*_arm64.deb)
+      role="image"
+      stem="${base%_arm64.deb}"
+      version="${stem##*_}"
+      package_part="${stem%_$version}"
+      abi="${package_part#linux-image-}"
+      ;;
+    linux-modules-*_arm64.deb)
+      role="modules"
+      stem="${base%_arm64.deb}"
+      version="${stem##*_}"
+      package_part="${stem%_$version}"
+      abi="${package_part#linux-modules-}"
+      ;;
+    *)
+      error "unexpected Debian package asset: $base"
+      continue
+      ;;
+  esac
+
+  if [ -z "$abi" ] || [ "$abi" = "-qcom-x1e" ] || [ -z "$version" ]; then
+    error "could not parse ABI/version from $base"
+    continue
+  fi
+  record_package "$role" "$deb" "$abi" "$version"
+done < <(find "$RELEASE_DIR" -mindepth 1 -maxdepth 1 -type f -name '*.deb' -print0)
+
+for role in image modules headers; do
+  if [ "${ROLE_COUNTS[$role]}" -ne 1 ]; then
+    error "expected exactly one $role qcom-x1e package, found ${ROLE_COUNTS[$role]}."
+  fi
+done
+if [ "${ROLE_COUNTS[common_headers]}" -gt 1 ]; then
+  error "expected at most one common qcom-x1e headers package, found ${ROLE_COUNTS[common_headers]}."
+fi
+
+kernel_abi="${ROLE_ABIS[image]:-}"
+package_version="${ROLE_VERSIONS[image]:-}"
+if [ -n "$kernel_abi" ]; then
+  case "$kernel_abi" in
+    *-qcom-x1e) ;;
+    *) error "kernel ABI is not a qcom-x1e ABI: $kernel_abi" ;;
+  esac
+fi
+for role in modules headers common_headers; do
+  [ "${ROLE_COUNTS[$role]}" -eq 1 ] || continue
+  if [ -n "$kernel_abi" ] && [ "${ROLE_ABIS[$role]}" != "$kernel_abi" ]; then
+    error "$role package ABI ${ROLE_ABIS[$role]} does not match $kernel_abi."
+  fi
+  if [ -n "$package_version" ] && [ "${ROLE_VERSIONS[$role]}" != "$package_version" ]; then
+    error "$role package version ${ROLE_VERSIONS[$role]} does not match $package_version."
+  fi
+done
+
+if [ "${#deb_files[@]}" -gt 0 ]; then
+  if ! have_tool dpkg-deb; then
+    error "missing required tool for Debian package validation: dpkg-deb"
+  else
+    for role in image modules headers common_headers; do
+      [ "${ROLE_COUNTS[$role]}" -eq 1 ] || continue
+      deb="${ROLE_FILES[$role]}"
+      case "$role" in
+        image) expected_package="linux-image-${ROLE_ABIS[$role]}"; expected_arch="arm64" ;;
+        modules) expected_package="linux-modules-${ROLE_ABIS[$role]}"; expected_arch="arm64" ;;
+        headers) expected_package="linux-headers-${ROLE_ABIS[$role]}"; expected_arch="arm64" ;;
+        common_headers)
+          expected_package="linux-qcom-x1e-headers-${ROLE_ABIS[$role]%-qcom-x1e}"
+          expected_arch="all"
+          ;;
+      esac
+      actual_package="$(dpkg-deb -f "$deb" Package 2>/dev/null || true)"
+      actual_version="$(dpkg-deb -f "$deb" Version 2>/dev/null || true)"
+      actual_arch="$(dpkg-deb -f "$deb" Architecture 2>/dev/null || true)"
+      [ "$actual_package" = "$expected_package" ] || \
+        error "$(basename "$deb") contains package '$actual_package', expected '$expected_package'."
+      [ "$actual_version" = "${ROLE_VERSIONS[$role]}" ] || \
+        error "$(basename "$deb") contains version '$actual_version', expected '${ROLE_VERSIONS[$role]}'."
+      [ "$actual_arch" = "$expected_arch" ] || \
+        error "$(basename "$deb") has architecture '$actual_arch', expected '$expected_arch'."
+    done
+
+    if [ "${ROLE_COUNTS[headers]}" -eq 1 ]; then
+      header_depends="$(dpkg-deb -f "${ROLE_FILES[headers]}" Depends 2>/dev/null || true)"
+      if [[ "$header_depends" =~ (linux-qcom-x1e-headers-[A-Za-z0-9.+:~_-]+) ]]; then
+        required_common="${BASH_REMATCH[1]}"
+        if [ "${ROLE_COUNTS[common_headers]}" -ne 1 ]; then
+          error "flavour headers require $required_common, but its common headers package is missing."
+        else
+          actual_common="$(dpkg-deb -f "${ROLE_FILES[common_headers]}" Package 2>/dev/null || true)"
+          [ "$actual_common" = "$required_common" ] || \
+            error "flavour headers require $required_common, but release contains $actual_common."
+        fi
+      fi
+    fi
+  fi
+fi
+
+release_manifest="$RELEASE_DIR/sp11-kernel-release-manifest.txt"
+support_commit=""
+manifest_release=""
+if [ ! -f "$release_manifest" ] || [ -L "$release_manifest" ]; then
+  error "missing regular, non-symlinked sp11-kernel-release-manifest.txt."
+else
+  if ! support_commit="$(single_manifest_value "$release_manifest" "Support repo commit")"; then
+    error "sp11-kernel-release-manifest.txt must contain exactly one nonempty 'Support repo commit:' field."
+    support_commit=""
+  fi
+  if ! manifest_release="$(single_manifest_value "$release_manifest" "Release")"; then
+    error "sp11-kernel-release-manifest.txt must contain exactly one nonempty 'Release:' field."
+    manifest_release=""
+  fi
+  if [[ ! "$support_commit" =~ ^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$ ]]; then
+    error "release manifest Support repo commit must be an immutable 40- or 64-hex commit."
+  else
+    support_commit="${support_commit,,}"
+  fi
+  if ! dirty_value="$(single_manifest_value "$release_manifest" "Support repo dirty")"; then
+    error "sp11-kernel-release-manifest.txt must contain exactly one nonempty 'Support repo dirty:' field."
+    dirty_value=""
+  fi
+  if [ -n "$dirty_value" ] && [ "$dirty_value" != "false" ]; then
+    error "release manifest records a dirty support repository: $dirty_value"
+  fi
+
+  for deb in "${deb_files[@]}"; do
+    base="$(basename "$deb")"
+    sha="$(sha256_file "$deb" 2>/dev/null || true)"
+    grep -Fq -- "- $base" "$release_manifest" || \
+      error "release manifest does not list package $base."
+    [ -z "$sha" ] || grep -Fiq -- "SHA256: $sha" "$release_manifest" || \
+      error "release manifest does not record the actual SHA-256 for $base."
+  done
+fi
+
+debs_manifest="$RELEASE_DIR/sp11-kernel-debs.txt"
+if [ ! -f "$debs_manifest" ] || [ -L "$debs_manifest" ]; then
+  error "missing regular, non-symlinked sp11-kernel-debs.txt."
+else
+  declare -A LISTED_DEBS=()
+  while IFS= read -r listed || [ -n "$listed" ]; do
+    listed="${listed%$'\r'}"
+    [ -n "$listed" ] || continue
+    case "$listed" in
+      */*|.*)
+        error "sp11-kernel-debs.txt contains an unsafe package name: $listed"
+        continue
+        ;;
+    esac
+    if [ -n "${LISTED_DEBS[$listed]+x}" ]; then
+      error "sp11-kernel-debs.txt lists $listed more than once."
+    fi
+    LISTED_DEBS["$listed"]=1
+  done < "$debs_manifest"
+
+  for deb in "${deb_files[@]}"; do
+    base="$(basename "$deb")"
+    [ -n "${LISTED_DEBS[$base]+x}" ] || error "sp11-kernel-debs.txt omits $base."
+  done
+  for listed in "${!LISTED_DEBS[@]}"; do
+    [ -f "$RELEASE_DIR/$listed" ] || error "sp11-kernel-debs.txt names a missing package: $listed"
+    case "$listed" in
+      *.deb) ;;
+      *) error "sp11-kernel-debs.txt contains a non-.deb entry: $listed" ;;
+    esac
+  done
+  if [ "${#LISTED_DEBS[@]}" -ne "${#deb_files[@]}" ]; then
+    error "sp11-kernel-debs.txt asset count (${#LISTED_DEBS[@]}) does not match the directory (${#deb_files[@]})."
+  fi
+fi
+
+if [ -n "$TAG" ]; then
+  repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+  if ! have_tool git; then
+    error "missing required tool for tag validation: git"
+  else
+    if [ -n "$manifest_release" ] && [ "$manifest_release" != "$TAG" ]; then
+      error "release manifest names '$manifest_release', but --tag is '$TAG'."
+    fi
+
+    local_target=""
+    if local_target="$(git -C "$repo_dir" rev-parse --verify "refs/tags/$TAG^{commit}" 2>/dev/null)"; then
+      local_target="${local_target,,}"
+      if [ -n "$support_commit" ] && [ "$support_commit" != "$local_target" ]; then
+        error "release manifest support commit $support_commit does not match local tag $TAG target $local_target."
+      else
+        checked
+      fi
+    else
+      error "local tag not found: $TAG"
+    fi
+
+    if [ -n "$REMOTE" ]; then
+      remote_output=""
+      if ! remote_output="$(git -C "$repo_dir" ls-remote --exit-code --tags "$REMOTE" \
+        "refs/tags/$TAG" "refs/tags/$TAG^{}" 2>/dev/null)"; then
+        error "could not resolve remote tag $TAG from $REMOTE."
+      else
+        remote_target="$(printf '%s\n' "$remote_output" | awk '$2 ~ /\^\{\}$/ {print $1; exit}')"
+        if [ -z "$remote_target" ]; then
+          remote_target="$(printf '%s\n' "$remote_output" | awk 'NF >= 2 {print $1; exit}')"
+        fi
+        remote_target="${remote_target,,}"
+        if [[ ! "$remote_target" =~ ^[0-9a-f]{40}([0-9a-f]{24})?$ ]]; then
+          error "remote tag $TAG did not resolve to a 40- or 64-hex target."
+        elif [ -n "$support_commit" ] && [ "$support_commit" != "$remote_target" ]; then
+          error "release manifest support commit $support_commit does not match remote tag $TAG target $remote_target."
+        else
+          checked
+        fi
+      fi
+    fi
+  fi
+fi
+
+touchscreen_release="false"
+case "$kernel_abi" in
+  *sp11v3*) touchscreen_release="true" ;;
+esac
+
+touch_modules=(gpi.ko spi-geni-qcom.ko mshw0485_touch.ko)
+present_ko_files=()
+while IFS= read -r -d '' ko; do
+  present_ko_files+=("$(basename "$ko")")
+done < <(find "$RELEASE_DIR" -mindepth 1 -maxdepth 1 -type f -name '*.ko' -print0)
+
+if [ "$touchscreen_release" = "true" ]; then
+  for expected in "${touch_modules[@]}"; do
+    if [ ! -f "$RELEASE_DIR/$expected" ] || [ -L "$RELEASE_DIR/$expected" ]; then
+      error "sp11v3 release is missing touchscreen module: $expected"
+    fi
+  done
+  for actual in "${present_ko_files[@]}"; do
+    case "$actual" in
+      gpi.ko|spi-geni-qcom.ko|mshw0485_touch.ko) ;;
+      *) error "sp11v3 release contains unexpected kernel module: $actual" ;;
+    esac
+  done
+  if [ "${#present_ko_files[@]}" -ne 3 ]; then
+    error "sp11v3 release must contain exactly three touchscreen .ko files; found ${#present_ko_files[@]}."
+  fi
+
+  touchscreen_manifest="$RELEASE_DIR/sp11-touchscreen-modules-manifest.txt"
+  touchscreen_source_commit=""
+  if [ ! -f "$touchscreen_manifest" ] || [ -L "$touchscreen_manifest" ]; then
+    error "sp11v3 release is missing sp11-touchscreen-modules-manifest.txt provenance."
+  else
+    if ! manifest_touch_abi="$(single_manifest_value "$touchscreen_manifest" "Kernel ABI")"; then
+      if ! manifest_touch_abi="$(single_manifest_value "$touchscreen_manifest" "Target release")"; then
+        error "touchscreen provenance must contain exactly one Kernel ABI or Target release field."
+        manifest_touch_abi=""
+      fi
+    fi
+    [ "$manifest_touch_abi" = "$kernel_abi" ] || \
+      error "touchscreen provenance ABI '$manifest_touch_abi' does not match '$kernel_abi'."
+
+    commit_values=()
+    value=""
+    while IFS= read -r value; do commit_values+=("$value"); done \
+      < <(manifest_values "$touchscreen_manifest" "Touchscreen source commit")
+    if [ "${#commit_values[@]}" -eq 0 ]; then
+      while IFS= read -r value; do commit_values+=("$value"); done \
+        < <(manifest_values "$touchscreen_manifest" "Source commit")
+    fi
+    if [ "${#commit_values[@]}" -ne 1 ] ||
+       [[ ! "${commit_values[0]:-}" =~ ^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$ ]]; then
+      error "touchscreen provenance must contain exactly one immutable 40- or 64-hex source commit."
+    else
+      touchscreen_source_commit="${commit_values[0],,}"
+    fi
+
+    ref_values=()
+    while IFS= read -r value; do ref_values+=("$value"); done \
+      < <(manifest_values "$touchscreen_manifest" "Source ref")
+    if [ "${#ref_values[@]}" -gt 1 ]; then
+      error "touchscreen provenance contains multiple Source ref fields."
+    elif [ "${#ref_values[@]}" -eq 1 ]; then
+      if [[ ! "${ref_values[0]}" =~ ^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$ ]]; then
+        error "touchscreen provenance Source ref must be an immutable 40- or 64-hex commit."
+      elif [ -n "$touchscreen_source_commit" ] && [ "${ref_values[0],,}" != "$touchscreen_source_commit" ]; then
+        error "touchscreen provenance Source ref and Source commit differ."
+      fi
+    fi
+  fi
+
+  if ! have_tool modinfo; then
+    error "missing required tool for touchscreen module validation: modinfo"
+  else
+    declare -A EXPECTED_MODULE_NAMES=(
+      [gpi.ko]=gpi
+      [spi-geni-qcom.ko]=spi_geni_qcom
+      [mshw0485_touch.ko]=mshw0485_touch
+    )
+    common_vermagic_abi=""
+    for module_file in "${touch_modules[@]}"; do
+      module_path="$RELEASE_DIR/$module_file"
+      [ -f "$module_path" ] && [ ! -L "$module_path" ] || continue
+      module_name="$(modinfo -F name "$module_path" 2>/dev/null || true)"
+      module_vermagic="$(modinfo -F vermagic "$module_path" 2>/dev/null || true)"
+      module_vermagic_abi="${module_vermagic%% *}"
+      module_srcversion="$(modinfo -F srcversion "$module_path" 2>/dev/null || true)"
+
+      [ "$module_name" = "${EXPECTED_MODULE_NAMES[$module_file]}" ] || \
+        error "$module_file has module name '$module_name', expected '${EXPECTED_MODULE_NAMES[$module_file]}'."
+      [ "$module_vermagic_abi" = "$kernel_abi" ] || \
+        error "$module_file vermagic targets '$module_vermagic_abi', expected '$kernel_abi'."
+      if [ -z "$common_vermagic_abi" ]; then
+        common_vermagic_abi="$module_vermagic_abi"
+      elif [ "$module_vermagic_abi" != "$common_vermagic_abi" ]; then
+        error "touchscreen modules do not share a common first-word vermagic."
+      fi
+      [[ "$module_srcversion" =~ ^[0-9A-Fa-f]+$ ]] || \
+        error "$module_file has an empty or invalid srcversion."
+
+      if [ -f "${touchscreen_manifest:-}" ]; then
+        module_sha="$(sha256_file "$module_path" 2>/dev/null || true)"
+        grep -Fq -- "- $module_file" "$touchscreen_manifest" || \
+          error "touchscreen provenance does not list $module_file."
+        [ -z "$module_sha" ] || grep -Fiq -- "SHA256: $module_sha" "$touchscreen_manifest" || \
+          error "touchscreen provenance does not record the actual SHA-256 for $module_file."
+        grep -Fq -- "$module_srcversion" "$touchscreen_manifest" || \
+          error "touchscreen provenance does not record the srcversion for $module_file."
+      fi
+    done
+
+    modinfo -p "$RELEASE_DIR/spi-geni-qcom.ko" 2>/dev/null | \
+      grep -q '^sp11_windows_se_init:' || \
+      error "spi-geni-qcom.ko lacks the required sp11_windows_se_init parameter."
+    modinfo -F alias "$RELEASE_DIR/mshw0485_touch.ko" 2>/dev/null | \
+      grep -q 'microsoft,mshw0485' || \
+      error "mshw0485_touch.ko lacks the microsoft,mshw0485 device-tree alias."
+  fi
+
+  if [ "${ROLE_COUNTS[modules]}" -eq 1 ]; then
+    if ! have_tool dpkg-deb || ! have_tool fdtget || ! have_tool tar; then
+      error "dpkg-deb, tar, and fdtget are required to inspect the packaged sp11v3 Denali OLED DTB."
+    else
+      temp_dir="$(mktemp -d 2>/dev/null || true)"
+      if [ -z "$temp_dir" ] || [ ! -d "$temp_dir" ]; then
+        error "could not create a temporary directory for DTB inspection."
+      else
+        TEMP_DIRS+=("$temp_dir")
+        image_root="$temp_dir/modules"
+        mkdir -p "$image_root"
+        archive_listing=""
+        if ! archive_listing="$(dpkg-deb --fsys-tarfile "${ROLE_FILES[modules]}" 2>/dev/null | tar -tf - 2>/dev/null)"; then
+          error "could not list $(basename "${ROLE_FILES[modules]}") for DTB inspection."
+        else
+          archive_dtb_paths=()
+          expected_dtb_prefix="./usr/lib/firmware/$kernel_abi/device-tree/qcom/"
+          while IFS= read -r archive_path; do
+            case "$archive_path" in
+              "${expected_dtb_prefix}x1e80100-microsoft-denali-oled.dtb"|\
+              "${expected_dtb_prefix}x1e80100-microsoft-denali-oled-el2.dtb")
+                archive_dtb_paths+=("$archive_path")
+                ;;
+            esac
+          done <<<"$archive_listing"
+
+          if [ "${#archive_dtb_paths[@]}" -gt 0 ]; then
+            if ! dpkg-deb --fsys-tarfile "${ROLE_FILES[modules]}" 2>/dev/null | \
+              tar -x -C "$image_root" -- "${archive_dtb_paths[@]}" 2>/dev/null; then
+              error "could not extract Denali OLED DTBs from $(basename "${ROLE_FILES[modules]}")."
+            fi
+          fi
+
+          denali_dtbs=()
+          while IFS= read -r -d '' dtb; do denali_dtbs+=("$dtb"); done \
+            < <(find "$image_root" -type f \
+              \( -name 'x1e80100-microsoft-denali-oled.dtb' \
+                 -o -name 'x1e80100-microsoft-denali-oled-el2.dtb' \) -print0)
+          primary_count=0
+          for dtb in "${denali_dtbs[@]}"; do
+            [ "$(basename "$dtb")" = "x1e80100-microsoft-denali-oled.dtb" ] && \
+              primary_count=$((primary_count + 1))
+          done
+          [ "$primary_count" -eq 1 ] || \
+            error "modules package must contain exactly one x1e80100-microsoft-denali-oled.dtb; found $primary_count."
+
+          for dtb in "${denali_dtbs[@]}"; do
+            dtb_name="$(basename "$dtb")"
+            root_compatible="$(fdtget "$dtb" / compatible 2>/dev/null || true)"
+            spi_path="/soc@0/geniqup@ac0000/spi@a88000"
+            touch_path="$spi_path/touchscreen@0"
+            spi_status="$(fdtget "$dtb" "$spi_path" status 2>/dev/null || true)"
+            spi_compatible="$(fdtget "$dtb" "$spi_path" compatible 2>/dev/null || true)"
+            touch_compatible="$(fdtget "$dtb" "$touch_path" compatible 2>/dev/null || true)"
+
+            [[ " $root_compatible " == *" microsoft,denali-oled "* ]] || \
+              error "$dtb_name is not a Microsoft Denali OLED device tree."
+            [ "$spi_status" = "okay" ] || \
+              error "$dtb_name does not enable $spi_path (status='$spi_status')."
+            [[ " $spi_compatible " == *" qcom,geni-spi "* ]] || \
+              error "$dtb_name lacks the qcom,geni-spi controller at $spi_path."
+            fdtget "$dtb" "$spi_path" qcom,biosref-qspi >/dev/null 2>&1 || \
+              error "$dtb_name lacks qcom,biosref-qspi at $spi_path."
+            fdtget "$dtb" "$spi_path" qcom,enable-gsi-dma >/dev/null 2>&1 || \
+              error "$dtb_name lacks qcom,enable-gsi-dma at $spi_path."
+            [[ " $touch_compatible " == *" microsoft,mshw0485 "* ]] || \
+              error "$dtb_name lacks the microsoft,mshw0485 touchscreen node."
+          done
+          [ "${#denali_dtbs[@]}" -gt 0 ] && checked
+        fi
+      fi
+    fi
+  fi
+else
+  if [ "${#present_ko_files[@]}" -gt 0 ]; then
+    error "non-sp11v3 release contains unexpected touchscreen kernel modules: ${present_ko_files[*]}"
+  fi
+  if [ -e "$RELEASE_DIR/sp11-touchscreen-modules-manifest.txt" ]; then
+    error "non-sp11v3 release contains an unexpected touchscreen provenance manifest."
+  fi
+fi
+
+echo "Validated directory: $RELEASE_DIR"
+if [ -n "$kernel_abi" ]; then
+  echo "Kernel ABI: $kernel_abi"
+  echo "Package version: $package_version"
+fi
+echo "Successful checks: $CHECK_COUNT"
+
+if [ "$ERROR_COUNT" -ne 0 ]; then
+  echo "Release validation failed with $ERROR_COUNT error(s)." >&2
+  exit 1
+fi
+
+echo "Release validation passed."


### PR DESCRIPTION
## Summary

- Build the SP11 touchscreen modules from an immutable source revision for the exact target kernel ABI, then install `gpi`, `spi_geni_qcom`, and `mshw0485_touch` as one validated set.
- Rebuild and inspect the target initramfs during installation so stock or duplicate drivers cannot initialize the touchscreen stack before the root filesystem is mounted.
- Add read-only touchscreen diagnostics and guard the kernel, live-image, and release workflows against incomplete, mismatched, or unverifiable touchscreen assets.
- Document the clean-install regression, why the stateful development system masked it, and the clean-hardware validation matrix in ADR0050.
- Record the repository-wide release audit and the removal of four broken or incorrectly identified releases and tags in ADR0051, while retaining valid historical artifacts with explicit provenance qualifications.

## Why

A community clean installation reported `Invalid proto 9` even though the touchscreen worked in the development environment. The released flow installed replacement modules on the root filesystem but did not make rebuilding and verifying the initramfs part of the transaction. A clean boot could therefore load the stock `spi_geni_qcom` driver before the replacement was available.

The development system had already accumulated the compatible module overrides and boot-image state, so it did not reproduce the clean-install path. The release audit also found artifacts whose tags, manifests, checksums, tagged trees, or default installation behavior did not match their published claims.

## Key changes

- Pin the touchscreen source to an immutable commit and reject dirty, mutable, unexpected, or ABI-incompatible build inputs.
- Validate kernel configuration, headers, `Module.symvers`, DTB support, module names, vermagic, source versions, controller parameters, and device-tree aliases.
- Generate a module provenance manifest and use it throughout installation and release validation.
- Add a guarded exact-ABI installer that deploys the complete module set, configures module ordering, rebuilds the boot image, and verifies the embedded module identities.
- Add diagnostics for selected and loaded module paths, firmware, device tree, SPI registration, input creation, initramfs contents, and known boot-log failure signatures.
- Require SP11 kernel packages and their matching touchscreen bundle to be installed, packaged, and released together unless an explicit kernel-development escape hatch is selected.
- Validate release membership, checksums, Debian metadata, tag and support-commit provenance, module provenance, and packaged Denali OLED DTBs.
- Remove the broken or incorrectly identified `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3`, `sp11-qcom-x1e-7.1.3-jg-0-touch`, `sp11-ubuntu-live-direct-jg-7.1.1`, and `sp11-audio-topology-v1` releases and tags.
- Establish immutable corrective-release, evidence-retention, deletion, and post-cleanup verification policies in ADR0051.
- Update the README, build and reinstall guides, release documentation, payload notes, patch notes, and related ADRs for the unified workflow.

## Validation

- Built the pinned touchscreen modules against the installed `7.2-rc5-jg-0sp11v3-qcom-x1e` headers.
- Passed all 198 upstream touchscreen tests.
- Verified missing and ABI-mismatched bundles are rejected before package mutation.
- Passed corrected release fixtures and confirmed the validator detects the historical v3 defects.
- Verified shell syntax, whitespace, ADR links, release and tag counts, and absence of all four retired refs.


## Follow-up release gate

Before publishing the corrective release, run the documented privileged clean-hardware matrix on a pristine SP11 installation, including stale-initramfs repair, both boot backends, cold boot, Windows transition, and suspend/resume coverage.
