### PR TITLE
sp11: rc-branch rc6 build, ubuntu:26.04 image default, CI defaults, ADR-0057

### DIFF
--- a/.github/workflows/sp11-kernel-build.yml
+++ b/.github/workflows/sp11-kernel-build.yml
@@ -13,12 +13,12 @@ on:
       git-branch:
         description: "Kernel git branch or tag"
         required: true
-        default: "sp11/integration-7.2-rc5"
+        default: "sp11/integration-7.2-rc"
         type: string
       patch-dirs:
-        description: "Space-separated patch directories (relative to repo root)"
-        required: true
-        default: "patches/jglathe-qcom-x1e-7.2-rc5 patches/sp11-qcom-x1e-7.2-rc5-v3"
+        description: "Space-separated patch directories (relative to repo root); empty for in-tree integration builds"
+        required: false
+        default: ""
         type: string
       docker-image:
         description: "Docker image for the build container"
@@ -100,11 +100,14 @@ jobs:
         id: release-assets
         if: ${{ inputs.release }}
         run: |
+          patch_args=()
+          for d in ${{ inputs.patch-dirs }}; do
+            patch_args+=(--patch-dir "$d")
+          done
           ./scripts/prepare-sp11-kernel-release-assets.sh \
             --kernel-debs-dir payload/kernel-debs \
             --artifacts-dir build/docker-sp11-kernel/artifacts \
