### PR TITLE
sp11: pair audio topology with v7 kernel bundle, mark ADR-0058 verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,9 +417,9 @@ sudo ./scripts/sp11-audio-topology.sh --install
 Alternatively, download the
 [audio topology and UCM v2 release](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-audio-topology-v2).
 Pair the corrected UCM with the newest kernel bundle
-[v6 rc6 (7.2-rc6-jg-0sp11v6)](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2-rc6-jg-0sp11v6),
+[v7 (7.2.0-jg-0sp11v7)](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2.0-jg-0sp11v7),
 built from the
-[`sp11/integration-7.2-rc`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/tree/sp11/integration-7.2-rc)
+[`sp11/integration-7.2.x`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/tree/sp11/integration-7.2.x)
 fork: it carries the wsa884x 2S/4-ohm PA-recovery profile (no left-speaker
 audio wedge at sustained full volume), the 2.4 MHz DMIC clock, and the
 in-tree phase55 touchscreen

--- a/docs/adr/adr-0058-sp11-7-2-0-jg-0sp11v7-non-rc-integration-line.md
+++ b/docs/adr/adr-0058-sp11-7-2-0-jg-0sp11v7-non-rc-integration-line.md
@@ -9,10 +9,12 @@ description: Architecture Decision Record (ADR) for the Surface Pro 11 non-rc in
 
 ## Status
 
-Accepted (2026-08-18). The `sp11/integration-7.2.x` branch is the new
-default integration line for non-rc Surface Pro 11 kernels, named
-`7.2.0-jg-0sp11v7`. The `sp11/integration-7.2-rc` branch continues to
-carry rc releases.
+Accepted and hardware-verified (2026-08-19). The
+`7.2.0-jg-0sp11v7-qcom-x1e` kernel is installed on the X1E80100 OLED
+device: the kernel boots, the in-tree phase55 touchscreen works, and
+Wi-Fi reconnects to the saved network. The `sp11/integration-7.2-rc`
+branch was retired after the 7.2.x line became the sole integration
+branch.
 
 ## Context
 
@@ -41,6 +43,6 @@ SP11 integration needed a non-rc line to track it.
 
 - The kernel build workflow defaults to `sp11/integration-7.2.x` for new
   non-rc builds.
-- The rc line remains for rc kernels; upstream syncs flow rc-first, then
-  into the 7.2.x line.
+- The `sp11/integration-7.2-rc` branch was retired; upstream syncs merge
+  directly into the 7.2.x line.
 - The v7 kernel package version is `7.2.0-jg-0sp11v7-qcom-x1e`.


### PR DESCRIPTION
The v7 (7.2.0-jg-0sp11v7) kernel release is live and hardware-verified.\n\n- README: audio-topology pairing -> v7 release on sp11/integration-7.2.x\n- ADR-0058: accepted and hardware-verified; rc-branch retirement recorded