### PR TITLE
[SP11-50/SP11-51] Prepare corrective SP11 v3 r1 prereleases

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ mkdir -p build
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
   --source git \
   --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
-  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --git-branch jg/ubuntu-qcom-x1e-7.2-rc5-jg-0 \
   --image ubuntu:26.04 \
   --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v2" \
   --build-target "binary-indep binary-qcom-x1e" \
@@ -106,7 +106,7 @@ mkdir -p build
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
   --source git \
   --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
-  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --git-branch jg/ubuntu-qcom-x1e-7.2-rc5-jg-0 \
   --image ubuntu:26.04 \
   --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v3" \
   --build-target "binary-indep binary-qcom-x1e" \
@@ -116,6 +116,11 @@ mkdir -p build
   --reset-source \
   --jobs 8
 ```
+
+The release examples use the immutable
+`jg/ubuntu-qcom-x1e-7.2-rc5-jg-0` tag. The moving
+`jg/ubuntu-qcom-x1e-7.2rc` branch resolved to the same source commit when this
+baseline was validated, but should not be used as release provenance.
 
 The v3 build enables the MSHW0485 OLED touchscreen in the device tree, but the
 runtime QSPI support ships as an exact-ABI out-of-tree module bundle. After the
@@ -241,10 +246,11 @@ bundle before invoking `apt`. `--skip-touchscreen-modules` is available for a
 deliberate kernel-development install, but touch will remain unavailable until
 `install-sp11-touchscreen.sh` completes.
 
-For a direct local installation instead of the USB payload flow, place all
-four matching `.deb` packages in one directory and run the same helper against
-that directory. For example, with the 2.4 MHz DMIC packages downloaded to
-`$HOME/Downloads`:
+For a direct local installation instead of the USB payload flow, place all four
+matching `.deb` packages in one directory and run the same helper against that
+directory. An `sp11v3` directory must also contain the release's matching
+`gpi.ko`, `spi-geni-qcom.ko`, and `mshw0485_touch.ko` files. For example, with
+the verified release assets downloaded to `$HOME/Downloads`:
 
 ```bash
 cd /path/to/linux-surface-pro-11-oe
@@ -254,11 +260,10 @@ cd /path/to/linux-surface-pro-11-oe
 sudo reboot
 ```
 
-For the standard v2 build, the directory must contain the matching image,
-modules, flavour-header, and common-header packages for
-`7.1.3-jg-1sp11v2` (or `7.2-rc5-jg-0sp11v2` for the current 7.2-rc5 v2
-kernel). After reboot, verify the running kernel and authoritative DMIC
-clock:
+The current v3 bundle contains matching image, modules, flavour-header, and
+common-header packages for `7.2-rc5-jg-0sp11v3`, plus the three touchscreen
+modules. The older `7.1.3-jg-1sp11v2` package set remains a kernel-only rollback
+option. After reboot, verify the running kernel and authoritative DMIC clock:
 
 ```bash
 uname -r