-            --patch-dir patches/jglathe-qcom-x1e-7.2-rc5 \
-            --patch-dir patches/sp11-qcom-x1e-7.2-rc5-v3 \
+            "${patch_args[@]}" \
             --source-url "${{ inputs.git-url }}" \
             --source-branch "${{ inputs.git-branch }}" \
             --docker-image "${{ inputs.docker-image }}" \

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ list for the upstream Arch status.
 | USB-C boot | ✅ Working with `--grub-mode direct` | The normal GRUB menu can display entries but input and timeout are unreliable. Use `--grub-mode direct` for the verified live-USB path. |
 | Wi-Fi | ✅ Working | WCN7850/Qualcomm FastConnect 7800 binds to `ath12k_wifi7_pci`, loads firmware, scans, reconnects to a saved network after reboot, and passes traffic on patched git-fallback `7.0.0-22-qcom-x1e` plus an rfkill-capable Denali DTB. Stock/upgraded `7.0.0-32-qcom-x1e` remained hard-blocked. Uses a [kernel hack to disable rfkill](https://github.com/dwhinham/kernel-surface-pro-11/commit/fcc769be9eaa9823d55e98a28402104621fa6784). Continue validating normal reboots, suspend/resume, and package upgrades. |
 | Bluetooth | ✅ Working | Public address set via raw `AF_BLUETOOTH` socket C helper (`tools/sp11-bt-set-addr.c`) before `bluetooth.service` starts, avoiding the btmgmt D-state hang. Cold boot service succeeds at T+1s. Pairing, audio, and suspend/resume still need validation. See [how-to-bring-up-bluetooth](docs/how-to/how-to-bring-up-bluetooth.md). |
-| Audio — speakers | ✅ Working on installed v6 kernel | Both physical speakers receive the stereo mix through a PipeWire manual sink with reordered `audio.position` labels — the 4-channel PCM is a transport layout mapping physical slots 0 and 2, not a DAPM bypass ([ADR-0036](docs/adr/adr-0036-right-speaker-audio-position-reorder.md)). The v6 integration kernel carries the wsa884x 2S/4-ohm PA-recovery profile, which fixes the left-speaker audio wedge at sustained full volume ([ADR-0056](docs/adr/adr-0056-sp11-7-2-rc5-jg-0sp11v6-integration-build.md)). `sp11-wsa-routing.service` applies the WSA path with PCM1 closed and exercises a fresh graph at boot, replacing the superseded alsactl boot-race fix ([ADR-0035](docs/adr/adr-0035-audio-boot-race-alsactl.md)). PA Volume is capped at raw 6 (0 dB) and the digital volumes at 81 (−3 dB) by the machine driver; the volume-slider taper is stock cubic, with a log-dB taper accepted but not yet implemented ([ADR-0055](docs/adr/adr-0055-audio-volume-taper-log-db.md)). See [`how-to-bring-up-audio`](docs/how-to/how-to-bring-up-audio.md). |
+| Audio — speakers | ✅ Working on installed v6 kernel | Both physical speakers receive the stereo mix through a PipeWire manual sink with reordered `audio.position` labels — the 4-channel PCM is a transport layout mapping physical slots 0 and 2, not a DAPM bypass ([ADR-0036](docs/adr/adr-0036-right-speaker-audio-position-reorder.md)). The rc6 integration kernel (`7.2-rc6-jg-0sp11v6`) carries the wsa884x 2S/4-ohm PA-recovery profile, which fixes the left-speaker audio wedge at sustained full volume ([ADR-0057](docs/adr/adr-0057-sp11-7-2-rc6-jg-0sp11v6-rc-branch-build.md), [ADR-0056](docs/adr/adr-0056-sp11-7-2-rc5-jg-0sp11v6-integration-build.md)). `sp11-wsa-routing.service` applies the WSA path with PCM1 closed and exercises a fresh graph at boot, replacing the superseded alsactl boot-race fix ([ADR-0035](docs/adr/adr-0035-audio-boot-race-alsactl.md)). PA Volume is capped at raw 6 (0 dB) and the digital volumes at 81 (−3 dB) by the machine driver; the volume-slider taper is stock cubic, with a log-dB taper accepted but not yet implemented ([ADR-0055](docs/adr/adr-0055-audio-volume-taper-log-db.md)). See [`how-to-bring-up-audio`](docs/how-to/how-to-bring-up-audio.md). |
 | Audio — microphone | ✅ Working with 2.4 MHz DMIC clock | The corrected single-WSA-macro UCM profile exposes two-channel internal microphone capture, and Surface-specific unity gain avoids the shared +16 dB default clipping. Setting the Denali DMIC clock to 2.4 MHz eliminates the continuous feedback/static heard at 4.8 MHz and makes recorded speech dramatically clearer. Capture remains slightly tinny or thin. See [ADR-0044](docs/adr/adr-0044-sp11-ucm-single-wsa-macro-microphone.md) and [ADR-0046](docs/adr/adr-0046-sp11-default-2p4mhz-dmic-clock.md). |
-| Touchscreen | ✅ Working on installed v6 system | MSHW0485 G6 touchscreen over SE2 QSPI (`spi@a88000`) with GPI DMA, now carried **in-tree** on the 7.2-rc5 v6 build (`7.2-rc5-jg-0sp11v6`) as the phase55 `mshw0485_touch`, `spi-geni-qcom`, and `gpi` drivers — no out-of-tree module install. Multi-touch, pinch/zoom, and three-finger gestures work, and sound is verified on the same build. Supersedes the v3 geocausa OOT-module approach. See [ADR-0054](docs/adr/adr-0054-sp11-7-2-rc5-jg-0sp11v4-intree-touchscreen-build.md) and [ADR-0049](docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md). |
+| Touchscreen | ✅ Working on installed v6 system | MSHW0485 G6 touchscreen over SE2 QSPI (`spi@a88000`) with GPI DMA, now carried **in-tree** on the 7.2-rc6 build (`7.2-rc6-jg-0sp11v6`) as the phase55 `mshw0485_touch`, `spi-geni-qcom`, and `gpi` drivers — no out-of-tree module install. Multi-touch, pinch/zoom, and three-finger gestures work, and sound is verified on the same build. Supersedes the v3 geocausa OOT-module approach. See [ADR-0054](docs/adr/adr-0054-sp11-7-2-rc5-jg-0sp11v4-intree-touchscreen-build.md) and [ADR-0049](docs/adr/adr-0049-sp11-7-2-rc5-jg-0sp11v3-touchscreen-build.md). |
 | Pen | ❌ Not working | Not working in live USB. Upstream Arch notes also list pen as not working. |
 | Touchpad | ✅ Working | Type Cover touchpad works after the kernel loads `i2c-hid-of` and the `gpio` keys. Hot-plug may need re-binding. |
 | Suspend/Resume | ⚠️ Partially | Lid suspend works with kernel `6.10+`, but can fail to resume display. |
@@ -69,7 +69,18 @@ Surface Pro 11 device tree at boot. This avoids remastering the Ubuntu ISO.
 cd /path/to/linux-surface-pro-11-oe
 mkdir -p build
 
-# Default: Ubuntu concept kernel
+# Default: current SP11 integration (7.2-rc6-jg-0sp11v6, in-tree delta, ubuntu:26.04)
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/ooaklee/linux_ms_dev_kit-sp11.git \
+  --git-branch sp11/integration-7.2-rc \
+  --image ubuntu:26.04 \
+  --build-target "binary-indep binary-qcom-x1e" \
+  --work-dir build/docker-sp11-qcom-x1e-kernel \
+  --linux-work-volume sp11-kernel-build-ci \
+  --copy-to-payload --reset-source --jobs 8
+
+# OR: Ubuntu concept kernel
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
   --source git --work-dir build/docker-sp11-qcom-x1e-kernel \
   --patch-dir patches/ubuntu-qcom-x1e-7.0 \
@@ -406,9 +417,9 @@ sudo ./scripts/sp11-audio-topology.sh --install
 Alternatively, download the
 [audio topology and UCM v2 release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-audio-topology-v2).
 Pair the corrected UCM with the newest kernel bundle
-[v6 (7.2-rc5-jg-0sp11v6)](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc5-jg-0sp11v6),
+[v6 rc6 (7.2-rc6-jg-0sp11v6)](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc6-jg-0sp11v6),
 built from the
-[`sp11/integration-7.2-rc5`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/tree/sp11/integration-7.2-rc5)
+[`sp11/integration-7.2-rc`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/tree/sp11/integration-7.2-rc)
 fork: it carries the wsa884x 2S/4-ohm PA-recovery profile (no left-speaker
 audio wedge at sustained full volume), the 2.4 MHz DMIC clock, and the
 in-tree phase55 touchscreen

--- a/docs/adr/adr-0057-sp11-7-2-rc6-jg-0sp11v6-rc-branch-build.md
+++ b/docs/adr/adr-0057-sp11-7-2-rc6-jg-0sp11v6-rc-branch-build.md
@@ -1,0 +1,81 @@
+---
+id: adr-0057-sp11-7-2-rc6-jg-0sp11v6-rc-branch-build
+title: "ADR0057: SP11 7.2-rc6-jg-0sp11v6 rc-Branch Integration Build"
+# prettier-ignore
+description: Architecture Decision Record (ADR) for the Surface Pro 11 v6 rc6 kernel, built from the sp11/integration-7.2-rc branch of the ooaklee/linux_ms_dev_kit-sp11 fork on the jglathe 7.2-rc6 base.
+---
+
+# ADR0057: SP11 7.2-rc6-jg-0sp11v6 rc-Branch Integration Build
+
+## Status
+
+Accepted and hardware-verified (2026-08-18). The
+`7.2-rc6-jg-0sp11v6-qcom-x1e` kernel is installed on the X1E80100 OLED
+device: the kernel boots, the in-tree phase55 touchscreen works, and Wi-Fi
+reconnects to the saved network on the new base. The build uses the same
+SP11 integration delta as
+[ADR-0056](adr-0056-sp11-7-2-rc5-jg-0sp11v6-integration-build.md), carried
+forward onto the jglathe `7.2-rc6` base.
+
+## Context
+
+[ADR-0056](adr-0056-sp11-7-2-rc5-jg-0sp11v6-integration-build.md) built the
+v6 kernel from `sp11/integration-7.2-rc5` at `7ee4adb3cb57f` (merge of pull
+request #8) with the wsa884x PA-recovery profile and the in-tree phase55
+touchscreen. jglathe subsequently published the `7.2-rc6` line, and the SP11
+integration branch was renamed to `sp11/integration-7.2-rc` (pull request
+#10) after absorbing the rc6 sync (pull request #9, `11c2e9198d914`).
+
+The integration CI validator regressed at the rename: the checkpatch gate
+scoped the style check to the first-parent line only when HEAD was the
+upstream-sync merge, so once the rc6 tree entered the first-parent line the
+gate started flagging upstream style patterns (for example an AMD display
+driver `CODE_INDENT` error in `dce_clock_source.c`). Commit `e4dd61d2cb5f`
+(`ci: scope checkpatch gate to the SP11-authored delta`) scopes the gate to
+files the SP11 integration actually authored or modified; upstream-only
+findings are reported for review without failing the build.
+
+## Decision
+
+Build the Surface Pro 11 kernel from the `sp11/integration-7.2-rc` branch of
+`ooaklee/linux_ms_dev_kit-sp11` at commit
+`5506be83f8084731b2d6c29f51266cd9365c7aa3` (merge of pull request #10,
+`sp11/ci-track-renamed-branch`), using Debian ABI `0sp11v6` and kernel
+release `7.2-rc6-jg-0sp11v6-qcom-x1e`. Apply no local patches at build time;
+the branch carries the full SP11 delta on the jglathe `7.2-rc6-jg-0` base.
+
+## Decision details
+
+The integration branch at the rc6 build head carries, on top of the jglathe
+`7.2-rc6-jg-0` base:
+
+- In-tree phase55 MSHW0485 touchscreen stack (`mshw0485_touch`,
+  `spi-geni-qcom` QSPI, `gpi` QSPI)
+- `ASoC: wsa884x: recover PA faults and apply SP11 2S 4-ohm profile`
+  (`40932bba5`): 2S supply detection, latched PA-fault recovery, and the
+  2S/4-ohm OCP/PBR profile
+- SP11 v6 package naming (`604fad833`), checkpatch cleanup (`0b1fb2d48`),
+  and the CI checkpatch scoping fix (`e4dd61d2cb5f`)
+- DP link-rate workaround (PR #2) and DWC3 USB resume quirk (PR #3)
+- PSCI cluster idle-state disable (PR #5), volume rocker (PR #6), and
+  platform-profile/fan (PR #7)
+
+Build: docker container `sp11-kernel-build-ci` on `ubuntu:26.04`, targets
+`binary-indep binary-qcom-x1e`, jobs 8. The `ubuntu:26.04` image is the
+required default for the rc line (the kernel `debian/rules.d` hardcodes
+`gcc-15`); the build script now defaults to it for `sp11/*` and
+`jg/ubuntu-qcom-x1e-*` git branches.
+
+## Consequences
+
+- Single-source build: no local patches and no out-of-tree module bundle.
+- The wsa884x 2S/4-ohm profile and PA-recovery logic are carried unchanged
+  from v6; the machine driver caps the PA Volume controls at raw 6 (0 dB)
+  and the digital volumes at 81 (-3 dB).
+- The CI validator gates only the SP11-authored delta; upstream style
+  findings no longer fail the integration checks.
+- The rc6 build initially omitted the arch-all package; a rebuild with
+  targets `binary-indep binary-qcom-x1e` is required to produce
+  `linux-qcom-x1e-headers-7.2-rc6-jg-0sp11v6` for the release.
+- Release `sp11-qcom-x1e-7.2-rc6-jg-0sp11v6` is prepared with debs,
+  `SHA256SUMS`, release manifest, and source tarball.

--- a/scripts/build-sp11-qcom-x1e-kernel-docker.sh
+++ b/scripts/build-sp11-qcom-x1e-kernel-docker.sh
@@ -47,8 +47,9 @@ Options:
   --source-version VER   apt source version. Usually comes from --metadata.
   --git-url URL          Kernel git URL for git mode.
   --git-branch BRANCH    Kernel git branch or tag for git mode.
-  --image IMAGE          Docker image. Defaults to ubuntu:26.04 for apt mode
-                         and ubuntu:25.10 for git mode.
+  --image IMAGE          Docker image. Defaults to ubuntu:26.04 for apt mode and for
+                         the sp11/ and jg/ubuntu-qcom-x1e- git branches;
+                         ubuntu:25.10 is the fallback for other git branches.
   --platform PLATFORM    Docker platform, default $PLATFORM.
   --work-dir DIR         Host control/artifact directory, default $WORK_DIR.
   --container-work-dir DIR
@@ -297,6 +298,7 @@ if [ -z "$IMAGE" ]; then
   case "$SOURCE_MODE" in
     git)
       case "$GIT_BRANCH" in
+        sp11/*) IMAGE="ubuntu:26.04" ;;
         jg/ubuntu-qcom-x1e-*) IMAGE="ubuntu:26.04" ;;
         *) IMAGE="ubuntu:25.10" ;;
       esac


### PR DESCRIPTION
## Summary

Makes the current SP11 rc6 build flow live in this repo and records the rc6 integration build (ADR-0057).

## Changes

- **`scripts/build-sp11-qcom-x1e-kernel-docker.sh`**: git-mode default image is now `ubuntu:26.04` for `sp11/*` and `jg/ubuntu-qcom-x1e-*` branches (the rc line's `debian/rules.d` hardcodes `gcc-15`, which only 26.04 provides); `ubuntu:25.10` remains the fallback for other branches. Usage text updated.
- **`.github/workflows/sp11-kernel-build.yml`**: default source branch `sp11/integration-7.2-rc` (renamed from `-rc5`); `patch-dirs` is now optional and defaults empty for in-tree integration builds; release-prep passes `--patch-dir` only when provided.
- **`README.md`**: status rows updated to the installed rc6 kernel (`7.2-rc6-jg-0sp11v6`), primary build example is the current integration flow, branch and bundle links updated to the rc branch / rc6 release tag.
- **`docs/adr/adr-0057-...rc-branch-build.md`**: records the rc6 integration build (branch rename, 7.2-rc6 base, CI checkpatch scoping fix, `ubuntu:26.04` requirement, missing arch-all headers note).

## Follow-ups

- Rebuild the arch-all headers package (`linux-qcom-x1e-headers-7.2-rc6-jg-0sp11v6`) and publish release `sp11-qcom-x1e-7.2-rc6-jg-0sp11v6`.