### PR TITLE
fix: bridge Denali GPU firmware lookup

### DIFF
--- a/scripts/sp11-grab-fw.sh
+++ b/scripts/sp11-grab-fw.sh
@@ -143,6 +143,23 @@ install_fw_file() {
   echo "Installed $dst"
 }
 
+# Discussion: https://discourse.ubuntu.com/t/ubuntu-concept-snapdragon-x-elite/48800/1639
+link_gpu_denali_path() {
+  local generic="$DEST_PREFIX/qcom/x1e80100/microsoft/qcdxkmsuc8380.mbn"
+  local denali_dir="$DEST_PREFIX/qcom/x1e80100/microsoft/Denali"
+  local denali="$denali_dir/qcdxkmsuc8380.mbn"
+
+  if [ ! -f "$generic" ]; then
+    echo "Warning: GPU firmware not installed; expected $generic" >&2
+    return 0
+  fi
+
+  install -d -m 0755 "$denali_dir"
+  rm -f "$denali"
+  ln -s ../qcdxkmsuc8380.mbn "$denali"
+  echo "Linked $denali -> ../qcdxkmsuc8380.mbn"
+}
+
 latest_version() {
   curl -fsSL "$DRIVER_REPO_API_URL" |
     jq -r '.[] | select(.type == "dir") | .name' |
@@ -253,6 +270,11 @@ case "$MODE" in
   download) grab_download ;;
   windows) grab_windows ;;
 esac
+
+# The Denali kernel looks below microsoft/Denali, while the generic firmware
+# mapping uses microsoft/. Keep the canonical file and bridge the lookup with
+# a relative symlink.
+link_gpu_denali_path
 
 apply_adsp_policy
 


### PR DESCRIPTION
## Summary

- Keep `qcdxkmsuc8380.mbn` in the canonical `qcom/x1e80100/microsoft/` directory.
- Create `qcom/x1e80100/microsoft/Denali/qcdxkmsuc8380.mbn` as a relative symlink after firmware installation.
- Link the implementation comment to the Ubuntu Snapdragon X discussion post.

## Findings

The kernel's Surface Pro 11 Denali device-tree firmware mapping checks:

`qcom/x1e80100/microsoft/qcdxkmsuc8380.mbn`

The Denali firmware bundle and related remote-processor files are installed below:

`qcom/x1e80100/microsoft/Denali/`

The Ubuntu discussion documents the same split and the symlink workaround: https://discourse.ubuntu.com/t/ubuntu-concept-snapdragon-x-elite/48800/1639

On the installed Surface Pro 11 LCD, the GPU firmware was present in `microsoft/` and the Denali symlink was needed to bridge the alternate lookup. The firmware helper completed successfully and the initramfs was regenerated.

## Validation

- `bash -n scripts/sp11-grab-fw.sh`
- `git diff --check`
- Ran the helper with the latest WOA driver set (`200.0.49.0`) on an NVMe-installed system.