@@ -266,8 +271,8 @@ od -An -tu4 -N4 --endian=big \
   /sys/firmware/devicetree/base/soc@0/codec@6d44000/qcom,dmic-sample-rate
 ```
 
-Expected values are `7.2-rc5-jg-0sp11v2-qcom-x1e` (or
-`7.1.3-jg-1sp11v2-qcom-x1e`) and `2400000`.
+Expected values are `7.2-rc5-jg-0sp11v3-qcom-x1e` (or
+`7.1.3-jg-1sp11v2-qcom-x1e` after selecting the rollback kernel) and `2400000`.
 
 ## Post-Install Bring-Up
 
@@ -342,10 +347,10 @@ sudo reboot
 
 Alternatively, download the
 [audio topology and UCM v2 release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-audio-topology-v2).
-The corrected v2 UCM should be paired with the
-[7.2-rc5-jg-0sp11v2 kernel](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc5-jg-0sp11v2),
+The corrected v2 UCM should be paired with the experimental
+[7.2-rc5-jg-0sp11v3 r1 kernel bundle](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1)
 which carries the 2.4 MHz DMIC clock required to eliminate the static observed
-with the earlier 4.8 MHz kernel. The previous
+with the earlier 4.8 MHz kernel. The existing
 [7.1.3-jg-1 v2 kernel](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.1.3-jg-1-v2)
 remains available as a rollback option.
 

--- a/docs/adr/adr-0026-prebuilt-kernel-release-artifacts.md
+++ b/docs/adr/adr-0026-prebuilt-kernel-release-artifacts.md
@@ -70,18 +70,28 @@ sp11-qcom-x1e-7.0.0-22.22-rfkill1
 Each binary release must include, at minimum:
 
 - the installable qcom-x1e `.deb` files;
-- `SHA256SUMS` for every uploaded asset;
-- a sanitized build manifest recording source mode, upstream URL, branch,
+- `SHA256SUMS` covering every other uploaded asset exactly once; the checksum
+  file must not list itself, and a local `RELEASE-NOTES.md` used only as the
+  GitHub release body is neither uploaded nor listed;
+- a sanitized build manifest recording source mode, upstream URL, source ref,
   source commit, build target, patch list, repository commit, Docker image
   family or digest when available, and build command shape;
 - a package manifest listing package filenames, sizes, versions, and checksums
   without local workstation paths;
-- patch checksums for `patches/ubuntu-qcom-x1e-7.0/`;
+- patch checksums for every project patch directory applied to the source (the
+  original 7.0 release used `patches/ubuntu-qcom-x1e-7.0/`);
 - corresponding source sufficient for the binary release, either as source
   package artifacts, a patched source archive, or immutable instructions and
   links that retrieve the exact source commit plus the project patches used;
 - release notes that mark the artifacts as experimental, Surface Pro 11
   specific, unsigned, and optional.
+
+The checksum and exact-asset rules above were clarified by the touchscreen
+release retrospective in [ADR0050](adr-0050-sp11-touchscreen-clean-install-release-flow.md)
+and the cleanup decision in [ADR0051](adr-0051-release-and-tag-cleanup.md).
+Generated notes used as the GitHub body remain local input, while
+`SHA256SUMS` is appended to the upload list only after the other upload assets
+have been hashed.
 
 The raw local manifests under `build/.../artifacts/` are build outputs, not
 automatically public release manifests. They may contain absolute paths from
@@ -128,9 +138,10 @@ recorded inputs".
 ## Consequences
 
 Users who trust the experimental release can avoid a multi-hour kernel build by
-downloading the `.deb` assets, verifying `SHA256SUMS`, copying the packages to
-`payload/kernel-debs/`, rebuilding the USB image, and installing with the
-existing `--install-only` fallback guard.
+downloading the `.deb` assets and any required exact-ABI module bundle,
+verifying `SHA256SUMS`, copying the matched set to `payload/kernel-debs/`,
+rebuilding the USB image, and installing with the existing `--install-only`
+fallback guard.
 
 GitHub Releases are not an apt repository. Users still need explicit download,
 checksum, copy-to-payload, USB rebuild, and Surface-side install instructions.

--- a/docs/adr/adr-0038-split-compressed-live-image-release-assets.md
+++ b/docs/adr/adr-0038-split-compressed-live-image-release-assets.md
@@ -18,6 +18,13 @@ pointed to the parent of the support commit recorded by its manifest. The
 split-image design remains valid, but a future image must bind its tag to the
 exact manifest commit.
 
+Corrective-release amendment (2026-08-07): the fresh image uses the new
+immutable tag `sp11-ubuntu-live-direct-7.2-rc5-jg-0sp11v3-r1`. The project
+owner authorized it as an experimental prerelease before completion of the
+clean-install hardware matrix. It is not a hardware-qualified promotion, and
+the exception does not relax checksum, provenance, explicit-target, or
+fresh-download validation requirements.
+
 ## Context
 
 The Surface Pro 11 bring-up can produce a direct-boot Ubuntu live USB raw disk
@@ -82,7 +89,8 @@ will:
 6. write `sp11-live-image-release-manifest.txt`
 7. write `SHA256SUMS` for the uploaded parts and metadata files
 8. write `RELEASE-NOTES.md` with reconstruct, verify, and write commands
-9. print a `gh release create` command that uploads only GitHub-safe assets
+9. print a `gh release create` command with an explicit
+   `--target <support-commit>` that uploads only GitHub-safe assets
 
 The default part size is 2,000,000,000 bytes. The helper rejects any configured
 part size that is greater than or equal to 2,147,483,648 bytes.
@@ -109,6 +117,36 @@ sudo dd if=sp11-ubuntu-live-direct.img of=/dev/diskX bs=16M conv=fsync status=pr
 
 The exact hashes are generated into the release notes for each release.
 
+For an image carrying an installed-system kernel payload, the notes and image
+outline must also distinguish the two boot contexts. The live environment
+continues to use the concept ISO's casper kernel. Kernel packages and
+exact-ABI touchscreen modules under `SP11DATA/payload/kernel-debs` are consumed
+only by the guarded installed-system flow; their presence does not add
+touchscreen support to the live session.
+
+For the corrective r1 image, the generated publication command must have this
+shape:
+
+```bash
+SUPPORT_COMMIT="$(git rev-parse HEAD)"
+
+gh release create sp11-ubuntu-live-direct-7.2-rc5-jg-0sp11v3-r1 \
+  --target "$SUPPORT_COMMIT" \
+  --prerelease \
+  --title "Surface Pro 11 live USB: 7.2-rc5-jg-0sp11v3 r1" \
+  --notes-file RELEASE-NOTES.md \
+  sp11-live-image-outline.txt \
+  sp11-live-image-release-manifest.txt \
+  SHA256SUMS \
+  sp11-ubuntu-live-direct-7.2-rc5-jg-0sp11v3-r1.img.zst.part-aa \
+  sp11-ubuntu-live-direct-7.2-rc5-jg-0sp11v3-r1.img.zst.part-ab \
+  sp11-ubuntu-live-direct-7.2-rc5-jg-0sp11v3-r1.img.zst.part-ac
+```
+
+`$SUPPORT_COMMIT` must equal the clean support commit in the image manifest.
+The retired image tag must not be reused, and GitHub must not infer the target
+from the default branch.
+
 ## Consequences
 
 The image can be published entirely through GitHub Releases without relying on
@@ -122,7 +160,9 @@ The raw `.img` is intentionally not uploaded as a release asset. The uploaded
 payload is the split compressed archive plus metadata files.
 
 The release remains experimental. The raw image is unsigned, and users must
-verify checksums and choose the correct removable disk before writing.
+verify checksums and choose the correct removable disk before writing. The r1
+authorization permits experimental distribution while the hardware matrix is
+outstanding; it does not justify a stable or hardware-qualified claim.
 
 ## Alternatives Considered
 

--- a/docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md
+++ b/docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md
@@ -100,7 +100,7 @@ The Docker kernel build:
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
   --source git \
   --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
-  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --git-branch jg/ubuntu-qcom-x1e-7.2-rc5-jg-0 \
   --image ubuntu:26.04 \
   --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v3" \
   --build-target "binary-indep binary-qcom-x1e" \

--- a/docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md
+++ b/docs/adr/adr-0050-sp11-touchscreen-clean-install-release-flow.md
@@ -9,9 +9,16 @@ description: Retrospective and decision record for making the Surface Pro 11 tou
 
 ## Status
 
-Accepted (2026-08-06). The implementation and module identities are validated
-on the existing OLED X1E80100 development device. A clean-install hardware run
-remains a release gate for the next touchscreen bundle.
+Accepted (2026-08-06), amended 2026-08-07. The implementation and module
+identities are validated on the existing OLED X1E80100 development device. A
+clean-install hardware run remains the gate for stable or hardware-qualified
+promotion of a touchscreen bundle.
+
+The project owner authorized one bounded exception for the fresh r1 kernel and
+image to be published as explicitly experimental prereleases after their
+automated package, module, DTB, image, provenance, and fresh-download checks
+pass. The clean-install matrix remains outstanding; these prereleases must say
+so and must not be described as clean-install validated or hardware-qualified.
 
 ## Context
 
@@ -141,12 +148,39 @@ and classifies the main signatures:
 - Validate tag commit, package ABI/version/roles, module vermagic/source
   versions/aliases, touchscreen DTB content, checksum coverage, and exact asset
   equality before publication and again from a fresh download.
-- Publish a new immutable corrective tag rather than moving the existing
-  public v3 tag.
+- Publish new immutable corrective tags rather than recreating or moving the
+  retired originals. The standalone bundle uses
+  `sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1`; the image uses
+  `sp11-ubuntu-live-direct-7.2-rc5-jg-0sp11v3-r1`. The installable kernel ABI
+  remains `7.2-rc5-jg-0sp11v3-qcom-x1e`.
+- An explicitly authorized experimental prerelease may precede the full
+  hardware matrix only when its release notes disclose the outstanding gate,
+  retain the fallback and recovery requirements, and make no stable or
+  hardware-qualified claim. All integrity and provenance gates still apply.
+
+### Automated evidence for the r1 prereleases
+
+The corrective-release rehearsal completed the non-device checks available on
+the ARM64 build host:
+
+- all 198 tests in the pinned Phase 91 touchscreen source passed with its
+  documented `python3 -m unittest discover -s tests -v` command;
+- the semantic release validator passed package role, ABI, dependency, module
+  identity, vermagic, source-version, alias, parameter, provenance, checksum,
+  and packaged touchscreen-DTB checks;
+- missing and deliberately mismatched module bundles were both rejected during
+  preflight, before package installation could begin; and
+- all four kernel packages, all three touchscreen modules, and the module
+  manifest extracted from the validated raw image matched the curated payload
+  byte for byte.
+
+These checks cover the refusal behavior in matrix item 4 and the artifact side
+of the release. Items 1–3 and 5–7 still require the physical Surface Pro 11
+transitions described below.
 
 ## Validation matrix
 
-The next release must cover:
+Stable or hardware-qualified promotion must cover:
 
 1. a clean v3 install while an older kernel is running;
 2. a deliberately stale stock-module initramfs, followed by guarded repair;
@@ -168,6 +202,10 @@ The next release must cover:
   initramfs is rebuilt and inspected.
 - The original v3 release and tag were removed on 2026-08-07. This ADR retains
   the audit evidence; a corrective successor must use a new immutable tag.
+- The authorized r1 prereleases can make corrected artifacts available for
+  community testing before the complete hardware matrix finishes, but their
+  experimental status and the remaining gate become part of the public
+  release record.
 
 ## Related
 

--- a/docs/adr/adr-0051-release-and-tag-cleanup.md
+++ b/docs/adr/adr-0051-release-and-tag-cleanup.md
@@ -9,7 +9,8 @@ description: Decision record for auditing the project's GitHub releases and tags
 
 ## Status
 
-Accepted and executed (2026-08-07).
+Accepted and executed (2026-08-07). Amended the same day to record the names
+and validation rules for the authorized experimental r1 successors.
 
 ## Context
 
@@ -180,23 +181,43 @@ Do not move a broken public tag to a corrected commit and do not reuse its
 name. A corrected artifact must receive a new immutable tag so caches, mirrors,
 and prior audit records cannot confuse the two releases.
 
+The corrective standalone kernel/module bundle is named
+`sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1`, and the corrective image is named
+`sp11-ubuntu-live-direct-7.2-rc5-jg-0sp11v3-r1`. The `-r1` suffix identifies
+new immutable public artifacts; it does not change the installable
+`7.2-rc5-jg-0sp11v3-qcom-x1e` kernel ABI. Neither retired original name may be
+recreated.
+
 ### Future release gates
 
-Before publishing a new binary release:
+Before publishing any new binary release:
 
-- create it with an explicit target support commit;
+- create it with an explicit `--target <support-commit>`, including image
+  releases prepared by `prepare-sp11-image-release-assets.sh`;
 - require the manifest support commit and local and remote tag targets to
   agree;
 - generate checksums from the exact upload list rather than adding assets
   afterward;
 - validate a fresh download against exact asset membership and semantic
-  package or hardware checks;
+  package or image checks;
 - keep release notes out of `SHA256SUMS` when they are used only as the GitHub
   release body; and
 - retain a new tag only after the release validator passes.
 
+When `gh release create` creates a previously absent tag, fetch that exact tag
+locally before the post-publication validator runs. The validator compares the
+manifest support commit with both the local and remote tag targets.
+
 Touchscreen releases additionally follow the exact-ABI module, DTB,
 initramfs, and provenance gates in ADR0050.
+
+The project owner authorized the fresh r1 kernel and image as experimental
+prereleases while ADR0050's clean-install hardware matrix is outstanding. This
+is a distribution exception, not a hardware qualification. The r1 notes must
+disclose the outstanding matrix and require a known-good fallback kernel and
+recovery media. Stable or hardware-qualified promotion remains blocked until
+the matrix passes; checksum, source, support-commit, tag, asset-equality, and
+fresh-download gates are not waived.
 
 ## Execution and verification
 

--- a/docs/how-to/how-to-bring-up-audio.md
+++ b/docs/how-to/how-to-bring-up-audio.md
@@ -262,21 +262,23 @@ Partition does not change the live tree. See
 build and [ADR-0046](../adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md) for the
 default-setting decision and device-side evidence.
 
-For normal installation, use the
-[`7.2-rc5-jg-0sp11v2` kernel release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc5-jg-0sp11v2)
+For a new installation, use the experimental
+[`7.2-rc5-jg-0sp11v3` r1 kernel bundle](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1)
 with the
 [`sp11-audio-topology-v2` assets](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-audio-topology-v2).
 The v2 topology binary is unchanged from v1; v2 updates the UCM capture path to
 match the single WSA macro, use two microphone channels, and apply unity
 decoder gain. The kernel remains necessary because UCM changes alone do not
-alter the Denali DMIC clock. See
-[ADR-0048](../adr/adr-0048-jglathe-qcom-7-2-rc5-jg-0sp11v2-build.md).
+alter the Denali DMIC clock. The v3 kernel retains the v2 build's validated
+2.4 MHz clock and adds the separately packaged, exact-ABI touchscreen module
+set. See [ADR-0048](../adr/adr-0048-jglathe-qcom-7-2-rc5-jg-0sp11v2-build.md)
+and [ADR-0049](../adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md).
 
-The 7.2-rc5 v2 kernel boots with the 2.4 MHz clock through the GRUB-injected
-`/boot/sp11-denali.dtb` (unlike the 7.1.3 v2 kernel, which carried the device
-tree embedded in the packaged Stubble image). The installer selects the v2
-build's DTB and injects it into every GRUB kernel entry, so the live
-device-tree value reflects the injected file:
+The 7.2-rc5 SP11 v2 and v3 kernels boot with the 2.4 MHz clock through the
+GRUB-injected `/boot/sp11-denali.dtb` (unlike the 7.1.3 v2 kernel, which carried
+the device tree embedded in the packaged Stubble image). The installer prefers
+the newest numeric `sp11vN` build's DTB and injects it into every GRUB kernel
+entry, so the live device-tree value reflects the injected file:
 
 ```bash
 uname -r
