### PR TITLE
[SP11-51] Fix image release-note generation

### DIFF
--- a/scripts/prepare-sp11-image-release-assets.sh
+++ b/scripts/prepare-sp11-image-release-assets.sh
@@ -309,9 +309,9 @@ installer ISO, and should be written only to the intended removable device.
 ## Installed-system payloads
 
 The live environment boots the concept ISO's casper kernel. A custom kernel or
-module bundle stored under `SP11DATA/payload/kernel-debs` is available only to
+module bundle stored under \`SP11DATA/payload/kernel-debs\` is available only to
 the guarded installed-system flow; it does not replace the live-session kernel.
-Check `$OUTLINE_NAME` for the exact payload carried by this image.
+Check \`$OUTLINE_NAME\` for the exact payload carried by this image.
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- Escape two Markdown code spans in the image release-note heredoc.
- Preserve the literal `SP11DATA/payload/kernel-debs` and generated outline filename in `RELEASE-NOTES.md`.

## Why

The real release-preparation run showed that the unquoted heredoc interpreted the new backticks as shell command substitutions. The script completed, but printed command errors and omitted both values from the generated notes. No GitHub release was created.

## Validation

- `bash -n scripts/prepare-sp11-image-release-assets.sh`
- Verified the release-note heredoc contains no unescaped backticks.
- `git diff --check`