@@ -284,7 +286,8 @@ od -An -tu4 -N4 --endian=big \
   /sys/firmware/devicetree/base/soc@0/codec@6d44000/qcom,dmic-sample-rate
 ```
 
-Expected output is `7.2-rc5-jg-0sp11v2-qcom-x1e` and `2400000`.
+Expected output for the current bundle is
+`7.2-rc5-jg-0sp11v3-qcom-x1e` and `2400000`.
 
 ## References
 
@@ -295,6 +298,7 @@ Expected output is `7.2-rc5-jg-0sp11v2-qcom-x1e` and `2400000`.
 - ADR: [adr-0044-sp11-ucm-single-wsa-macro-microphone.md](../adr/adr-0044-sp11-ucm-single-wsa-macro-microphone.md)
 - ADR: [adr-0045-sp11-2p4mhz-dmic-clock-test-kernel.md](../adr/adr-0045-sp11-2p4mhz-dmic-clock-test-kernel.md)
 - ADR: [adr-0046-sp11-default-2p4mhz-dmic-clock.md](../adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md)
+- ADR: [adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md](../adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md)
 - Script: [sp11-audio-topology.sh](../../scripts/sp11-audio-topology.sh)
 - Script: [sp11-pipewire-speaker-sink.sh](../../scripts/sp11-pipewire-speaker-sink.sh)
 - Script: [sp11-enable-wsa-routing.sh](../../scripts/sp11-enable-wsa-routing.sh)

--- a/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
+++ b/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
@@ -175,11 +175,15 @@ branch configures the DMIC clock at 4.8 MHz, which reintroduces microphone
 static, so the Surface Pro 11 v2 patch set restores the validated 2.4 MHz
 clock and gives the result the distinct `7.2-rc5-jg-0sp11v2` ABI:
 
+Use the immutable `jg/ubuntu-qcom-x1e-7.2-rc5-jg-0` tag for a release build.
+The moving `jg/ubuntu-qcom-x1e-7.2rc` branch is useful for development but is
+not durable release provenance.
+
 ```bash
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
   --source git \
   --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
-  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --git-branch jg/ubuntu-qcom-x1e-7.2-rc5-jg-0 \
   --image ubuntu:26.04 \
   --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v2" \
   --build-target "binary-indep binary-qcom-x1e" \
@@ -208,7 +212,7 @@ the distinct `7.2-rc5-jg-0sp11v3` ABI:
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
   --source git \
   --git-url https://github.com/jglathe/linux_ms_dev_kit.git \
-  --git-branch jg/ubuntu-qcom-x1e-7.2rc \
+  --git-branch jg/ubuntu-qcom-x1e-7.2-rc5-jg-0 \
   --image ubuntu:26.04 \
   --patch-dirs "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v3" \
   --build-target "binary-indep binary-qcom-x1e" \

--- a/docs/how-to/how-to-reinstall-patched-kernel-from-usb.md
+++ b/docs/how-to/how-to-reinstall-patched-kernel-from-usb.md
@@ -2,23 +2,24 @@
 id: how-to-reinstall-patched-kernel-from-usb
 title: "Reinstall the Patched Kernel from USB or GitHub Releases"
 # prettier-ignore
-description: How-to guide for reinstalling the patched qcom-x1e kernel over a stock Ubuntu kernel that lacks ath12k disable-rfkill support, using either the live-USB payload or the GitHub release .deb packages.
+description: How-to guide for installing or reinstalling a Surface Pro 11 qcom-x1e kernel bundle from the live-USB payload or verified GitHub Release assets.
 ---
 
 # How To: Reinstall the Patched Kernel from USB or GitHub Releases
 
 Use this procedure after Ubuntu `apt` or an official kernel package has
-overwritten the patched qcom-x1e kernel. The patched kernel carries two
-patches (`0001` and `0002` from `patches/ubuntu-qcom-x1e-7.0/`) that skip
-ath12k rfkill configuration on Denali, resolving the intermittent WCN7850
-Wi-Fi hard-block.
+displaced a Surface Pro 11-specific qcom-x1e kernel, or when installing a
+downloaded kernel bundle for the first time. Release families differ: the
+historical 7.0 build applied two local ath12k rfkill patches, while the current
+`sp11v3` build starts from an immutable Johan G. kernel tag and adds the SP11
+build-policy, 2.4 MHz DMIC, touchscreen device-tree, and exact-ABI module work.
 
 ## Purpose
 
-Ubuntu ships a stock `linux-image-*-qcom-x1e` kernel that does not include
-`disable-rfkill` support for the Denali WCN7850 devicetree node. When a kernel
-update or reinstall replaces the patched kernel, Wi-Fi may reappear
-hard-blocked (`rfkill list` shows `Hard blocked: yes` for `phy0`).
+Replacing an SP11-specific kernel can regress the Denali Wi-Fi, DMIC-clock, or
+touchscreen path, depending on the stock kernel version. For `sp11v3`, the four
+kernel packages and three touchscreen modules form one exact-ABI transaction;
+installing only the `.deb` files does not provide a working touchscreen.
 
 This procedure gets the pre-built patched kernel `.deb` files onto the Surface
 and reinstalls them — no Docker build required. The packages can come from the
@@ -29,8 +30,9 @@ same way.
 
 - Root access on the Surface Pro 11.
 - The patched kernel `.deb` packages, from one of the sources below.
-- For an `sp11v3` touchscreen kernel, the release's matching `gpi.ko`,
-  `spi-geni-qcom.ko`, and `mshw0485_touch.ko` files in the same directory.
+- For an `sp11v3` touchscreen kernel, the complete release asset set, including
+  its matching `gpi.ko`, `spi-geni-qcom.ko`, and `mshw0485_touch.ko` files,
+  provenance manifest, and `SHA256SUMS`.
 - A checkout of this repository on the Surface — either the live USB
   `SP11DATA/support` directory, or a `git clone` — so the guarded installer and
   its post-install support helper are available.
@@ -66,61 +68,50 @@ ls "$DEBS"/linux-*.deb
 
 **Option B — from GitHub releases (Surface has Wi-Fi, Ethernet, or tethering):**
 
-Browse the releases page and pick the newest patched-kernel tag:
+Browse the releases page and select the intended patched-kernel tag:
 
 ```
 https://github.com/ooaklee/linux-surface-pro-11-oe/releases
 ```
 
-At the time of writing the current tag is
-`sp11-qcom-x1e-7.0.0-22.22-rfkill1`. Download the kernel `.deb` packages plus
-the `SHA256SUMS` file into a working directory. With the GitHub CLI:
+The corrective v3 prerelease is
+[`sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1`](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1)
+(experimental). The removed unsuffixed v3 tag is retired and must not be
+reused.
+
+For `sp11v3`, download the complete published asset set into a new directory,
+fetch the release tag into the local repository, and run the semantic release
+validator before installation:
 
 ```bash
-DEBS=~/sp11-kernel-debs
-TAG=sp11-qcom-x1e-7.0.0-22.22-rfkill1
+TAG=sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1
+DEBS="$HOME/sp11-kernel-debs-$TAG"
+mkdir -p "$DEBS"
 
 gh release download "$TAG" \
   --repo ooaklee/linux-surface-pro-11-oe \
-  --pattern 'linux-*.deb' \
-  --pattern 'SHA256SUMS' \
   --dir "$DEBS"
-```
 
-Or, without `gh`, download each asset with `wget` (replace the tag if newer):
-
-```bash
-DEBS=~/sp11-kernel-debs
-mkdir -p "$DEBS" && cd "$DEBS"
-BASE=https://github.com/ooaklee/linux-surface-pro-11-oe/releases/download/sp11-qcom-x1e-7.0.0-22.22-rfkill1
-wget "$BASE/linux-headers-7.0.0-22-qcom-x1e_7.0.0-22.22_arm64.deb"
-wget "$BASE/linux-image-7.0.0-22-qcom-x1e_7.0.0-22.22_arm64.deb"
-wget "$BASE/linux-modules-7.0.0-22-qcom-x1e_7.0.0-22.22_arm64.deb"
-wget "$BASE/SHA256SUMS"
-```
-
-Verify the downloads before installing:
-
-```bash
-cd "$DEBS"
-sha256sum -c SHA256SUMS --ignore-missing
-# Expect: each linux-*.deb line printed as "OK"
-```
-
-For an `sp11v3` release, download the entire published asset set rather than
-only `linux-*.deb`; the kernel and three touchscreen modules are one matched
-transaction. Validate that fresh directory before installation:
-
-```bash
-gh release download "$TAG" \
-  --repo ooaklee/linux-surface-pro-11-oe \
-  --dir "$DEBS"
+cd /path/to/linux-surface-pro-11-oe
+git fetch https://github.com/ooaklee/linux-surface-pro-11-oe.git \
+  "refs/tags/$TAG:refs/tags/$TAG"
 
 ./scripts/validate-sp11-touchscreen-release.sh \
   --dir "$DEBS" \
   --tag "$TAG" \
   --remote https://github.com/ooaklee/linux-surface-pro-11-oe.git
 ```
+
+The validator checks exact checksum and asset membership, package roles and
+ABI, module provenance and vermagic, the touchscreen device tree, and both the
+local and remote tag targets. Without `gh`, download every asset listed on the
+release page into one empty directory, fetch the tag as above, and run the same
+validator.
+
+For an older non-touchscreen release, downloading only its `.deb` files and
+`SHA256SUMS` is sufficient for installation. In that narrower case,
+`sha256sum -c SHA256SUMS --ignore-missing` verifies the downloaded packages but
+does not validate the release's complete asset set.
 
 ## 2. Install the patched kernel
 
@@ -213,7 +204,7 @@ Verify the running kernel:
 
 ```bash
 uname -r
-# 7.0.0-22-qcom-x1e
+# 7.2-rc5-jg-0sp11v3-qcom-x1e
 ```
 
 For an `sp11v3` kernel, also verify the complete touchscreen boot path:
@@ -224,11 +215,14 @@ sudo ./scripts/troubleshoot-sp11-touchscreen.sh
 
 ## Privacy and Safety
 
-The GitHub release ships the standard Ubuntu kernel binaries with two small
-open-source patches applied; no device-specific data is included. The release
-is **experimental and unsigned** — verify each package against the published
-`SHA256SUMS` before installing (section 1), and keep a known-good qcom-x1e
-fallback kernel installed so the GRUB fallback guard can protect the boot path.
+The release manifest records the source family, immutable source commit,
+applied project patches, and module provenance for that specific bundle. The
+v3 release is built from the Johan G. 7.2-rc5 tag with the SP11 DMIC and
+touchscreen changes; it is not the historical Ubuntu 7.0 two-patch build. No
+device-specific data is included. Every kernel release is **experimental and
+unsigned** — validate the published asset set before installing, and keep a
+known-good qcom-x1e fallback kernel installed so the GRUB fallback guard can
+protect the boot path.
 
 ## Related
 

--- a/docs/how-to/how-to-release-kernel-artifacts.md
+++ b/docs/how-to/how-to-release-kernel-artifacts.md
@@ -81,25 +81,66 @@ For git-fallback builds, use a patched source archive or another durable source
 asset that contains the exact upstream source plus the project patches used for
 the binary release.
 
-If the kernel was built with the Docker workflow, the named build volume can be
-used to create a local source archive. One draft pattern is:
+If the kernel was built with the Docker workflow, create the source archive
+from the tracked files in the patched worktree. Do not archive the whole
+post-build directory: it also contains generated objects and packaging output
+that are not corresponding source and can make the archive too large to
+publish.
+
+For the fresh `7.2-rc5-jg-0sp11v3` build, the source worktree is in the named
+Docker volume used by the build command. The following command verifies the
+immutable upstream commit and the expected patched tracked-file set, then
+archives only files known to git. The volume is mounted read-only:
 
 ```bash
 mkdir -p build/release-source
 
 docker run --rm --platform linux/arm64 \
-  -v sp11-qcom-x1e-kernel-build:/linux-work:ro \
+  -v sp11-qcom-x1e-kernel-build-jg-7.2rc-sp11-v3-r1:/linux-work:ro \
   -v "$PWD/build/release-source:/out" \
-  ubuntu:25.10 \
+  ubuntu:26.04 \
   bash -lc '
-    cd /linux-work/source/git-qcom-x1e-7.0
-    tar --exclude=.git -caf /out/sp11-qcom-x1e-7.0.0-22.22-rfkill1-patched-source.tar.xz .
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    export XZ_OPT="-T0 -6"
+    apt-get update
+    apt-get install -y --no-install-recommends git tar xz-utils
+
+    source_dir=/linux-work/source/git-jg-ubuntu-qcom-x1e-7.2-rc5-jg-0
+    archive_root=sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1-patched-source
+    cd "$source_dir"
+
+    test "$(git rev-parse HEAD)" = \
+      8f953dd060bc6e8fb86ca2ea8a92f258141c0169
+    git diff --check
+    test "$(git diff --name-only HEAD)" = "$(printf "%s\n" \
+      arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi \
+      debian.qcom-x1e/changelog \
+      debian.qcom-x1e/config/annotations)"
+    test "$(git -c core.abbrev=40 diff --binary --full-index HEAD | \
+      sha256sum | cut -d " " -f 1)" = \
+      96004d57880b7827537f90c8820cdd46a9687519d669342f81d39e73d4b4c02b
+
+    git ls-files -z | tar \
+      --null \
+      --verbatim-files-from \
+      --no-recursion \
+      --files-from=- \
+      --format=gnu \
+      --sort=name \
+      --mtime=@0 \
+      --owner=0 \
+      --group=0 \
+      --numeric-owner \
+      --transform="flags=r;s|^|$archive_root/|" \
+      -cJf "/out/$archive_root.tar.xz"
   '
 ```
 
-Before publishing, review that archive for the intended source state. The
-helper can enforce that a source file exists, but it cannot prove the source
-asset is legally or technically sufficient.
+Review the archive before publishing. It must have one top-level directory,
+must not contain `.git`, and must contain the patched versions of the three
+tracked files checked above. The helper can enforce that a source file exists,
+but it cannot prove the source asset is legally or technically sufficient.
 
 For an `sp11v3` release, build the touchscreen bundle against the release ABI
 and preserve the generated provenance manifest:
@@ -107,7 +148,7 @@ and preserve the generated provenance manifest:
 ```bash
 ./scripts/build-sp11-touchscreen-modules.sh \
   --release 7.2-rc5-jg-0sp11v3-qcom-x1e \
-  --out-dir build/sp11v3-touchscreen-modules
+  --out-dir build/sp11v3-touchscreen-modules-final
 ```
 
 4. Prepare release assets.
@@ -119,19 +160,31 @@ and preserve the generated provenance manifest:
 ```
 
 An `sp11v3` release must also supply the ABI-matched module directory and its
-immutable source provenance. Publish it under a new corrective tag; do not
-move the existing public v3 tag:
+immutable source provenance. The original v3 tag is retired and must not be
+reused. The fresh corrective release keeps the package ABI
+`7.2-rc5-jg-0sp11v3` but uses the new immutable release tag
+`sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1`:
 
 ```bash
 ./scripts/prepare-sp11-kernel-release-assets.sh \
   --kernel-debs-dir payload/kernel-debs \
+  --artifacts-dir build/docker-sp11-qcom-x1e-kernel-jg-7.2rc-sp11-v3-r1/artifacts \
+  --patch-dir patches/jglathe-qcom-x1e-7.2-rc5 \
   --patch-dir patches/sp11-qcom-x1e-7.2-rc5-v3 \
   --release-name sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1 \
-  --source-asset build/release-source/sp11-v3-patched-source.tar.xz \
-  --touchscreen-modules-dir build/sp11v3-touchscreen-modules \
+  --source-url https://github.com/jglathe/linux_ms_dev_kit.git \
+  --source-branch jg/ubuntu-qcom-x1e-7.2-rc5-jg-0 \
+  --docker-image ubuntu:26.04 \
+  --source-asset build/release-source/sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1-patched-source.tar.xz \
+  --touchscreen-modules-dir build/sp11v3-touchscreen-modules-final \
   --touchscreen-source-url https://github.com/geocausa/SP11X1e-touchscreen.git \
   --touchscreen-source-ref 6bbcf7a4759a73014047a57e819219dd7f34951a
 ```
+
+Repeat `--patch-dir` in the same order used for the kernel build. The release
+manifest must list all four applied patches: the Johan G. annotation update
+and the three Surface Pro 11 v3 patches. Supplying only the v3 directory makes
+the source provenance incomplete.
 
 The helper writes an ignored directory under:
 
@@ -145,9 +198,10 @@ local rehearsal, never for a public binary release.
 5. Review the generated release directory.
 
 ```bash
-find build/release/sp11-qcom-x1e-7.0.0-22.22-rfkill1 -maxdepth 1 -type f -print | sort
-sed -n '1,220p' build/release/sp11-qcom-x1e-7.0.0-22.22-rfkill1/sp11-kernel-release-manifest.txt
-sed -n '1,220p' build/release/sp11-qcom-x1e-7.0.0-22.22-rfkill1/RELEASE-NOTES.md
+TAG=sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1
+find "build/release/$TAG" -maxdepth 1 -type f -print | sort
+sed -n '1,220p' "build/release/$TAG/sp11-kernel-release-manifest.txt"
+sed -n '1,220p' "build/release/$TAG/RELEASE-NOTES.md"
 ```
 
 Check that the directory contains:
@@ -164,9 +218,8 @@ Check that the directory contains:
 6. Verify checksums from inside the generated release directory.
 
 ```bash
-cd build/release/sp11-qcom-x1e-7.0.0-22.22-rfkill1
-shasum -a 256 -c SHA256SUMS
-cd -
+(cd build/release/sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1 && \
+  shasum -a 256 -c SHA256SUMS)
 ```
 
 Then run the semantic validator. It checks package identities, exact asset and
@@ -182,7 +235,19 @@ OLED touchscreen device tree:
 
 For a pre-tag local rehearsal, omit `--tag` and `--remote`. Run the full command
 after creating the tag and again against a fresh directory containing exactly
-the downloaded release assets.
+the downloaded release assets. If `gh release create` created a new remote tag,
+fetch that exact tag before invoking the validator, which checks both its local
+and remote targets:
+
+```bash
+TAG=sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1
+git fetch origin "refs/tags/$TAG:refs/tags/$TAG"
+
+./scripts/validate-sp11-touchscreen-release.sh \
+  --dir build/release/$TAG \
+  --tag "$TAG" \
+  --remote origin
+```
 
 7. Review the generated publish command.
 
@@ -197,19 +262,42 @@ Do not add extra assets to the command unless you also regenerate
 
 8. Publish as a prerelease.
 
-Run the generated `gh release create ... --prerelease ...` command only after
-the source, checksum, privacy, and release-note reviews pass.
+Run the generated `gh release create ... --target <support-commit>
+--prerelease ...` command only after the source, checksum, privacy, and
+release-note reviews pass. The target must be the clean support commit recorded
+in both generated manifests; never let GitHub infer the default branch tip.
+
+The project owner authorized the fresh r1 kernel and image as explicitly
+experimental prereleases while the complete clean-install hardware matrix is
+still outstanding. This exception does not make either artifact
+hardware-qualified and does not waive the clean-install gate for a stable or
+promoted release. The release notes must disclose that distinction and retain
+the fallback-kernel and recovery-media requirements.
 
 9. Verify the published release.
 
 ```bash
-gh release view sp11-qcom-x1e-7.0.0-22.22-rfkill1 --json tagName,isPrerelease,assets
+TAG=sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1
+gh release view "$TAG" \
+  --json tagName,targetCommitish,isPrerelease,assets
+
+download_dir="$(mktemp -d)"
+gh release download "$TAG" \
+  --repo ooaklee/linux-surface-pro-11-oe \
+  --dir "$download_dir"
+git fetch origin "refs/tags/$TAG:refs/tags/$TAG"
+
+./scripts/validate-sp11-touchscreen-release.sh \
+  --dir "$download_dir" \
+  --tag "$TAG" \
+  --remote origin
 ```
 
 Confirm the release is marked as a prerelease and that every uploaded binary or
-source asset is listed in `SHA256SUMS`. Download the assets into a new empty
-directory and rerun `validate-sp11-touchscreen-release.sh` with `--tag` and
-`--remote origin`.
+source asset is listed in `SHA256SUMS`. Confirm the remote tag resolves to the
+manifest support commit. Download the assets into a new empty directory, fetch
+the new tag locally, and rerun `validate-sp11-touchscreen-release.sh` with
+`--tag` and `--remote origin`.
 
 ## Expected Output
 
@@ -225,6 +313,25 @@ The local release directory should contain a flat asset set:
 - for `sp11v3`, `gpi.ko`, `spi-geni-qcom.ko`, `mshw0485_touch.ko`, and their
   provenance manifest,
 - `RELEASE-NOTES.md`.
+
+For the fresh r1 release, the exact upload set is:
+
+```text
+linux-headers-7.2-rc5-jg-0sp11v3-qcom-x1e_7.2-rc5-jg-0sp11v3_arm64.deb
+linux-image-7.2-rc5-jg-0sp11v3-qcom-x1e_7.2-rc5-jg-0sp11v3_arm64.deb
+linux-modules-7.2-rc5-jg-0sp11v3-qcom-x1e_7.2-rc5-jg-0sp11v3_arm64.deb
+linux-qcom-x1e-headers-7.2-rc5-jg-0sp11v3_7.2-rc5-jg-0sp11v3_all.deb
+gpi.ko
+spi-geni-qcom.ko
+mshw0485_touch.ko
+sp11-touchscreen-modules-manifest.txt
+sp11-kernel-release-manifest.txt
+sp11-kernel-debs.txt
+sp11-qcom-x1e-7.2-rc5-jg-0sp11v3-r1-patched-source.tar.xz
+SHA256SUMS
+```
+
+`RELEASE-NOTES.md` is the GitHub release body and is not an uploaded asset.
 
 The published GitHub release should include the `.deb` packages, checksums,
 manifests, and source assets. `RELEASE-NOTES.md` should normally be used as the

--- a/scripts/build-sp11-qcom-x1e-kernel.sh
+++ b/scripts/build-sp11-qcom-x1e-kernel.sh
@@ -632,6 +632,9 @@ write_manifest() {
       echo "Resolved source package: $RESOLVED_SOURCE_PACKAGE"
       echo "Source version mode: $SOURCE_VERSION"
       echo "Apt source spec: $SOURCE_SPEC"
+    else
+      echo "Source URL: $GIT_URL"
+      echo "Source ref: $GIT_BRANCH"
     fi
     echo "Source directory: $source_dir"
     if [ -d "$source_dir/.git" ]; then

--- a/scripts/prepare-sp11-image-release-assets.sh
+++ b/scripts/prepare-sp11-image-release-assets.sh
@@ -306,6 +306,13 @@ Experimental direct-boot Ubuntu live USB raw disk image for Surface Pro 11.
 This image is an optional convenience artifact. It is not signed, is not an
 installer ISO, and should be written only to the intended removable device.
 
+## Installed-system payloads
+
+The live environment boots the concept ISO's casper kernel. A custom kernel or
+module bundle stored under `SP11DATA/payload/kernel-debs` is available only to
+the guarded installed-system flow; it does not replace the live-session kernel.
+Check `$OUTLINE_NAME` for the exact payload carried by this image.
+
 ## Verify
 
 \`\`\`bash
@@ -369,8 +376,8 @@ done
 echo "Prepared release assets in $OUT_DIR_DISPLAY"
 echo
 echo "Review $OUT_DIR_DISPLAY/RELEASE-NOTES.md, then publish with a command like:"
-printf '  (cd %q && gh release create %q --prerelease --title %q --notes-file RELEASE-NOTES.md' \
-  "$OUT_DIR_DISPLAY" "$RELEASE_NAME" "$RELEASE_NAME"
+printf '  (cd %q && gh release create %q --target %q --prerelease --title %q --notes-file RELEASE-NOTES.md' \
+  "$OUT_DIR_DISPLAY" "$RELEASE_NAME" "$repo_commit" "$RELEASE_NAME"
 for asset in "${release_assets[@]}"; do
   printf ' %q' "$asset"
 done

--- a/scripts/prepare-sp11-kernel-release-assets.sh
+++ b/scripts/prepare-sp11-kernel-release-assets.sh
@@ -3,11 +3,14 @@ set -euo pipefail
 
 KERNEL_DEBS_DIR="payload/kernel-debs"
 ARTIFACTS_DIR="build/docker-sp11-qcom-x1e-kernel/artifacts"
-PATCH_DIR="patches/ubuntu-qcom-x1e-7.0"
+PATCH_DIRS=("patches/ubuntu-qcom-x1e-7.0")
+PATCH_DIR_EXPLICIT="false"
 OUT_DIR=""
 RELEASE_NAME=""
 SOURCE_URL="https://git.launchpad.net/~ubuntu-concept/ubuntu/+source/linux/+git/resolute"
 SOURCE_BRANCH="qcom-x1e-7.0"
+SOURCE_URL_EXPLICIT="false"
+SOURCE_BRANCH_EXPLICIT="false"
 DOCKER_IMAGE=""
 ALLOW_DIRTY="false"
 ALLOW_MISSING_SOURCE="false"
@@ -36,7 +39,8 @@ Options:
                           default $KERNEL_DEBS_DIR.
   --artifacts-dir DIR     Directory containing local build manifests,
                           default $ARTIFACTS_DIR.
-  --patch-dir DIR         Patch directory, default $PATCH_DIR.
+  --patch-dir DIR         Patch directory. Repeat to record ordered patch sets;
+                          default ${PATCH_DIRS[0]}.
   --release-name NAME     Release/tag name. If omitted, derived from package
                           version when possible.
   --out-dir DIR           Output directory. If omitted, defaults to
@@ -109,7 +113,11 @@ while [ "$#" -gt 0 ]; do
       ;;
     --patch-dir)
       require_arg "$1" "${2:-}"
-      PATCH_DIR="$2"
+      if [ "$PATCH_DIR_EXPLICIT" != "true" ]; then
+        PATCH_DIRS=()
+        PATCH_DIR_EXPLICIT="true"
+      fi
+      PATCH_DIRS+=("$2")
       shift 2
       ;;
     --release-name)
@@ -125,11 +133,13 @@ while [ "$#" -gt 0 ]; do
     --source-url)
       require_arg "$1" "${2:-}"
       SOURCE_URL="$2"
+      SOURCE_URL_EXPLICIT="true"
       shift 2
       ;;
     --source-branch)
       require_arg "$1" "${2:-}"
       SOURCE_BRANCH="$2"
+      SOURCE_BRANCH_EXPLICIT="true"
       shift 2
       ;;
     --docker-image)
@@ -211,10 +221,12 @@ if [ ! -d "$KERNEL_DEBS_DIR" ]; then
   exit 1
 fi
 
-if [ ! -d "$PATCH_DIR" ]; then
-  echo "Patch directory not found: $PATCH_DIR" >&2
-  exit 1
-fi
+for patch_dir in "${PATCH_DIRS[@]}"; do
+  if [ ! -d "$patch_dir" ]; then
+    echo "Patch directory not found: $patch_dir" >&2
+    exit 1
+  fi
+done
 
 debs=()
 while IFS= read -r deb; do
@@ -510,6 +522,10 @@ OUT_DIR_DISPLAY="$release_root/$out_leaf"
 build_manifest="$ARTIFACTS_DIR/sp11-kernel-build-manifest.txt"
 source_mode=""
 source_head=""
+manifest_source_url=""
+manifest_source_ref=""
+apt_source_spec=""
+manifest_patch_dirs=""
 build_target=""
 jobs=""
 rules_runner=""
@@ -517,9 +533,29 @@ rules_runner=""
 if [ -f "$build_manifest" ]; then
   source_mode="$(awk -F': ' '$1 == "Source mode" { print $2; exit }' "$build_manifest")"
   source_head="$(awk -F': ' '$1 == "Source HEAD" { print $2; exit }' "$build_manifest")"
+  manifest_source_url="$(awk -F': ' '$1 == "Source URL" { print $2; exit }' "$build_manifest")"
+  manifest_source_ref="$(awk -F': ' '$1 == "Source ref" { print $2; exit }' "$build_manifest")"
+  apt_source_spec="$(awk -F': ' '$1 == "Apt source spec" { print $2; exit }' "$build_manifest")"
+  manifest_patch_dirs="$(awk -F': ' '$1 == "Patch directories" || $1 == "Patch directory" { print $2; exit }' "$build_manifest")"
   build_target="$(awk -F': ' '$1 == "Build target" { print $2; exit }' "$build_manifest")"
   jobs="$(awk -F': ' '$1 == "Jobs" { print $2; exit }' "$build_manifest")"
   rules_runner="$(awk -F': ' '$1 == "Rules runner" { print $2; exit }' "$build_manifest")"
+fi
+
+if [ "$SOURCE_URL_EXPLICIT" != "true" ] && [ -n "$manifest_source_url" ]; then
+  SOURCE_URL="$manifest_source_url"
+fi
+if [ "$SOURCE_BRANCH_EXPLICIT" != "true" ] && [ -n "$manifest_source_ref" ]; then
+  SOURCE_BRANCH="$manifest_source_ref"
+fi
+
+if [ -n "$manifest_source_url" ] && [ "$SOURCE_URL" != "$manifest_source_url" ]; then
+  echo "--source-url does not match the URL recorded by the build manifest." >&2
+  exit 1
+fi
+if [ -n "$manifest_source_ref" ] && [ "$SOURCE_BRANCH" != "$manifest_source_ref" ]; then
+  echo "--source-branch does not match the ref recorded by the build manifest." >&2
+  exit 1
 fi
 
 repo_commit="$(git rev-parse HEAD)"
@@ -555,11 +591,73 @@ fi
 
 if [ "$SOURCE_ASSET_COUNT" -gt 0 ]; then
   for source_asset in "${SOURCE_ASSETS[@]}"; do
-    if [ ! -f "$source_asset" ]; then
-      echo "Source asset not found: $source_asset" >&2
+    if [ ! -f "$source_asset" ] || [ -L "$source_asset" ]; then
+      echo "Source asset must be a regular, non-symlinked file: $source_asset" >&2
       exit 1
     fi
   done
+fi
+
+if [ "$SOURCE_ASSET_COUNT" -gt 0 ]; then
+  if [ ! -f "$build_manifest" ] || [ -L "$build_manifest" ]; then
+    echo "Refusing publishable assets without a kernel build manifest: $build_manifest" >&2
+    echo "Pass --artifacts-dir for the exact build being released." >&2
+    exit 1
+  fi
+
+  case "$source_mode" in
+    git)
+      if [[ ! "$source_head" =~ ^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$ ]]; then
+        echo "Git build manifest has a missing or invalid immutable Source HEAD." >&2
+        exit 1
+      fi
+      if [ -z "$manifest_source_url" ] && [ "$SOURCE_URL_EXPLICIT" != "true" ]; then
+        echo "Git build manifest has no Source URL; pass --source-url explicitly." >&2
+        exit 1
+      fi
+      if [ -z "$manifest_source_ref" ] && [ "$SOURCE_BRANCH_EXPLICIT" != "true" ]; then
+        echo "Git build manifest has no Source ref; pass --source-branch explicitly." >&2
+        exit 1
+      fi
+      ;;
+    apt)
+      if [ -z "$apt_source_spec" ]; then
+        echo "Apt build manifest has no exact Apt source spec." >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Build manifest has a missing or unsupported Source mode: ${source_mode:-unknown}" >&2
+      exit 1
+      ;;
+  esac
+
+  for required_build_field in "$build_target" "$jobs" "$rules_runner"; do
+    if [ -z "$required_build_field" ] || [ "$required_build_field" = "unknown" ]; then
+      echo "Build manifest is missing target, jobs, or rules-runner provenance." >&2
+      exit 1
+    fi
+  done
+
+  if [ -z "$manifest_patch_dirs" ]; then
+    echo "Build manifest does not record its patch directory or directories." >&2
+    exit 1
+  fi
+
+  manifest_patch_basenames=()
+  for manifest_patch_dir in $manifest_patch_dirs; do
+    manifest_patch_basenames+=("$(basename "$manifest_patch_dir")")
+  done
+  release_patch_basenames=()
+  for patch_dir in "${PATCH_DIRS[@]}"; do
+    release_patch_basenames+=("$(basename "$patch_dir")")
+  done
+  if [ "${manifest_patch_basenames[*]}" != "${release_patch_basenames[*]}" ]; then
+    echo "Release patch directories do not match the ordered build manifest patch directories." >&2
+    echo "Build: ${manifest_patch_basenames[*]}" >&2
+    echo "Release: ${release_patch_basenames[*]}" >&2
+    exit 1
+  fi
 fi
 
 if [ "$SOURCE_ASSET_COUNT" -gt 0 ]; then
@@ -697,6 +795,9 @@ fi
   echo "Source URL: ${SOURCE_URL:-unknown}"
   echo "Source branch: ${SOURCE_BRANCH:-unknown}"
   echo "Source HEAD: ${source_head:-unknown}"
+  if [ "$source_mode" = "apt" ]; then
+    echo "Apt source spec: ${apt_source_spec:-unknown}"
+  fi
   echo "Docker image: $DOCKER_IMAGE"
   echo "Build target: ${build_target:-unknown}"
   echo "Jobs: ${jobs:-unknown}"
@@ -751,11 +852,13 @@ fi
   echo
   echo "## Patches"
   echo
-  find "$PATCH_DIR" -maxdepth 1 -type f -name '*.patch' | sort | while IFS= read -r patch; do
-    base="$(basename "$patch")"
-    sha="$(shasum -a 256 "$patch" | awk '{print $1}')"
-    echo "- $base"
-    echo "  - SHA256: $sha"
+  for patch_dir in "${PATCH_DIRS[@]}"; do
+    find "$patch_dir" -maxdepth 1 -type f -name '*.patch' | sort | while IFS= read -r patch; do
+      base="$(basename "$patch")"
+      sha="$(shasum -a 256 "$patch" | awk '{print $1}')"
+      echo "- $patch_dir/$base"
+      echo "  - SHA256: $sha"
+    done
   done
 } > "$OUT_DIR/sp11-kernel-release-manifest.txt"
 
@@ -833,9 +936,17 @@ Recorded source:
 - Source URL: \`${SOURCE_URL:-unknown}\`
 - Source ref: \`${SOURCE_BRANCH:-unknown}\`
 - Source HEAD: \`${source_head:-unknown}\`
-- Docker image: \`$DOCKER_IMAGE\`
-- Patch directory: \`$PATCH_DIR\`
 EOF
+
+if [ "$source_mode" = "apt" ]; then
+  echo "- Apt source spec: \`${apt_source_spec:-unknown}\`" >> "$OUT_DIR/RELEASE-NOTES.md"
+fi
+
+echo "- Docker image: \`$DOCKER_IMAGE\`" >> "$OUT_DIR/RELEASE-NOTES.md"
+
+for patch_dir in "${PATCH_DIRS[@]}"; do
+  echo "- Patch directory: \`$patch_dir\`" >> "$OUT_DIR/RELEASE-NOTES.md"
+done
 
 if [ "$TOUCHSCREEN_ENABLED" = "true" ]; then
   cat >> "$OUT_DIR/RELEASE-NOTES.md" <<EOF

--- a/scripts/validate-sp11-touchscreen-release.sh
+++ b/scripts/validate-sp11-touchscreen-release.sh
@@ -52,7 +52,7 @@ have_tool() {
 
 cleanup() {
   local path
-  for path in "${TEMP_DIRS[@]}"; do
+  for path in "${TEMP_DIRS[@]-}"; do
     if [ -n "$path" ] && [ -d "$path" ]; then
       rm -rf -- "$path"
     fi
@@ -392,6 +392,50 @@ else
   fi
   if [ -n "$dirty_value" ] && [ "$dirty_value" != "false" ]; then
     error "release manifest records a dirty support repository: $dirty_value"
+  fi
+
+  if ! grep -Fq "No source assets included." "$release_manifest"; then
+    manifest_source_mode="$(single_manifest_value "$release_manifest" "Source mode" 2>/dev/null || true)"
+    manifest_source_url="$(single_manifest_value "$release_manifest" "Source URL" 2>/dev/null || true)"
+    manifest_source_ref="$(single_manifest_value "$release_manifest" "Source branch" 2>/dev/null || true)"
+    manifest_source_head="$(single_manifest_value "$release_manifest" "Source HEAD" 2>/dev/null || true)"
+    manifest_docker_image="$(single_manifest_value "$release_manifest" "Docker image" 2>/dev/null || true)"
+    manifest_build_target="$(single_manifest_value "$release_manifest" "Build target" 2>/dev/null || true)"
+    manifest_jobs="$(single_manifest_value "$release_manifest" "Jobs" 2>/dev/null || true)"
+    manifest_rules_runner="$(single_manifest_value "$release_manifest" "Rules runner" 2>/dev/null || true)"
+
+    for provenance_value in \
+      "$manifest_source_mode" "$manifest_source_url" "$manifest_source_ref" \
+      "$manifest_docker_image" "$manifest_build_target" "$manifest_jobs" \
+      "$manifest_rules_runner"; do
+      if [ -z "$provenance_value" ] || [ "$provenance_value" = "unknown" ]; then
+        error "publishable release manifest has missing or unknown build provenance."
+        break
+      fi
+    done
+
+    case "$manifest_source_mode" in
+      git)
+        if [[ ! "$manifest_source_head" =~ ^[0-9A-Fa-f]{40}([0-9A-Fa-f]{24})?$ ]]; then
+          error "git release manifest Source HEAD must be an immutable 40- or 64-hex commit."
+        fi
+        ;;
+      apt)
+        manifest_apt_source_spec="$(single_manifest_value "$release_manifest" "Apt source spec" 2>/dev/null || true)"
+        if [ -z "$manifest_apt_source_spec" ] || [ "$manifest_apt_source_spec" = "unknown" ]; then
+          error "apt release manifest must record an exact Apt source spec."
+        fi
+        ;;
+      *)
+        error "release manifest Source mode must be git or apt, got '${manifest_source_mode:-missing}'."
+        ;;
+    esac
+
+    [[ "$manifest_jobs" =~ ^[1-9][0-9]*$ ]] || \
+      error "release manifest Jobs must be a positive integer."
+    grep -Eq '^- patches/.+\.patch$' "$release_manifest" || \
+      error "publishable release manifest does not record repository-relative patch assets."
+    checked
   fi
 
   for deb in "${deb_files[@]}"; do


### PR DESCRIPTION
## Summary

- Pin the SP11 7.2-rc5 release workflow to the immutable Johan G. source tag and record the exact source URL, ref, and commit in build and release provenance.
- Require publishable kernel bundles to include the matching build manifest, corresponding source, and every ordered patch directory used by the build.
- Bind both kernel and live-image publication commands to the recorded support commit with an explicit `--target`.
- Correct the source-archive, kernel-install, audio, live-session, and post-publication validation guidance discovered during the r1 release rehearsal.
- Record the owner-authorized experimental-prerelease exception while keeping the physical clean-install matrix as the gate for stable or hardware-qualified promotion.

## Why

The corrective-release rehearsal exposed three provenance and packaging hazards. The first kernel draft silently used the generic Launchpad defaults and recorded an unknown source commit because it was prepared without the exact build-artifacts directory. The release helper could also record only one patch directory even though this kernel uses the Johan G. annotations patch followed by the three SP11 v3 patches. Finally, the documented source recipe archived the entire post-build worktree, which would have included several gigabytes of transient build output.

The image release helper also printed a publication command without an explicit target, and its generic notes did not distinguish the concept ISO's live casper kernel from the custom kernel and touchscreen modules carried for installed-system deployment.

## Key changes

- Record the Git source URL and ref in future kernel build manifests.
- Make `--patch-dir` repeatable and require its ordered set to match the exact build manifest before producing publishable assets.
- Reject public kernel bundles with missing build manifests, unknown build provenance, mismatched source metadata, symlinked source inputs, or missing corresponding source.
- Extend the semantic release validator to reject publishable manifests with incomplete Git or apt provenance.
- Generate image and kernel publication commands with `--target <support-commit>`.
- Document a tracked-files-only patched-source archive that excludes generated objects and packaging output.
- Update the README, build, reinstall, audio, release, and ADR guidance for the immutable v3 r1 bundle and its complete four-package plus three-module transaction.
- State that the live environment still boots the concept ISO's casper kernel; the v3 payload enables touchscreen support only after guarded installation.

## Validation

- Built the fresh `7.2-rc5-jg-0sp11v3-qcom-x1e` package set from `jg/ubuntu-qcom-x1e-7.2-rc5-jg-0` at `8f953dd060bc6e8fb86ca2ea8a92f258141c0169` using both ordered patch directories.
- Proved the retained patched source tree is exactly the immutable upstream commit plus the four repository patches.
- Created an integrity-checked corresponding-source archive containing one top-level directory and 95,141 Git-tracked files, with no transient build output.
- Passed all 198 tests from the pinned Phase 91 touchscreen source.
- Passed 13 semantic release checks across package roles, ABI, dependencies, module identities, vermagic, source versions, aliases, parameters, provenance, checksums, and packaged touchscreen DTBs.
- Verified missing and mismatched module bundles are rejected before package mutation.
- Extracted the four packages, three modules, and module manifest from the validated raw image and matched them byte-for-byte with the curated payload.
- Passed shell syntax, whitespace, negative provenance, checksum, source-integrity, and public-data hygiene checks.

## Experimental release gate

The r1 kernel and image are authorized for publication as experimental prereleases so community testing can proceed. They are not clean-install validated or hardware-qualified. Physical SP11 coverage for clean install, stale-initramfs repair, reinstall idempotency, both boot-image backends, cold boot, Windows-to-Linux transition, suspend/resume, and default controller initialization remains required before stable or hardware-qualified promotion.
