### PR TITLE
usb4: add guarded SP11 v20 integration and isolated top-port test flow

### DIFF
--- a/.github/workflows/kernel-build-script-tests.yml
+++ b/.github/workflows/kernel-build-script-tests.yml
@@ -6,25 +6,35 @@ on:
   pull_request:
     paths:
       - ".github/workflows/kernel-build-script-tests.yml"
+      - "README.md"
+      - "docs/adr/adr-0068-sp11-usb4-dp-integration.md"
+      - "docs/how-to/how-to-test-sp11-usb4-dp.md"
       - "docs/how-to/how-to-release-kernel-artifacts.md"
+      - "scripts/collect-sp11-usb4-diagnostics.sh"
       - "scripts/build-sp11-qcom-x1e-kernel.sh"
       - "scripts/build-sp11-qcom-x1e-kernel-docker.sh"
       - "scripts/preflight-sp11-kernel-test.sh"
       - "scripts/prepare-sp11-kernel-release-assets.sh"
       - "tests/test-kernel-test-preflight.sh"
       - "tests/test-kernel-patch-selection.sh"
+      - "tests/test-usb4-integration-policy.sh"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/kernel-build-script-tests.yml"
+      - "README.md"
+      - "docs/adr/adr-0068-sp11-usb4-dp-integration.md"
+      - "docs/how-to/how-to-test-sp11-usb4-dp.md"
       - "docs/how-to/how-to-release-kernel-artifacts.md"
+      - "scripts/collect-sp11-usb4-diagnostics.sh"
       - "scripts/build-sp11-qcom-x1e-kernel.sh"
       - "scripts/build-sp11-qcom-x1e-kernel-docker.sh"
       - "scripts/preflight-sp11-kernel-test.sh"
       - "scripts/prepare-sp11-kernel-release-assets.sh"
       - "tests/test-kernel-test-preflight.sh"
       - "tests/test-kernel-patch-selection.sh"
+      - "tests/test-usb4-integration-policy.sh"
 
 permissions:
   contents: read
@@ -46,10 +56,12 @@ jobs:
           for script in \
             scripts/build-sp11-qcom-x1e-kernel.sh \
             scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+            scripts/collect-sp11-usb4-diagnostics.sh \
             scripts/preflight-sp11-kernel-test.sh \
             scripts/prepare-sp11-kernel-release-assets.sh \
             tests/test-kernel-test-preflight.sh \
-            tests/test-kernel-patch-selection.sh
+            tests/test-kernel-patch-selection.sh \
+            tests/test-usb4-integration-policy.sh
           do
             bash -n "$script"
           done
@@ -59,3 +71,6 @@ jobs:
 
       - name: Test distinct-ABI hardware-test preflight
         run: bash tests/test-kernel-test-preflight.sh
+
+      - name: Test guarded USB4 integration policy
+        run: bash tests/test-usb4-integration-policy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,14 @@ payload/**/*.img
 *.cab
 *.dtb
 *.elf
+*.etl
+*.evtx
 *.fw
 *.jsn
 *.mbn
+*.pdb
+*.sys
+*.tmf
 
 # Downloaded installers and generated disk images.
 *.iso

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ mkdir -p build
   --linux-work-volume sp11-kernel-build-ci \
   --copy-to-payload --reset-source --jobs 8
 
-# Experimental USB4 v20: public PHY groundwork; production USB4 stays disabled
+# Experimental USB4 v20: guarded normal image plus an opt-in top-port test image
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
   --source git \
   --git-url https://github.com/ooaklee/linux_ms_dev_kit-sp11.git \
@@ -93,7 +93,7 @@ mkdir -p build
 
 # The branch is mutable; accept this milestone only at the ADR-recorded head.
 grep -Fx \
-  'Source HEAD: e056649b9b56622fedd806134d4f79dcf251a2f0' \
+  'Source HEAD: 70ddec100fe953712c309067fe2db4d8207facc6' \
   build/docker-sp11-qcom-x1e-kernel-usb4-v20/artifacts/sp11-kernel-build-manifest.txt
 
 # OR: Ubuntu concept kernel

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ list for the upstream Arch status.
 | Graphics | ✅ Working | Direct boot reaches the Ubuntu desktop. 3D acceleration for X1E SoCs only; X1P support is on its way from upstream. |
 | Backlight | ✅ Working | Night Light and screen brightness controls work. X1E/OLED uses `/sys/class/backlight/dp_aux_backlight`; X1P/LCD uses the upstream `x1p64100-microsoft-denali.dtb` PWM-backlight path. |
 | USB3 | ⚠️ Partially | USB-C ports are working, but the Surface Dock connector is presumably not. |
-| USB4/Thunderbolt | ❌ Not working | No external display output when using the [official USB4 dock](https://learn.microsoft.com/en-us/surface/surface-usb4-dock). |
-| USB-C display output | ✅ Working | Working as of 6.15-rc6 (for DP alt mode). |
+| USB4/Thunderbolt | 🧪 PHY groundwork only | The independent v20 line carries Qualcomm's public USB43DP PHY series, but production keeps the PS8830 USB4-disable fallback. No host-router consumer is enabled, and the retimer-to-controller sideband path remains blocked in [issue 52](https://github.com/ooaklee/linux-surface-pro-11-oe/issues/52); no tunneled-display claim yet. See [kernel PR 24](https://github.com/ooaklee/linux_ms_dev_kit-sp11/pull/24) and [ADR0068](docs/adr/adr-0068-sp11-usb4-dp-integration.md). |
+| USB-C display output | ✅ Working | Direct DisplayPort Alt Mode works as of 6.15-rc6. This is separate from DisplayPort tunneled through USB4. |
 | USB-C boot | ✅ Working with `--grub-mode direct` | The normal GRUB menu can display entries but input and timeout are unreliable. Use `--grub-mode direct` for the verified live-USB path. |
 | Wi-Fi | ✅ Working | WCN7850/Qualcomm FastConnect 7800 binds to `ath12k_wifi7_pci`, loads firmware, scans, reconnects to a saved network after reboot, and passes traffic on patched git-fallback `7.0.0-22-qcom-x1e` plus an rfkill-capable Denali DTB. Stock/upgraded `7.0.0-32-qcom-x1e` remained hard-blocked. Uses a [kernel hack to disable rfkill](https://github.com/dwhinham/kernel-surface-pro-11/commit/fcc769be9eaa9823d55e98a28402104621fa6784). Continue validating normal reboots, suspend/resume, and package upgrades. |
 | Bluetooth | ✅ Working | Public address set via raw `AF_BLUETOOTH` socket C helper (`tools/sp11-bt-set-addr.c`) before `bluetooth.service` starts, avoiding the btmgmt D-state hang. Cold boot service succeeds at T+1s. Pairing, audio, and suspend/resume still need validation. See [how-to-bring-up-bluetooth](docs/how-to/how-to-bring-up-bluetooth.md). |
@@ -79,6 +79,22 @@ mkdir -p build
   --work-dir build/docker-sp11-qcom-x1e-kernel \
   --linux-work-volume sp11-kernel-build-ci \
   --copy-to-payload --reset-source --jobs 8
+
+# Experimental USB4 v20: public PHY groundwork; production USB4 stays disabled
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/ooaklee/linux_ms_dev_kit-sp11.git \
+  --git-branch sp11/integration-7.2.x-usb4-support \
+  --image ubuntu:26.04 \
+  --build-target "binary-indep binary-qcom-x1e" \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-usb4-v20 \
+  --linux-work-volume sp11-qcom-x1e-kernel-usb4-v20 \
+  --copy-to-payload --reset-source --jobs 8
+
+# The branch is mutable; accept this milestone only at the ADR-recorded head.
+grep -Fx \
+  'Source HEAD: e056649b9b56622fedd806134d4f79dcf251a2f0' \
+  build/docker-sp11-qcom-x1e-kernel-usb4-v20/artifacts/sp11-kernel-build-manifest.txt
 
 # OR: Ubuntu concept kernel
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \

--- a/docs/adr/adr-0068-sp11-usb4-dp-integration.md
+++ b/docs/adr/adr-0068-sp11-usb4-dp-integration.md
@@ -1,0 +1,242 @@
+---
+id: adr-0068-sp11-usb4-dp-integration
+title: "ADR0068: SP11 USB4 and DisplayPort Integration"
+# prettier-ignore
+description: Architecture Decision Record (ADR) for starting the Surface Pro 11 USB4 integration at kernel milestone v20 with public Qualcomm USB43DP PHY support, a production-safe retimer fallback, proprietary-firmware boundaries, and evidence-gated USB4 DisplayPort tunnelling.
+---
+
+# ADR0068: SP11 USB4 and DisplayPort Integration
+
+## Status
+
+Accepted for the source and static-build portion of the
+`7.2.0-jg-0sp11v20` implementation milestone on 2026-08-30. Runtime USB4
+enablement is not accepted: the production Denali device tree still disables
+USB4 at the PS8830 retimers, and this branch enables no host-router consumer.
+
+### Kernel integration record
+
+The implementation is reviewed in
+[linux_ms_dev_kit-sp11 PR 24](https://github.com/ooaklee/linux_ms_dev_kit-sp11/pull/24)
+on `sp11/integration-7.2.x-usb4-support`. This immutable record distinguishes
+the five public backports, the separate downstream lifecycle fix, and the
+packaging-only commits:
+
+| Role | Exact source |
+|---|---|
+| Linux 7.2 integration base | [`d915d679423e`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/d915d679423e002b27f60e6b27116a03e18a96d0) |
+| Public USB43DP binding | [`076072b40299`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/076072b402996a09319cf5985fad10e668a1d12e) |
+| Public TBT PHY mode | [`b343d089a705`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/b343d089a705665764648092624bd3afc05feb78) |
+| Public preliminary USB4 PHY lifecycle | [`d2ddf9dce2ef`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/d2ddf9dce2ef132b551f86ca32a57b473f66c0f3) |
+| Public Hamoa USB4/TBT3 configuration | [`c6d1b64af29f`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/c6d1b64af29f2f2a3b716d89e5f3194fcc2f1ca6) |
+| Public Hamoa PHY-to-router clocks | [`8564ca38642c`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/8564ca38642cade24dd02fc2ceb8fc3a22f8a275) |
+| Downstream ownership and rollback hardening; exact validated code head | [`5b5f1d124b7a`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/5b5f1d124b7ad43b9aac076ad65aa27fa3689ce9) |
+| `sp11v20` package boundary | [`bb0e70e6684a`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/bb0e70e6684ac1c41c59eeb6a7b3b5e2539b5d0f) |
+| Guarded-scope clarification; final kernel PR head | [`e056649b9b56`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/e056649b9b56622fedd806134d4f79dcf251a2f0) |
+| Upstream submission | [Qualcomm USB43DP PHY v4](https://patchew.org/linux/20260820-topic-usb4phy-v4-0-aec9d2cb31f6@oss.qualcomm.com/), mbox SHA-256 `cf05fc8da482ab8085cfe3eeb37798b62bc74c5b2a73f8e74a8cc9b0dc93d3e2` |
+
+## Context
+
+The Surface Pro 11 has two USB-C connectors. Direct USB-C DisplayPort Alt Mode
+already works. DisplayPort carried through a USB4 dock is a different path: it
+requires the USB4 host router, retimer sideband connection, link training, and
+USB4 Connection Manager to create a DisplayPort tunnel before DRM can drive the
+monitor.
+
+A private, reviewed same-device Windows capture reports a matched top-port
+attach with USB4, PCIe, and DisplayPort tunnels, but it does not disclose the
+retimer-to-controller sideband sequence needed by Linux. A publishable
+redacted derivative remains pending. This private report informs the later
+test matrix only; it is not committed, linked as public evidence, treated as
+source-code provenance, or counted as Linux runtime validation.
+
+The Linux 7.2 integration base already contains:
+
+- the non-PCI Thunderbolt NHI preparation series;
+- X1E80100 USB4 GCC clock and power-domain definitions;
+- both Denali Type-C connector graphs and PS8830 retimers;
+- USB4, Type-C Thunderbolt Alt Mode, PS8830, and QMP kernel configuration; and
+- `parade,disable-usb4`, which rejects USB4 negotiation and preserves working
+  direct DisplayPort Alt Mode while the router path is incomplete.
+
+Qualcomm's public
+[USB43DP PHY v4 series](https://patchew.org/linux/20260820-topic-usb4phy-v4-0-aec9d2cb31f6@oss.qualcomm.com/)
+adds the next independently useful layer. Its five patches define the USB4
+PHY specifier and TBT PHY mode, add USB4 lifecycle support to the QMP combo
+driver, provide X1E80100 electrical tables, and describe Hamoa's P2RR2P
+PHY-to-router clocks. The series was based on `next-20260820`; it is not yet in
+Linus's tree. Its cover letter explicitly says that a separate router driver
+will follow; no published, usable in-tree router implementation is part of the
+PHY series or this integration.
+
+[Issue 52](https://github.com/ooaklee/linux-surface-pro-11-oe/issues/52)
+bounds the current hardware failure. Experimental code can load controller
+firmware, initialize rings and DROM, register a USB4 domain and host router,
+enter the TBT QMP mode, and tell the PS8830 that TBT is connected. Link training
+does not start: the controller waits for its sideband receive connection and
+reports failure to read the sideband link configuration.
+
+The X1P-64-100 investigation in issue 52 also reports hard locks after raw
+reads of controller windows, attempted interrupt-sequence replay, and repeated
+USB4 power-domain activation. Those addresses are not a verified X1E80100
+register map and are deliberately not repeated here. Raw access and replay are
+prohibited on both variants. Until X1E recovery behavior is qualified, use the
+X1P result as a conservative rule: run at most one active USB4 experiment per
+cold power cycle and retain a known-good kernel recovery path.
+
+The old experimental host-router branches are evidence, not merge sources.
+They combine useful observations with proprietary firmware dependencies,
+unsafe register probes, generated binaries, logs, local artifacts, and
+retracted experiments. Merging one wholesale would make the integration less
+reviewable and could hard-lock the device.
+
+## Decision
+
+### Version and branch boundary
+
+USB4 work starts at `7.2.0-jg-0sp11v20` on
+`sp11/integration-7.2.x-usb4-support`. Versions v15 through v19 remain
+available to the independent pen and touch work. USB4 commits must remain
+independently reviewable and revertible; this branch does not absorb the open
+pen integration branches.
+
+### First v20 kernel increment
+
+Carry Qualcomm's five public USB43DP PHY v4 patches as provenance-preserving
+commits on top of the current `sp11/integration-7.2.x` branch. Patches 1, 2,
+and 5 retain stable public-series patch IDs; patches 3 and 4 contain only the
+contextual conflict resolution required by the 7.2 QMP refactor.
+
+Add one integration-specific commit after that series to track common-block,
+regulator, runtime-suspend, and physical USB ownership; make mode and
+orientation changes transactional; restore the former PHY state on failure;
+and reject unsafe DP-only or active-DisplayPort transitions. This hardening
+improves lifecycle correctness but is not runtime USB4 evidence.
+
+The v20 changelog must describe this as preliminary PHY groundwork. The PHY
+series alone does not establish full USB4 support, a USB4 domain, tunneled
+DisplayPort, tunneled PCIe, or dock parity.
+
+No kernel configuration change is needed for this increment. The qcom-x1e
+package policy already enables `CONFIG_PHY_QCOM_QMP_COMBO=y`, `CONFIG_USB4=m`,
+`CONFIG_USB4_CONFIGFS=m`, `CONFIG_USB4_NET=m`, the PS8830 mux, Qualcomm PMIC
+Type-C support, and the DisplayPort and Thunderbolt Alt Mode modules.
+
+### Production safety boundary
+
+Keep `parade,disable-usb4` on both production Denali PS8830 nodes. Do not add a
+production host-router node and do not make the USB4 sub-PHY a production
+consumer until the router, sideband, power, and recovery gates below pass.
+
+The QMP provider keeps runtime PM forbidden by default. Manually changing its
+runtime power policy to `auto` is outside the v20 production contract and must
+not be used until consumer teardown, direct DisplayPort, orientation changes,
+and router ownership have been qualified together.
+
+The first active USB4 experiment must use an explicitly named experimental DTB
+that is not selected by the normal boot entry. Its patch must contain no raw
+MMIO diagnostic interface, arbitrary register write, firmware-memory dump,
+debugfs write path, or user-triggered GDSC toggle.
+
+### Host-router integration boundary
+
+The next kernel series is gated on a reviewable Qualcomm host-router driver or
+a minimal downstream implementation derived from public interfaces. It must
+separate the following concerns into bisectable commits:
+
+1. a documented device-tree binding for clocks, resets, interconnects, IOMMU,
+   firmware, interrupts, NHI, and one router port;
+2. non-PCI NHI operations that avoid Intel-only capability, reset, and mailbox
+   registers;
+3. controller firmware loading and ring startup with bounded cleanup and
+   runtime power management;
+4. Type-C and retimer notification flow from PMIC GLINK through QMP, PS8830,
+   and the router;
+5. bounded Qualcomm revision-3 DROM trailing-entry tolerance;
+6. verified Denali per-port resources without guessing the physical
+   top/bottom-to-controller mapping; and
+7. a separate experimental DTB that enables one port at a time.
+
+The unresolved PS8830-to-UC sideband receive connection is a blocker, not an
+invitation to replay unverified Windows writes. If public documentation or a
+trace with matching symbols does not establish the sequence, the branch stays
+disabled.
+
+### Firmware and evidence policy
+
+The controller payload extracted from a Windows driver is proprietary. Follow
+[ADR0004](adr-0004-firmware-extraction-policy.md): do not commit, attach, or
+publish the payload, its containing Windows driver, raw ETL traces, or firmware
+memory dumps. A future extractor may copy an exact, user-owned payload into
+the documented `/lib/firmware/qcom/x1e80100/microsoft/Denali/` location, but it
+must be opt-in, deterministic, hash-verified, and tested only with synthetic
+fixtures in this repository.
+
+Any prebuilt v20 package follows
+[ADR0026](adr-0026-prebuilt-kernel-release-artifacts.md). It remains an
+experimental prerelease and includes exact source provenance and checksums,
+but no proprietary payload or private diagnostic archive.
+
+### Verification gates
+
+The PHY increment requires:
+
+- `git diff --check` and `scripts/checkpatch.pl` review;
+- QMP binding validation;
+- a warning-enabled ARM64 build of `phy-qcom-qmp-combo.o`;
+- builds of the X1E and X1P Denali DTBs; and
+- confirmation that both production retimer nodes retain
+  `parade,disable-usb4`.
+
+The source/static gates below were run against exact kernel-code head
+[`5b5f1d124b7a`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/5b5f1d124b7ad43b9aac076ad65aa27fa3689ce9).
+The final kernel PR head is its changelog-only descendant
+[`e056649b9b56`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/e056649b9b56622fedd806134d4f79dcf251a2f0).
+
+| Gate | Result |
+|---|---|
+| Public-series provenance | Pass: patches 1, 2, and 5 retain stable public-series patch IDs; patches 3 and 4 were compared hunk by hunk after 7.2 conflict resolution |
+| `git diff --check` | Pass |
+| Strict `checkpatch.pl` on downstream QMP hardening | Pass: 0 errors, 0 warnings, 0 checks; 652 lines checked |
+| `make ARCH=arm64 ubuntu_x1e_defconfig` | Pass |
+| `W=1` QMP combo-PHY object | Pass from a clean output tree |
+| `W=1` PS8830 mux and Thunderbolt core objects | Pass |
+| Targeted USB43DP binding validation | Pass with dtschema 2026.6 |
+| X1E OLED and X1P Denali DTBs | Pass |
+| Required kernel configuration | Pass; existing QMP, USB4, Type-C, PS8830, TBT Alt Mode, and direct-DP options remain enabled |
+| Production fallback | Pass; both Denali PS8830 nodes retain `parade,disable-usb4`, and no production router consumer is added |
+| Full qcom-x1e Debian package build | In progress at final PR head; acceptance and package hashes are pending |
+| Linux USB4 domain/router runtime | Not run — production USB4 is disabled |
+| USB3, PCIe, or DisplayPort tunnel runtime | Not run — production USB4 is disabled |
+| Direct DisplayPort regression and automatic runtime-PM qualification | Not run; required before either production guard or runtime-PM policy changes |
+
+Before removing the fallback from any production DTB, hardware evidence must
+show all of the following:
+
+- a stable USB4 domain and host router after a cold boot;
+- successful link training and a downstream dock router;
+- USB 3, PCIe, and DisplayPort tunnels without IOMMU or security regressions;
+- direct DisplayPort Alt Mode still working on both connectors and both cable
+  orientations;
+- USB4-tunneled display on both connectors with hotplug and unplug recovery;
+- at least 20 suspend/resume cycles and repeated cold boots without a hard
+  lock, stale domain, or lost direct-DP fallback; and
+- a tested fallback kernel and recovery procedure.
+
+DisplayPort audio is a separate gate. The current Denali sound graph has no
+DisplayPort DAI link, so a working video tunnel must not be described as full
+monitor audio parity.
+
+## Consequences
+
+- The v20 line can compile and review the public QMP USB4 layer without risking
+  the ongoing pen milestones or activating an incomplete production path.
+- The existing direct DisplayPort Alt Mode configuration remains unchanged
+  while USB4-tunneled DisplayPort remains explicitly blocked.
+- The branch records a precise boundary for further upstream work instead of
+  claiming support from firmware boot or router registration alone.
+- Full USB4 still depends on a published, usable in-tree host-router
+  implementation or a carefully reviewed downstream equivalent, verified
+  sideband activation, per-port DT integration, and target hardware
+  qualification.
+- Proprietary Windows artifacts remain outside git and release assets.

--- a/docs/adr/adr-0068-sp11-usb4-dp-integration.md
+++ b/docs/adr/adr-0068-sp11-usb4-dp-integration.md
@@ -205,10 +205,36 @@ The final kernel PR head is its changelog-only descendant
 | X1E OLED and X1P Denali DTBs | Pass |
 | Required kernel configuration | Pass; existing QMP, USB4, Type-C, PS8830, TBT Alt Mode, and direct-DP options remain enabled |
 | Production fallback | Pass; both Denali PS8830 nodes retain `parade,disable-usb4`, and no production router consumer is added |
-| Full qcom-x1e Debian package build | In progress at final PR head; acceptance and package hashes are pending |
+| Full qcom-x1e Debian package build | Pass: `binary-indep binary-qcom-x1e` completed from exact final kernel PR head `e056649b9b56`; all four packages report version `7.2.0-jg-0sp11v20` |
 | Linux USB4 domain/router runtime | Not run — production USB4 is disabled |
 | USB3, PCIe, or DisplayPort tunnel runtime | Not run — production USB4 is disabled |
 | Direct DisplayPort regression and automatic runtime-PM qualification | Not run; required before either production guard or runtime-PM policy changes |
+
+### Reproducible package evidence
+
+On 2026-08-30, the documented Ubuntu 26.04 container build completed with
+target `binary-indep binary-qcom-x1e`. Its generated provenance manifest
+records source head
+[`e056649b9b56`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/e056649b9b56622fedd806134d4f79dcf251a2f0),
+with no local patches. Package metadata was inspected after export: each
+package reports version `7.2.0-jg-0sp11v20`, the three machine-specific
+packages report architecture `arm64`, and the common header package reports
+architecture `all`.
+
+| Artifact | SHA-256 |
+|---|---|
+| `linux-headers-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `6ec9b5872ff2a3ce22a21030f399517c433236867ed1f90df88cfef434b8daba` |
+| `linux-image-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `90e36276604a38ada5466015f851f466b62194d50317076f8608157e42d51153` |
+| `linux-modules-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `46a545cb44419916a794c575d08c221bb2a8bccba5ce867efe34fe813019ac35` |
+| `linux-qcom-x1e-headers-7.2.0-jg-0sp11v20_7.2.0-jg-0sp11v20_all.deb` | `f949f5649271e18f48b9164d6442cf4b5ec0d1b832f055f285819a52a7177cad` |
+| Generated source/build manifest | `26f5bce2bb66a4c093b47ed9339c5312efa489788b819b7f0aa3c6cc1a6c64ba` |
+| Generated package-list manifest | `8fc74e8f48e3cef6a1cc487ff0c55e073f4244017607c7ae419ecfdd0adec358` |
+
+The checksum manifest was verified after artifact export; its own SHA-256 is
+`6953bfcaa9522f00ac193fb00701982910922b22d71a1dec0077b3e9aa498db4`.
+These files remain local build evidence, not published release assets. This
+package result demonstrates pinned-source compilation and packaging only; it
+adds no runtime USB4, tunneled DisplayPort, or monitor-audio claim.
 
 Before removing the fallback from any production DTB, hardware evidence must
 show all of the following:

--- a/docs/adr/adr-0068-sp11-usb4-dp-integration.md
+++ b/docs/adr/adr-0068-sp11-usb4-dp-integration.md
@@ -11,8 +11,9 @@ description: Architecture Decision Record (ADR) for starting the Surface Pro 11 
 
 Accepted for the source/static portion and the controlled procedure for an
 explicitly selected top-port retimer qualification boot at the
-`7.2.0-jg-0sp11v20` implementation milestone on 2026-08-30. The same-version
-package rebuild and runtime result remain pending. Full USB4 enablement is not
+`7.2.0-jg-0sp11v20` implementation milestone on 2026-08-30. The clean
+same-version package rebuild and packaged-image inspection passed; guarded and
+experimental runtime results remain pending. Full USB4 enablement is not
 accepted: the production Denali device tree still disables USB4 at both PS8830
 retimers, and this branch enables no host-router consumer.
 
@@ -258,8 +259,9 @@ isolation are validated statically at
 | Experimental DTB isolation | Pass: production OLED, explicitly targeted experimental OLED, and X1P Denali DTBs build; full ARM64 `dtbs` completes; the experimental filename is absent from the normal `dtbs-list` |
 | Compiled guard isolation | Pass: production OLED DTB contains two `parade,disable-usb4` properties; experimental DTB contains only the `i2c3` bottom-port property |
 | Experimental targeted schema validation | Not run locally: `dt-doc-validate` is unavailable. The wrapper adds no property and deletes one optional boolean already covered by the previously validated PS8830 binding |
-| Alternate Stubble construction | Pass in an Ubuntu 26.04 container: ARM64 PE image, exactly one `.dtbauto`, and extracted experimental model/guard count verified |
-| Experimental full qcom-x1e package rebuild | Pending at `70ddec100fe9`; retain version `7.2.0-jg-0sp11v20` and inspect both packaged EFI images because version alone cannot distinguish same-version rebuilds |
+| Alternate Stubble construction | Pass in the Ubuntu 26.04 qualification package: ARM64 PE image, exactly one `.dtbauto`, and extracted experimental model/guard count verified |
+| Experimental full qcom-x1e package rebuild | Pass at exact source head `70ddec100fe9`: `binary-indep binary-qcom-x1e` completed with no local patches; four version-`7.2.0-jg-0sp11v20` packages exported and their six-file checksum manifest verified strictly |
+| Packaged Stubble isolation | Pass: the normal ARM64 PE image contains 38 `.dtbauto` sections and no experimental marker; the alternate contains exactly one `.dtbauto`; no experimental path exists under `/boot` and no loose experimental DTB is packaged |
 | Linux USB4 domain/router runtime | Not run — production USB4 is disabled |
 | USB3, PCIe, or DisplayPort tunnel runtime | Not run — production USB4 is disabled |
 | Direct DisplayPort regression and automatic runtime-PM qualification | Not run; required before either production guard or runtime-PM policy changes |
@@ -299,9 +301,47 @@ its checksum-manifest SHA-256 is
 `7884167a1b56482e36bbc6034908810c9391ccbe2ea637b2b450ed5e51a0e2e0`.
 That guarded build is the installed pre-experiment baseline, not the new
 top-port experiment. Because all three builds use the same Debian version, the
-source manifest is mandatory evidence and the guarded artifacts must be kept
-under `artifacts-672638f-guarded/` before the experimental rebuild overwrites
-the working `artifacts/` path.
+source manifest is mandatory evidence. For the clean `70ddec100fe9`
+qualification rebuild, the operator intentionally cleared the prior local
+build and untracked payload assets before building. The hashes above remain
+provenance for the previously installed guarded v20, but no local
+`artifacts-672638f-guarded/` archive is claimed for this run. Guarded v20
+remains the installed pre-install baseline; v16 remains installed as the
+independent fallback and becomes the only independent rollback after the
+same-ABI v20 replacement.
+
+The clean qualification rebuild completed from exact source head
+[`70ddec100fe9`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/70ddec100fe953712c309067fe2db4d8207facc6)
+with `Local patches: none`, target `binary-indep binary-qcom-x1e`, and eight
+jobs. Each package reports version `7.2.0-jg-0sp11v20`; the three
+machine-specific packages report architecture `arm64`, and the common header
+package reports architecture `all`.
+
+| Clean qualification artifact | SHA-256 |
+|---|---|
+| `linux-headers-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `535cef2ee7043a7756c9b57fd225d8353eff03c6b6404c1aed6750d59cb3404e` |
+| `linux-image-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `ea0354d32dd11ae0fa0cb3b2d443099e37def695a6c119239b852d095c6a6333` |
+| `linux-modules-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `64fbda78899a0a145fe826e33657c7a9b6cb359c34d4cfd98255ac5ab41d1ac1` |
+| `linux-qcom-x1e-headers-7.2.0-jg-0sp11v20_7.2.0-jg-0sp11v20_all.deb` | `763579b1d489a834c59ceb8710204810bb593a8fca56561084b5c0b68ce5238b` |
+| Generated source/build manifest | `4d1a7675fbbdfc11c8ca84bd040aa3446f1a0a702ebcc97e48501002ac252348` |
+| Generated package-list manifest | `8fc74e8f48e3cef6a1cc487ff0c55e073f4244017607c7ae419ecfdd0adec358` |
+
+The generated six-entry `SHA256SUMS` passed strict verification; its own
+SHA-256 is
+`980d4c3dca485b7f575c4f95c5ef8b0482a7ac6c5306c80aec21fd4904e13c88`.
+The Docker export helper now generates that manifest atomically, validates the
+declared package set against the exported set, and installs it read-only for
+normal-user verification.
+
+Package inspection confirms that the production DTB still contains two
+`parade,disable-usb4` properties while the alternate DTB contains one. The
+alternate's exact model is `Microsoft Surface Pro 11th Edition (OLED,
+top-port USB4 retimer experiment)`. The normal and alternate `.linux` payloads
+are identical at SHA-256
+`032c34ba16cddee96d3dcbe8190dc7e5a8848928313f41ebdd10fc2892e92779`;
+only their embedded DTB sets differ. The packaged production OLED DTB is
+byte-identical to the installed guarded v20 DTB at SHA-256
+`b65e0b97e3cd8ce2454000d9d14ff27bd8863c0730cde27a2b42b8fff4809efa`.
 
 Before removing the fallback from any production DTB, hardware evidence must
 show all of the following:

--- a/docs/adr/adr-0068-sp11-usb4-dp-integration.md
+++ b/docs/adr/adr-0068-sp11-usb4-dp-integration.md
@@ -9,10 +9,12 @@ description: Architecture Decision Record (ADR) for starting the Surface Pro 11 
 
 ## Status
 
-Accepted for the source and static-build portion of the
-`7.2.0-jg-0sp11v20` implementation milestone on 2026-08-30. Runtime USB4
-enablement is not accepted: the production Denali device tree still disables
-USB4 at the PS8830 retimers, and this branch enables no host-router consumer.
+Accepted for the source/static portion and the controlled procedure for an
+explicitly selected top-port retimer qualification boot at the
+`7.2.0-jg-0sp11v20` implementation milestone on 2026-08-30. The same-version
+package rebuild and runtime result remain pending. Full USB4 enablement is not
+accepted: the production Denali device tree still disables USB4 at both PS8830
+retimers, and this branch enables no host-router consumer.
 
 ### Kernel integration record
 
@@ -32,7 +34,12 @@ packaging-only commits:
 | Public Hamoa PHY-to-router clocks | [`8564ca38642c`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/8564ca38642cade24dd02fc2ceb8fc3a22f8a275) |
 | Downstream ownership and rollback hardening; exact validated code head | [`5b5f1d124b7a`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/5b5f1d124b7ad43b9aac076ad65aa27fa3689ce9) |
 | `sp11v20` package boundary | [`bb0e70e6684a`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/bb0e70e6684ac1c41c59eeb6a7b3b5e2539b5d0f) |
-| Guarded-scope clarification; final kernel PR head | [`e056649b9b56`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/e056649b9b56622fedd806134d4f79dcf251a2f0) |
+| Guarded-scope clarification; initial guarded USB4 head | [`e056649b9b56`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/e056649b9b56622fedd806134d4f79dcf251a2f0) |
+| Pen/touch integration merge used by the guarded rebuild | [`672638f963d3`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/672638f963d37f55a93544568db41bfc4469df6d) |
+| Retimer/QMP handoff diagnostics | [`75617434c1e6`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/75617434c1e686e807dd0742799cb29bf0201a90) |
+| Top-port-only experimental DTB | [`a57d6d807dbc`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/a57d6d807dbce79f5877cf61e25febd5cef9bf1b) |
+| Experimental-DTB changelog | [`5321047ea5e2`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/5321047ea5e2d23d44b0041b69db776c46eb015f) |
+| Alternate Stubble-image isolation; current qualification source head | [`70ddec100fe9`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/70ddec100fe953712c309067fe2db4d8207facc6) |
 | Upstream submission | [Qualcomm USB43DP PHY v4](https://patchew.org/linux/20260820-topic-usb4phy-v4-0-aec9d2cb31f6@oss.qualcomm.com/), mbox SHA-256 `cf05fc8da482ab8085cfe3eeb37798b62bc74c5b2a73f8e74a8cc9b0dc93d3e2` |
 
 ## Context
@@ -43,12 +50,26 @@ requires the USB4 host router, retimer sideband connection, link training, and
 USB4 Connection Manager to create a DisplayPort tunnel before DRM can drive the
 monitor.
 
-A private, reviewed same-device Windows capture reports a matched top-port
-attach with USB4, PCIe, and DisplayPort tunnels, but it does not disclose the
-retimer-to-controller sideband sequence needed by Linux. A publishable
-redacted derivative remains pending. This private report informs the later
-test matrix only; it is not committed, linked as public evidence, treated as
-source-code provenance, or counted as Linux runtime validation.
+A reviewed same-device Windows capture and its public
+[redacted result](https://github.com/ooaklee/sp11-windows-capture/blob/85161cd5c84f2d7463f74d9ff2a81fcc175ff86c/analysis/usb4-first-attach-20260829/redacted-result.md)
+establish a useful hardware oracle. The exact CalDigit TS4 and bundled passive
+40 Gb/s cable formed a real USB4 connection through the physical top port,
+with host/root/dock routers plus USB3, PCIe, and DisplayPort tunnels.
+
+A separate review of the private device graph identifies the Qualcomm
+host-router bus as `QCOM0C6D` / `_SB.UBF0`, its successful port as
+`_SB.UBF0.PRT1`, and the tunneled USB controller as `QCOM0C8C` / `_SB.URS1`.
+Those sanitized conclusions are not attributed to the linked public report.
+
+That private review also shows why the bottom-port capture is not a valid
+negative hardware comparison:
+`QCOM0C8B` / `_SB.URS0` was reserved by KDNET with
+`CM_PROB_USED_BY_DEBUGGER`. Its charge-only result must not be used to claim a
+bad bottom port. The capture also contains no host-router MMIO map, interrupts,
+clocks, resets, IOMMU stream IDs, firmware protocol, or decoded PS8830
+sideband sequence. It guides top-port selection and the success oracle; it is
+not source-code provenance or Linux runtime validation. Raw capture output
+remains private and outside this repository.
 
 The Linux 7.2 integration base already contains:
 
@@ -96,9 +117,9 @@ reviewable and could hard-lock the device.
 
 USB4 work starts at `7.2.0-jg-0sp11v20` on
 `sp11/integration-7.2.x-usb4-support`. Versions v15 through v19 remain
-available to the independent pen and touch work. USB4 commits must remain
-independently reviewable and revertible; this branch does not absorb the open
-pen integration branches.
+available as historical pen and touch milestones. The branch now includes the
+validated pen/touch integration merge at `672638f963d3`; the later USB4 commits
+remain independently reviewable and revertible on top of that shared base.
 
 ### First v20 kernel increment
 
@@ -137,6 +158,27 @@ The first active USB4 experiment must use an explicitly named experimental DTB
 that is not selected by the normal boot entry. Its patch must contain no raw
 MMIO diagnostic interface, arbitrary register write, firmware-memory dump,
 debugfs write path, or user-triggered GDSC toggle.
+
+The first such DTB is
+`x1e80100-microsoft-denali-oled-usb4-top-experimental.dtb`. It inherits the
+production OLED tree and deletes `parade,disable-usb4` only from the `i2c7`
+PS8830 mapped to the physical top port. The `i2c3` bottom-port guard remains,
+and the normal DTB retains both guards. The experimental target stays outside
+`dtb-y` and the normal `dtbs-list`. Packaging filters it from the normal
+Stubble auto-selection set, fails closed if that invariant changes, and embeds
+it only in `/usr/lib/linux-image-<ABI>/sp11-usb4-top-experimental.efi`.
+
+The normal `/boot/vmlinuz-*` therefore stays guarded. A tester must copy the
+alternate EFI image to a distinct temporary `/boot` filename and transiently
+edit only the GRUB `linux` path for one cold boot, leaving initrd unchanged.
+Editing a loose GRUB `devicetree` line does not override the FDT embedded by
+Stubble and is not part of this procedure.
+
+This DTB can establish whether Enter_USB reaches and programs the PS8830. It
+cannot create a USB4 domain: QMP deliberately ignores USB4/TBT mux requests
+until a host-router consumer initializes the USB4 PHY, and no such consumer is
+present. The diagnostic messages distinguish these two outcomes without
+faking PHY ownership.
 
 ### Host-router integration boundary
 
@@ -188,10 +230,14 @@ The PHY increment requires:
 - confirmation that both production retimer nodes retain
   `parade,disable-usb4`.
 
-The source/static gates below were run against exact kernel-code head
-[`5b5f1d124b7a`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/5b5f1d124b7ad43b9aac076ad65aa27fa3689ce9).
-The final kernel PR head is its changelog-only descendant
+The original PHY source/static gates below were run against exact kernel-code
+head
+[`5b5f1d124b7a`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/5b5f1d124b7ad43b9aac076ad65aa27fa3689ce9),
+with the initial guarded package completed at
 [`e056649b9b56`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/e056649b9b56622fedd806134d4f79dcf251a2f0).
+The separately reviewable retimer experiment and its alternate Stubble-image
+isolation are validated statically at
+[`70ddec100fe9`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/70ddec100fe953712c309067fe2db4d8207facc6).
 
 | Gate | Result |
 |---|---|
@@ -206,6 +252,14 @@ The final kernel PR head is its changelog-only descendant
 | Required kernel configuration | Pass; existing QMP, USB4, Type-C, PS8830, TBT Alt Mode, and direct-DP options remain enabled |
 | Production fallback | Pass; both Denali PS8830 nodes retain `parade,disable-usb4`, and no production router consumer is added |
 | Full qcom-x1e Debian package build | Pass: `binary-indep binary-qcom-x1e` completed from exact final kernel PR head `e056649b9b56`; all four packages report version `7.2.0-jg-0sp11v20` |
+| Experimental-diff `git diff --check` | Pass at `70ddec100fe9` |
+| Strict `checkpatch.pl` on experimental changes | Pass: 0 errors, 0 warnings, 0 checks |
+| Experimental `W=1` driver build | Pass: `ps883x.ko` and `phy-qcom-qmp-combo.o` with the ARM64 cross toolchain |
+| Experimental DTB isolation | Pass: production OLED, explicitly targeted experimental OLED, and X1P Denali DTBs build; full ARM64 `dtbs` completes; the experimental filename is absent from the normal `dtbs-list` |
+| Compiled guard isolation | Pass: production OLED DTB contains two `parade,disable-usb4` properties; experimental DTB contains only the `i2c3` bottom-port property |
+| Experimental targeted schema validation | Not run locally: `dt-doc-validate` is unavailable. The wrapper adds no property and deletes one optional boolean already covered by the previously validated PS8830 binding |
+| Alternate Stubble construction | Pass in an Ubuntu 26.04 container: ARM64 PE image, exactly one `.dtbauto`, and extracted experimental model/guard count verified |
+| Experimental full qcom-x1e package rebuild | Pending at `70ddec100fe9`; retain version `7.2.0-jg-0sp11v20` and inspect both packaged EFI images because version alone cannot distinguish same-version rebuilds |
 | Linux USB4 domain/router runtime | Not run — production USB4 is disabled |
 | USB3, PCIe, or DisplayPort tunnel runtime | Not run — production USB4 is disabled |
 | Direct DisplayPort regression and automatic runtime-PM qualification | Not run; required before either production guard or runtime-PM policy changes |
@@ -236,6 +290,19 @@ These files remain local build evidence, not published release assets. This
 package result demonstrates pinned-source compilation and packaging only; it
 adds no runtime USB4, tunneled DisplayPort, or monitor-audio claim.
 
+A later same-version guarded rebuild at
+[`672638f963d3`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/672638f963d37f55a93544568db41bfc4469df6d)
+integrated the validated pen/touch branch while retaining both production USB4
+guards. Its manifest SHA-256 is
+`0c27041400692122ac76b26cfc291981525be5e95dea1d025d539b3cb7165b8f`;
+its checksum-manifest SHA-256 is
+`7884167a1b56482e36bbc6034908810c9391ccbe2ea637b2b450ed5e51a0e2e0`.
+That guarded build is the installed pre-experiment baseline, not the new
+top-port experiment. Because all three builds use the same Debian version, the
+source manifest is mandatory evidence and the guarded artifacts must be kept
+under `artifacts-672638f-guarded/` before the experimental rebuild overwrites
+the working `artifacts/` path.
+
 Before removing the fallback from any production DTB, hardware evidence must
 show all of the following:
 
@@ -255,8 +322,8 @@ monitor audio parity.
 
 ## Consequences
 
-- The v20 line can compile and review the public QMP USB4 layer without risking
-  the ongoing pen milestones or activating an incomplete production path.
+- The v20 line can compile and review the public QMP USB4 layer on the validated
+  pen/touch base without activating an incomplete production path.
 - The existing direct DisplayPort Alt Mode configuration remains unchanged
   while USB4-tunneled DisplayPort remains explicitly blocked.
 - The branch records a precise boundary for further upstream work instead of

--- a/docs/adr/adr-0068-sp11-usb4-dp-integration.md
+++ b/docs/adr/adr-0068-sp11-usb4-dp-integration.md
@@ -9,13 +9,15 @@ description: Architecture Decision Record (ADR) for starting the Surface Pro 11 
 
 ## Status
 
-Accepted for the source/static portion and the controlled procedure for an
-explicitly selected top-port retimer qualification boot at the
-`7.2.0-jg-0sp11v20` implementation milestone on 2026-08-30. The clean
-same-version package rebuild and packaged-image inspection passed; guarded and
-experimental runtime results remain pending. Full USB4 enablement is not
-accepted: the production Denali device tree still disables USB4 at both PS8830
-retimers, and this branch enables no host-router consumer.
+Accepted for the source/static portion and the controlled top-port retimer
+qualification at the `7.2.0-jg-0sp11v20` implementation milestone on
+2026-08-30. The clean same-version rebuild, packaged-image inspection, guarded
+control attach, top-port experimental attach, and guarded rollback passed for
+their intended scope. Full USB4 enablement is not accepted: the experimental
+attach reached the top-port PS8830 USB4 configuration path, but no active
+host-router PHY consumer or USB4 domain/router was present, and no dock
+USB/Thunderbolt enumeration appeared. The production tree and normal rollback
+image retain both PS8830 guards.
 
 ### Kernel integration record
 
@@ -262,9 +264,14 @@ isolation are validated statically at
 | Alternate Stubble construction | Pass in the Ubuntu 26.04 qualification package: ARM64 PE image, exactly one `.dtbauto`, and extracted experimental model/guard count verified |
 | Experimental full qcom-x1e package rebuild | Pass at exact source head `70ddec100fe9`: `binary-indep binary-qcom-x1e` completed with no local patches; four version-`7.2.0-jg-0sp11v20` packages exported and their six-file checksum manifest verified strictly |
 | Packaged Stubble isolation | Pass: the normal ARM64 PE image contains 38 `.dtbauto` sections and no experimental marker; the alternate contains exactly one `.dtbauto`; no experimental path exists under `/boot` and no loose experimental DTB is packaged |
-| Linux USB4 domain/router runtime | Not run — production USB4 is disabled |
-| USB3, PCIe, or DisplayPort tunnel runtime | Not run — production USB4 is disabled |
-| Direct DisplayPort regression and automatic runtime-PM qualification | Not run; required before either production guard or runtime-PM policy changes |
+| Guarded v20 regressions | Partial pass: ordinary OLED model and two live guards; one-, two-, and three-finger touch, pen inking/pressure/barrel button, and a direct USB3 device passed. Direct USB-C DisplayPort Alt Mode was not run because no suitable test device or adapter was available |
+| Guarded TS4 control attach | Pass for the production safety boundary: the top-port attach encountered the DT policy rejection; no dock USB/Thunderbolt device or USB4 domain appeared in this session |
+| Top-port experimental boot | Pass: exact experimental model, alternate `BOOT_IMAGE`, and only the bottom-port guard remained |
+| Top-port experimental TS4 attach | Pass for the retimer-only scope: the PS8830 driver completed its USB4 configuration writes without error, then QMP reported no active host-router PHY consumer; no dock USB/Thunderbolt device or USB4 domain appeared |
+| Guarded rollback | Pass: a cold boot of the normal unedited v20 image restored the ordinary OLED model and both live guards |
+| Linux USB4 domain/router runtime | Observed negative as designed: no domain or router appeared; QMP had no active host-router PHY consumer when the mux request arrived |
+| USB3, PCIe, or DisplayPort tunnel runtime | Not established: no dock USB/Thunderbolt enumeration or USB4 domain appeared; direct USB3 success is not tunnel evidence |
+| Direct DisplayPort regression and automatic runtime-PM qualification | Not run; suitable direct-DP test hardware was unavailable, and both gates remain required before any production guard or runtime-PM change |
 
 ### Reproducible package evidence
 
@@ -342,6 +349,49 @@ are identical at SHA-256
 only their embedded DTB sets differ. The packaged production OLED DTB is
 byte-identical to the installed guarded v20 DTB at SHA-256
 `b65e0b97e3cd8ce2454000d9d14ff27bd8863c0730cde27a2b42b8fff4809efa`.
+
+### Controlled top-port runtime evidence
+
+The 2026-08-30 qualification first booted the normal v20 image with the
+ordinary OLED model and both live PS8830 guards. One-, two-, and three-finger
+touch, pen inking with pressure variation, the barrel button, and a direct
+USB3 device passed. Direct USB-C DisplayPort Alt Mode was not run because no
+suitable test device or adapter was available; the existing project support
+claim was therefore not requalified by this run.
+
+The guarded TS4 control attach produced the expected policy rejection and no
+dock topology. After a cold power cycle, the alternate image booted with exact
+model `Microsoft Surface Pro 11th Edition (OLED, top-port USB4 retimer
+experiment)` and only the bottom-port guard. A single attach of the matched
+CalDigit TS4 and bundled 40 Gb/s cable changed the labelled top Type-C port to
+normal orientation, host data role, USB Power Delivery, and a PD-capable
+partner. The two publishable driver lines were:
+
+```text
+ps883x_retimer 5-0008: USB4 mode accepted by retimer; host-router state not established
+qcom-qmp-combo-phy fda000.phy: USB4/TBT mux request ignored: no active host-router PHY consumer
+```
+
+The first line is emitted only after the driver completes its USB4
+configuration writes without error. It does not prove that the silicon formed
+a USB4 link or trained at 40 Gb/s. The second establishes that a USB4 PHY
+object existed but had no active host-router PHY consumer when the mux request
+arrived; it does not establish why that initialization was absent or that one
+consumer is the only remaining blocker.
+
+There was no change in USB topology, PCI enumeration, DRM connectors,
+Thunderbolt devices, or USB4 domains. The result validates removal of the
+retimer-side policy rejection for this scoped top-port experiment. It does not
+validate a USB4 link, a working dock, or any USB3, PCIe, or DisplayPort tunnel.
+
+The ignored local baseline and attached snapshots started at
+`2026-08-30T10:55:47Z` and `2026-08-30T10:57:08Z`. Each passed strict
+verification; their checksum-manifest SHA-256 values are respectively
+`d05b9aa87e0fab5db13fb2fe52a105111e5921bd208e43f51acbc89667fb0039`
+and `a60b835f3c81010dd8909f68d66f7960f3368ca4c9b0930a2a9553093d7ca92f`.
+The raw snapshots remain private because their full logs and inventories can
+contain host identifiers. A subsequent cold boot of the normal unedited v20
+image restored the ordinary OLED model and both live guards.
 
 Before removing the fallback from any production DTB, hardware evidence must
 show all of the following:

--- a/docs/how-to/how-to-test-sp11-usb4-dp.md
+++ b/docs/how-to/how-to-test-sp11-usb4-dp.md
@@ -35,9 +35,18 @@ the only immediate independent fallback.
 
 ## Preserve the guarded v20 artifacts
 
-The build helper recreates `artifacts/`. Before starting the same-version
-build, verify and preserve the guarded pen/touch-integrated build at exact
-kernel head `672638f963d37f55a93544568db41bfc4469df6d`.
+**Qualification-run note (2026-08-30):** The operator intentionally cleared
+the prior local build tree and untracked payload assets before starting this
+clean rebuild. No `artifacts-672638f-guarded/` rollback archive is claimed for
+this run, so skip the archive-copy commands below. The currently installed
+guarded v20 remains the pre-install baseline, and installed v16 remains the
+independent rollback. Reinstalling the same v20 ABI replaces the installed
+guarded v20, after which v16 is the independent rollback.
+
+For a future same-version rebuild where the prior artifacts still exist, the
+build helper recreates `artifacts/`. Before starting, verify and preserve the
+guarded pen/touch-integrated build at exact kernel head
+`672638f963d37f55a93544568db41bfc4469df6d`.
 
 Set `work_dir` to the build directory actually used on the machine. The
 current SP11 checkout uses the first path below; the Docker example in the
@@ -91,9 +100,12 @@ artifacts="$work_dir/artifacts"
 grep -Fx \
   'Source HEAD: 70ddec100fe953712c309067fe2db4d8207facc6' \
   "$artifacts/sp11-kernel-build-manifest.txt"
-(cd "$artifacts" && sha256sum -c SHA256SUMS)
+(cd "$artifacts" && sha256sum --check --strict SHA256SUMS)
 ```
 
+The Docker helper writes `SHA256SUMS` atomically after comparing the package
+list manifest with the exported package set. A missing checksum manifest or a
+set mismatch is an export failure, not a reason to install without the gate.
 All four packages must report version `7.2.0-jg-0sp11v20`. Reject a mixed
 bundle.
 
@@ -164,8 +176,11 @@ any mismatch.
 Confirm the fallback exists before replacing v20:
 
 ```bash
-test -f /boot/vmlinuz-7.2.0-jg-0sp11v16-qcom-x1e
-ls -l /boot/sp11-denali-v19-known-good.dtb
+fallback_abi=7.2.0-jg-0sp11v16-qcom-x1e
+test -f "/boot/vmlinuz-$fallback_abi"
+test -f "/boot/initrd.img-$fallback_abi"
+test -d "/usr/lib/modules/$fallback_abi"
+grep -F "/vmlinuz-$fallback_abi" /boot/grub/grub.cfg
 ```
 
 Install all four exact artifacts explicitly:

--- a/docs/how-to/how-to-test-sp11-usb4-dp.md
+++ b/docs/how-to/how-to-test-sp11-usb4-dp.md
@@ -2,41 +2,78 @@
 id: how-to-test-sp11-usb4-dp
 title: "Test SP11 USB4 and DisplayPort"
 # prettier-ignore
-description: How-to guide for safely building the Surface Pro 11 v20 USB4 PHY integration, preserving direct DisplayPort fallback, and collecting passive evidence for later USB4-tunnel qualification.
+description: How to build and install the same-version Surface Pro 11 v20 USB4 increment, preserve its guarded production Stubble image, and run one top-port retimer qualification boot.
 ---
 
 # How To: Test SP11 USB4 and DisplayPort
 
-Use this procedure to build the v20 USB4 integration, verify the working
-direct-DisplayPort baseline, and collect comparable top- and bottom-port
-snapshots. The current v20 increment does not enable the production USB4 path.
+This procedure keeps the normal `7.2.0-jg-0sp11v20` boot guarded on both
+PS8830 retimers and adds one explicitly selected top-port experiment. The
+experiment can prove that Enter_USB reaches the retimer. It cannot supply the
+missing Qualcomm host-router consumer, create a USB4 domain, or satisfy the
+USB4-tunnel gate by itself.
 
-## Purpose
+## Safety boundary
 
-Direct USB-C DisplayPort Alt Mode and DisplayPort tunneled through USB4 are
-different tests. A monitor appearing through a direct USB-C cable does not
-prove that a USB4 router or DisplayPort tunnel exists. This guide keeps those
-results separate and establishes the evidence needed for a later USB4-tunnel
-gate.
+- Keep v16 installed and bootable as the independent fallback.
+- Keep the dock disconnected until the guide says to attach it.
+- Use the exact CalDigit TS4 and bundled passive 0.8 m 40 Gb/s cable that
+  passed the matched Windows test.
+- Test only the physical top USB-C port and attach the dock once in the
+  experimental cold-boot cycle.
+- Do not use `--skip-clean` for this same-version build.
+- Do not use `devmem`, `i2cget`, `i2cset`, `i2ctransfer`, raw MMIO, debugfs
+  writes, driver rebinding, or manual power-domain toggles.
+- Secure Boot must be disabled unless the locally built image is signed and
+  trusted independently.
 
-## Prerequisites
+The kernel ABI and Debian version remain
+`7.2.0-jg-0sp11v20-qcom-x1e` and `7.2.0-jg-0sp11v20`. Reinstalling the new
+packages replaces the installed v20 files; it does not create a second v20
+GRUB entry. The source manifest is therefore mandatory evidence, and v16 is
+the only immediate independent fallback.
 
-- Surface Pro 11 X1E80100 with AC power connected.
-- A known-good qcom-x1e kernel retained in GRUB and recovery media nearby.
-- Secure Boot disabled for the experimental package.
-- The USB4 v20 support and kernel branches checked out separately from pen
-  work.
-- A direct USB-C DisplayPort cable or monitor for the regression baseline.
-- A known USB4 dock, display, and certified cable for passive topology
-  snapshots. Record whether the physical top or bottom connector is used.
-- A cold shutdown between any future active USB4 experiments. Do not use
-  driver unbind/rebind as a substitute. This is a conservative X1E safety
-  rule derived from the X1P hard-lock observations in issue 52, not a claim
-  that the two variants share a verified controller register map.
+## Preserve the guarded v20 artifacts
 
-## Build the v20 kernel
+The build helper recreates `artifacts/`. Before starting the same-version
+build, verify and preserve the guarded pen/touch-integrated build at exact
+kernel head `672638f963d37f55a93544568db41bfc4469df6d`.
 
-From the support repository, run:
+Set `work_dir` to the build directory actually used on the machine. The
+current SP11 checkout uses the first path below; the Docker example in the
+README uses the second.
+
+```bash
+work_dir=build/linux-surface-pro-11-oe-usb4-support-usb4-v20
+# work_dir=build/docker-sp11-qcom-x1e-kernel-usb4-v20
+
+current="$work_dir/artifacts"
+guarded="$work_dir/artifacts-672638f-guarded"
+guarded_head=672638f963d37f55a93544568db41bfc4469df6d
+
+grep -Fx "Source HEAD: $guarded_head" \
+  "$current/sp11-kernel-build-manifest.txt"
+(cd "$current" && sha256sum -c SHA256SUMS)
+
+if [ -e "$guarded" ]; then
+  diff -qr "$current" "$guarded"
+else
+  cp -a -- "$current" "$guarded"
+fi
+
+grep -Fx "Source HEAD: $guarded_head" \
+  "$guarded/sp11-kernel-build-manifest.txt"
+(cd "$guarded" && sha256sum -c SHA256SUMS)
+```
+
+Stop if the source head, checksums, or an existing backup comparison differs.
+Do not overwrite an unexplained backup.
+
+## Build exact v20 source
+
+Build the pushed kernel branch from exact qualification head
+`70ddec100fe953712c309067fe2db4d8207facc6`. Use the normal clean path; do not
+pass `--skip-clean` with this unchanged package version.
 
 ```bash
 ./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
@@ -44,145 +81,237 @@ From the support repository, run:
   --git-url https://github.com/ooaklee/linux_ms_dev_kit-sp11.git \
   --git-branch sp11/integration-7.2.x-usb4-support \
   --image ubuntu:26.04 \
-  --build-target "binary-indep binary-qcom-x1e" \
-  --work-dir build/docker-sp11-qcom-x1e-kernel-usb4-v20 \
+  --platform linux/arm64 \
+  --work-dir "$work_dir" \
   --linux-work-volume sp11-qcom-x1e-kernel-usb4-v20 \
-  --copy-to-payload --reset-source --jobs 8
-```
+  --build-target 'binary-indep binary-qcom-x1e' \
+  --reset-source --jobs 8
 
-The branch name is mutable. Reject the build unless its generated provenance
-manifest resolves to the exact kernel PR head accepted by ADR0068:
-
-```bash
+artifacts="$work_dir/artifacts"
 grep -Fx \
-  'Source HEAD: e056649b9b56622fedd806134d4f79dcf251a2f0' \
-  build/docker-sp11-qcom-x1e-kernel-usb4-v20/artifacts/sp11-kernel-build-manifest.txt
+  'Source HEAD: 70ddec100fe953712c309067fe2db4d8207facc6' \
+  "$artifacts/sp11-kernel-build-manifest.txt"
+(cd "$artifacts" && sha256sum -c SHA256SUMS)
 ```
 
-The four packages must share version `7.2.0-jg-0sp11v20`; the installed image
-ABI is `7.2.0-jg-0sp11v20-qcom-x1e`. Reject mixed-version package sets.
+All four packages must report version `7.2.0-jg-0sp11v20`. Reject a mixed
+bundle.
 
-Before installing, run the existing read-only package preflight with the v20
-ABI and an explicitly selected known-good fallback:
+## Inspect the packaged Stubble images
+
+The kernel image and DTBs are in the large `linux-modules` package, not the
+small `linux-image` package. Extract that package into a temporary directory
+and inspect both EFI images before installing anything.
 
 ```bash
-sudo ./scripts/preflight-sp11-kernel-test.sh \
-  --deb-dir payload/kernel-debs \
-  --target-abi 7.2.0-jg-0sp11v20-qcom-x1e \
-  --fallback-abi YOUR_KNOWN_GOOD_QCOM_X1E_ABI
+abi=7.2.0-jg-0sp11v20-qcom-x1e
+(
+set -euo pipefail
+modules_deb="$artifacts/linux-modules-${abi}_7.2.0-jg-0sp11v20_arm64.deb"
+test -f "$modules_deb"
+
+inspect_dir="$(mktemp -d)"
+trap 'rm -rf -- "$inspect_dir"' EXIT
+dpkg-deb -x "$modules_deb" "$inspect_dir"
+
+normal="$inspect_dir/boot/vmlinuz-$abi"
+experimental="$inspect_dir/usr/lib/linux-image-$abi/sp11-usb4-top-experimental.efi"
+production_dtb="$inspect_dir/usr/lib/firmware/$abi/device-tree/qcom/x1e80100-microsoft-denali-oled.dtb"
+test -f "$normal"
+test -f "$experimental"
+test -f "$production_dtb"
+
+# Nothing experimental may be installed into /boot automatically.
+if find "$inspect_dir/boot" -maxdepth 1 -type f \
+  -name '*usb4*experimental*' -print -quit | grep -q .; then
+  echo 'experimental image leaked into /boot' >&2
+  exit 1
+fi
+
+# The production DTB retains both retimer guards.
+test "$(dtc -q -I dtb -O dts "$production_dtb" | \
+  grep -c 'parade,disable-usb4')" -eq 2
+
+# The normal Stubble image contains the ordinary model and no experiment.
+strings -a "$normal" >"$inspect_dir/normal.strings"
+grep -Fq 'Microsoft Surface Pro 11th Edition (OLED)' \
+  "$inspect_dir/normal.strings"
+if grep -Fq 'top-port USB4 retimer experiment' \
+  "$inspect_dir/normal.strings"; then
+  echo 'experimental DTB leaked into the normal Stubble image' >&2
+  exit 1
+fi
+
+# The alternate image must contain exactly one embedded DTB.
+objdump -h "$experimental" >"$inspect_dir/experimental.sections"
+test "$(awk '$2 == ".dtbauto" { count++ } END { print count + 0 }' \
+  "$inspect_dir/experimental.sections")" -eq 1
+objcopy --dump-section \
+  .dtbauto="$inspect_dir/experimental.dtb" "$experimental"
+test "$(fdtget -t s "$inspect_dir/experimental.dtb" / model)" = \
+  'Microsoft Surface Pro 11th Edition (OLED, top-port USB4 retimer experiment)'
+test "$(dtc -q -I dtb -O dts "$inspect_dir/experimental.dtb" | \
+  grep -c 'parade,disable-usb4')" -eq 1
+)
 ```
 
-Install with the existing kernel helper, reboot, and confirm the ABI:
+The production DTB must have two guards. The alternate image must have one
+`.dtbauto`, the explicit experimental model, and one remaining guard. Stop on
+any mismatch.
+
+## Install the same-version packages
+
+Confirm the fallback exists before replacing v20:
 
 ```bash
-./scripts/build-sp11-qcom-x1e-kernel.sh \
-  --work-dir payload/kernel-debs --install-only
-sudo reboot
+test -f /boot/vmlinuz-7.2.0-jg-0sp11v16-qcom-x1e
+ls -l /boot/sp11-denali-v19-known-good.dtb
+```
+
+Install all four exact artifacts explicitly:
+
+```bash
+sudo dpkg -i \
+  "$artifacts/linux-headers-${abi}_7.2.0-jg-0sp11v20_arm64.deb" \
+  "$artifacts/linux-image-${abi}_7.2.0-jg-0sp11v20_arm64.deb" \
+  "$artifacts/linux-modules-${abi}_7.2.0-jg-0sp11v20_arm64.deb" \
+  "$artifacts/linux-qcom-x1e-headers-7.2.0-jg-0sp11v20_7.2.0-jg-0sp11v20_all.deb"
+
+test -f "/boot/vmlinuz-$abi"
+test -f "/usr/lib/linux-image-$abi/sp11-usb4-top-experimental.efi"
+```
+
+The package post-install and `update-grub` steps select only the guarded
+`/boot/vmlinuz-$abi` image.
+
+## Regress the normal guarded boot
+
+Boot the normal v20 entry once before selecting the experiment. Confirm:
+
+```bash
 uname -r
+tr -d '\0' </proc/device-tree/model; echo
 ```
 
-## Verify the direct-DisplayPort baseline
+The ABI must be v20 and the model must be the ordinary OLED model, without
+`top-port USB4 retimer experiment`. Quickly verify:
 
-Connect the monitor directly, without a USB4 dock. Test both physical ports
-and both cable orientations. Record resolution, refresh rate, hotplug, unplug,
-and one suspend/resume cycle.
+- normal one-, two-, and three-finger touch;
+- pen inking, pressure variation, and the barrel button;
+- a direct USB3 device; and
+- Direct USB-C DisplayPort Alt Mode.
 
-Passing this phase proves that v20 did not regress Direct USB-C DisplayPort Alt
-Mode. It does not prove a USB4 router or DisplayPort tunnel.
+Disconnect all test devices and shut down completely after these regressions.
 
-## Collect passive USB4 snapshots
+## Prepare the one-boot experimental image
 
-With the dock disconnected, collect a baseline for the port under test:
+After package installation has completed its `update-grub`, copy the alternate
+EFI image under a distinct filename:
+
+```bash
+sudo install -m 0600 \
+  "/usr/lib/linux-image-$abi/sp11-usb4-top-experimental.efi" \
+  "/boot/vmlinuz-$abi-usb4-top-experimental"
+```
+
+Do not run `update-grub` while this temporary `/boot` copy exists. Keep the TS4
+disconnected and power the machine off completely.
+
+At the next GRUB menu, highlight the normal v20 entry and press `e`. On its
+`linux` line, change only the kernel image path from:
+
+```text
+/boot/vmlinuz-7.2.0-jg-0sp11v20-qcom-x1e
+```
+
+to:
+
+```text
+/boot/vmlinuz-7.2.0-jg-0sp11v20-qcom-x1e-usb4-top-experimental
+```
+
+Some GRUB configurations omit the `/boot` prefix; preserve the existing style.
+Leave the command line and `initrd` line unchanged. Do not edit or add a
+`devicetree` line. Boot the transient edit with Ctrl-X.
+
+## Verify the live experiment before attachment
+
+With the TS4 still disconnected, require both the ABI and live model:
+
+```bash
+expected_model='Microsoft Surface Pro 11th Edition (OLED, top-port USB4 retimer experiment)'
+test "$(uname -r)" = '7.2.0-jg-0sp11v20-qcom-x1e'
+test "$(tr -d '\0' </proc/device-tree/model)" = "$expected_model"
+```
+
+If either test fails, stop and do not attach the dock.
+
+## Collect the one-attach comparison
+
+Capture the disconnected baseline immediately before the only attach:
 
 ```bash
 ./scripts/collect-sp11-usb4-diagnostics.sh \
   --out "build/usb4-diagnostics/top-baseline-$(date -u +%Y%m%dT%H%M%SZ)" \
   --port-label top --phase baseline \
-  --expected-kernel-commit e056649b9b56622fedd806134d4f79dcf251a2f0
+  --expected-kernel-commit 70ddec100fe953712c309067fe2db4d8207facc6 \
+  --expected-device-tree-model "$expected_model"
 ```
 
-Connect the dock, wait 15 seconds, then collect the attached state:
+Connect the exact TS4 and bundled 40 Gb/s cable once to the physical top port,
+wait 15 seconds, and capture the attached state:
 
 ```bash
 ./scripts/collect-sp11-usb4-diagnostics.sh \
   --out "build/usb4-diagnostics/top-attached-$(date -u +%Y%m%dT%H%M%SZ)" \
   --port-label top --phase attached \
-  --expected-kernel-commit e056649b9b56622fedd806134d4f79dcf251a2f0
+  --expected-kernel-commit 70ddec100fe953712c309067fe2db4d8207facc6 \
+  --expected-device-tree-model "$expected_model"
+
+sudo journalctl -k -b --no-pager | \
+  grep -E 'ps883|qmp-combo|USB4|thunderbolt'
 ```
 
-Repeat from a cold boot for the bottom port. Do not infer a controller port
-number from the physical label; retain the label until a live Type-C event
-correlates it with a router port.
-
-The collector uses standard read-only kernel interfaces and commands. It does
-not access raw MMIO or device registers. The output can still include hardware
-topology and kernel log details, so review and redact it before sharing.
-
-## USB4-tunnel gate
-
-A later experimental DTB may pass the USB4-tunnel gate only when all of these
-are present in one matched attach:
+The useful expected split is:
 
 ```text
-USB4 domain and Qualcomm host router
-downstream dock router
-USB 3 tunnel
-PCIe tunnel where the dock exposes PCIe devices
-DisplayPort tunnel and connected DRM display
-clean detach and reattach
+ps883x: USB4 mode accepted by retimer; host-router state not established
+qmp-combo: USB4/TBT mux request ignored: no active host-router PHY consumer
 ```
 
-`boltctl list`, `/sys/bus/thunderbolt/devices`, `lspci -nnk`, `lsusb -t`, and
-the DRM connector state must agree. A firmware-ready message, a parsed DROM,
-QMP TBT mode, or a retimer TBT notification is not sufficient by itself.
+The first line means the former PS8830 device-tree rejection was bypassed and
+retimer programming completed. The second is the expected next blocker: no
+Linux Qualcomm host-router consumer initialized the USB4 PHY. Charging without
+a USB4 domain remains a valid result for this increment. If a domain or router
+appears unexpectedly, collect it passively; do not rebind or probe registers.
 
-## Expected Output
+Disconnect the dock and power off. On the next boot, use the normal unedited
+v20 entry. Then remove the temporary copy before any future `update-grub`:
 
-For the production v20 DTB, expect:
+```bash
+sudo rm -- "/boot/vmlinuz-$abi-usb4-top-experimental"
+```
 
-- the v20 kernel and Denali DTB to boot;
-- direct DisplayPort Alt Mode to remain functional;
-- both PS8830 nodes to retain the USB4-disable fallback; and
-- no USB4 domain or tunneled DisplayPort claim.
+The packaged source remains available at
+`/usr/lib/linux-image-$abi/sp11-usb4-top-experimental.efi`, so the temporary
+copy is recoverable.
 
-Each collector run writes `metadata.txt`, allowlisted Type-C, Thunderbolt, and
-DRM state, optional `lsusb`, `lspci`, and redacted `boltctl` output, command
-availability and exit status, the current kernel log, and a verified
-`SHA256SUMS` manifest into the selected private output directory. The expected
-kernel commit is metadata; compare it with the package build manifest because
-the running kernel cannot prove its source commit by itself.
+## Interpret against the Windows oracle
 
-## Privacy and Safety
+The reviewed, redacted Windows result proves that this TS4, cable, and top port
+can enumerate the Qualcomm host router, Microsoft root router, TS4 router,
+USB3 and PCIe topology, and a DisplayPort tunnel. A private reviewed device
+graph additionally maps the successful Windows path to `UBF0.PRT1` / `URS1`.
+The bottom Windows run is not a valid negative comparison because `URS0` was
+reserved by KDNET with `CM_PROB_USED_BY_DEBUGGER`.
 
-Do not use `devmem`, `/dev/mem`, raw register tools, debugfs write controls,
-or arbitrary interrupt and clock writes during this procedure. In particular,
-do not copy the X1P controller-window probes from issue 52 onto X1E; their
-addresses are not a verified X1E register map. Follow the conservative safety
-boundary in [ADR0068](../adr/adr-0068-sp11-usb4-dp-integration.md).
+The capture does not provide the host-router MMIO map, interrupts, clocks,
+resets, IOMMU stream IDs, firmware/ring protocol, or decoded PS8830 sideband
+sequence. Do not publish the raw Windows output; use the
+[redacted result](https://github.com/ooaklee/sp11-windows-capture/blob/85161cd5c84f2d7463f74d9ff2a81fcc175ff86c/analysis/usb4-first-attach-20260829/redacted-result.md)
+as the public hardware evidence.
 
-Do not commit or publish Windows driver binaries, extracted controller
-firmware, raw ETL captures, firmware memory, or unredacted diagnostic
-directories. Preserve a known-good GRUB entry and cold-power the device after
-an active experiment. If the device stops producing USB4 events, do not cycle
-the USB4 GDSC or reload an experimental router driver in the same boot.
-
-## Troubleshooting
-
-If direct DisplayPort regresses, boot the known-good kernel and stop USB4
-testing. Save the passive v20 and fallback snapshots for comparison.
-
-If the dock provides USB 2/3 devices but no Thunderbolt domain, that does not
-show partial USB4 success; it may be the ordinary USB fallback path.
-
-If the controller waits for sideband receive connection or link training never
-starts, record the passive state and continue in
-[issue 52](https://github.com/ooaklee/linux-surface-pro-11-oe/issues/52).
-Do not replay the hard-locking probes.
-
-## Related Documents
-
-- [Kernel USB4 PHY integration PR 24](https://github.com/ooaklee/linux_ms_dev_kit-sp11/pull/24)
-- [ADR0068: SP11 USB4 and DisplayPort Integration](../adr/adr-0068-sp11-usb4-dp-integration.md)
-- [ADR0004: Firmware Extraction Policy](../adr/adr-0004-firmware-extraction-policy.md)
-- [ADR0026: Prebuilt Kernel Release Artifacts](../adr/adr-0026-prebuilt-kernel-release-artifacts.md)
-- [Release Kernel Artifacts](how-to-release-kernel-artifacts.md)
+A later kernel may pass the USB4-tunnel gate only when one matched attach
+shows a Linux USB4 domain and host router, downstream router enumeration,
+USB3/PCIe/DisplayPort tunnels, stable display output, detach recovery, and no
+direct-DP regression. This retimer-only experiment is not that claim.

--- a/docs/how-to/how-to-test-sp11-usb4-dp.md
+++ b/docs/how-to/how-to-test-sp11-usb4-dp.md
@@ -1,0 +1,188 @@
+---
+id: how-to-test-sp11-usb4-dp
+title: "Test SP11 USB4 and DisplayPort"
+# prettier-ignore
+description: How-to guide for safely building the Surface Pro 11 v20 USB4 PHY integration, preserving direct DisplayPort fallback, and collecting passive evidence for later USB4-tunnel qualification.
+---
+
+# How To: Test SP11 USB4 and DisplayPort
+
+Use this procedure to build the v20 USB4 integration, verify the working
+direct-DisplayPort baseline, and collect comparable top- and bottom-port
+snapshots. The current v20 increment does not enable the production USB4 path.
+
+## Purpose
+
+Direct USB-C DisplayPort Alt Mode and DisplayPort tunneled through USB4 are
+different tests. A monitor appearing through a direct USB-C cable does not
+prove that a USB4 router or DisplayPort tunnel exists. This guide keeps those
+results separate and establishes the evidence needed for a later USB4-tunnel
+gate.
+
+## Prerequisites
+
+- Surface Pro 11 X1E80100 with AC power connected.
+- A known-good qcom-x1e kernel retained in GRUB and recovery media nearby.
+- Secure Boot disabled for the experimental package.
+- The USB4 v20 support and kernel branches checked out separately from pen
+  work.
+- A direct USB-C DisplayPort cable or monitor for the regression baseline.
+- A known USB4 dock, display, and certified cable for passive topology
+  snapshots. Record whether the physical top or bottom connector is used.
+- A cold shutdown between any future active USB4 experiments. Do not use
+  driver unbind/rebind as a substitute. This is a conservative X1E safety
+  rule derived from the X1P hard-lock observations in issue 52, not a claim
+  that the two variants share a verified controller register map.
+
+## Build the v20 kernel
+
+From the support repository, run:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel-docker.sh \
+  --source git \
+  --git-url https://github.com/ooaklee/linux_ms_dev_kit-sp11.git \
+  --git-branch sp11/integration-7.2.x-usb4-support \
+  --image ubuntu:26.04 \
+  --build-target "binary-indep binary-qcom-x1e" \
+  --work-dir build/docker-sp11-qcom-x1e-kernel-usb4-v20 \
+  --linux-work-volume sp11-qcom-x1e-kernel-usb4-v20 \
+  --copy-to-payload --reset-source --jobs 8
+```
+
+The branch name is mutable. Reject the build unless its generated provenance
+manifest resolves to the exact kernel PR head accepted by ADR0068:
+
+```bash
+grep -Fx \
+  'Source HEAD: e056649b9b56622fedd806134d4f79dcf251a2f0' \
+  build/docker-sp11-qcom-x1e-kernel-usb4-v20/artifacts/sp11-kernel-build-manifest.txt
+```
+
+The four packages must share version `7.2.0-jg-0sp11v20`; the installed image
+ABI is `7.2.0-jg-0sp11v20-qcom-x1e`. Reject mixed-version package sets.
+
+Before installing, run the existing read-only package preflight with the v20
+ABI and an explicitly selected known-good fallback:
+
+```bash
+sudo ./scripts/preflight-sp11-kernel-test.sh \
+  --deb-dir payload/kernel-debs \
+  --target-abi 7.2.0-jg-0sp11v20-qcom-x1e \
+  --fallback-abi YOUR_KNOWN_GOOD_QCOM_X1E_ABI
+```
+
+Install with the existing kernel helper, reboot, and confirm the ABI:
+
+```bash
+./scripts/build-sp11-qcom-x1e-kernel.sh \
+  --work-dir payload/kernel-debs --install-only
+sudo reboot
+uname -r
+```
+
+## Verify the direct-DisplayPort baseline
+
+Connect the monitor directly, without a USB4 dock. Test both physical ports
+and both cable orientations. Record resolution, refresh rate, hotplug, unplug,
+and one suspend/resume cycle.
+
+Passing this phase proves that v20 did not regress Direct USB-C DisplayPort Alt
+Mode. It does not prove a USB4 router or DisplayPort tunnel.
+
+## Collect passive USB4 snapshots
+
+With the dock disconnected, collect a baseline for the port under test:
+
+```bash
+./scripts/collect-sp11-usb4-diagnostics.sh \
+  --out "build/usb4-diagnostics/top-baseline-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --port-label top --phase baseline \
+  --expected-kernel-commit e056649b9b56622fedd806134d4f79dcf251a2f0
+```
+
+Connect the dock, wait 15 seconds, then collect the attached state:
+
+```bash
+./scripts/collect-sp11-usb4-diagnostics.sh \
+  --out "build/usb4-diagnostics/top-attached-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --port-label top --phase attached \
+  --expected-kernel-commit e056649b9b56622fedd806134d4f79dcf251a2f0
+```
+
+Repeat from a cold boot for the bottom port. Do not infer a controller port
+number from the physical label; retain the label until a live Type-C event
+correlates it with a router port.
+
+The collector uses standard read-only kernel interfaces and commands. It does
+not access raw MMIO or device registers. The output can still include hardware
+topology and kernel log details, so review and redact it before sharing.
+
+## USB4-tunnel gate
+
+A later experimental DTB may pass the USB4-tunnel gate only when all of these
+are present in one matched attach:
+
+```text
+USB4 domain and Qualcomm host router
+downstream dock router
+USB 3 tunnel
+PCIe tunnel where the dock exposes PCIe devices
+DisplayPort tunnel and connected DRM display
+clean detach and reattach
+```
+
+`boltctl list`, `/sys/bus/thunderbolt/devices`, `lspci -nnk`, `lsusb -t`, and
+the DRM connector state must agree. A firmware-ready message, a parsed DROM,
+QMP TBT mode, or a retimer TBT notification is not sufficient by itself.
+
+## Expected Output
+
+For the production v20 DTB, expect:
+
+- the v20 kernel and Denali DTB to boot;
+- direct DisplayPort Alt Mode to remain functional;
+- both PS8830 nodes to retain the USB4-disable fallback; and
+- no USB4 domain or tunneled DisplayPort claim.
+
+Each collector run writes `metadata.txt`, allowlisted Type-C, Thunderbolt, and
+DRM state, optional `lsusb`, `lspci`, and redacted `boltctl` output, command
+availability and exit status, the current kernel log, and a verified
+`SHA256SUMS` manifest into the selected private output directory. The expected
+kernel commit is metadata; compare it with the package build manifest because
+the running kernel cannot prove its source commit by itself.
+
+## Privacy and Safety
+
+Do not use `devmem`, `/dev/mem`, raw register tools, debugfs write controls,
+or arbitrary interrupt and clock writes during this procedure. In particular,
+do not copy the X1P controller-window probes from issue 52 onto X1E; their
+addresses are not a verified X1E register map. Follow the conservative safety
+boundary in [ADR0068](../adr/adr-0068-sp11-usb4-dp-integration.md).
+
+Do not commit or publish Windows driver binaries, extracted controller
+firmware, raw ETL captures, firmware memory, or unredacted diagnostic
+directories. Preserve a known-good GRUB entry and cold-power the device after
+an active experiment. If the device stops producing USB4 events, do not cycle
+the USB4 GDSC or reload an experimental router driver in the same boot.
+
+## Troubleshooting
+
+If direct DisplayPort regresses, boot the known-good kernel and stop USB4
+testing. Save the passive v20 and fallback snapshots for comparison.
+
+If the dock provides USB 2/3 devices but no Thunderbolt domain, that does not
+show partial USB4 success; it may be the ordinary USB fallback path.
+
+If the controller waits for sideband receive connection or link training never
+starts, record the passive state and continue in
+[issue 52](https://github.com/ooaklee/linux-surface-pro-11-oe/issues/52).
+Do not replay the hard-locking probes.
+
+## Related Documents
+
+- [Kernel USB4 PHY integration PR 24](https://github.com/ooaklee/linux_ms_dev_kit-sp11/pull/24)
+- [ADR0068: SP11 USB4 and DisplayPort Integration](../adr/adr-0068-sp11-usb4-dp-integration.md)
+- [ADR0004: Firmware Extraction Policy](../adr/adr-0004-firmware-extraction-policy.md)
+- [ADR0026: Prebuilt Kernel Release Artifacts](../adr/adr-0026-prebuilt-kernel-release-artifacts.md)
+- [Release Kernel Artifacts](how-to-release-kernel-artifacts.md)

--- a/docs/how-to/how-to-test-sp11-usb4-dp.md
+++ b/docs/how-to/how-to-test-sp11-usb4-dp.md
@@ -216,7 +216,39 @@ The ABI must be v20 and the model must be the ordinary OLED model, without
 - a direct USB3 device; and
 - Direct USB-C DisplayPort Alt Mode.
 
-Disconnect all test devices and shut down completely after these regressions.
+**Qualification result (2026-08-30):** One-, two-, and three-finger touch, pen
+inking with pressure variation, the barrel button, and a direct USB3 device
+passed on the clean v20 rebuild. Direct USB-C DisplayPort Alt Mode was not run
+because no suitable test device or adapter was available; do not count it as a
+regression pass.
+
+### Capture the guarded attach control
+
+Before selecting the experiment, confirm that the live production tree has two
+guards:
+
+```bash
+test "$(find /sys/firmware/devicetree/base \
+  -type f -name 'parade,disable-usb4' -print | wc -l)" -eq 2
+```
+
+Attach the matched TS4 once to the physical top port and wait 15 seconds. The
+guarded control must reject USB4 mode and must not create a Thunderbolt device
+or USB4 domain. An ordinary USB fallback function may still enumerate; record
+the USB topology instead of treating that as a failure. Use only passive
+evidence:
+
+```bash
+sudo journalctl -k -b --no-pager | \
+  grep -E 'ps883.*USB4 disabled via DT|USB4|thunderbolt'
+lsusb -t
+find /sys/bus/thunderbolt/devices -mindepth 1 -maxdepth 1 -print 2>/dev/null
+```
+
+The 2026-08-30 control session observed the DT policy rejection and no dock
+topology. This is the expected production safety result, not evidence of a bad
+dock or cable. Disconnect all test devices and shut down completely before the
+experimental boot.
 
 ## Prepare the one-boot experimental image
 
@@ -224,6 +256,7 @@ After package installation has completed its `update-grub`, copy the alternate
 EFI image under a distinct filename:
 
 ```bash
+abi=7.2.0-jg-0sp11v20-qcom-x1e
 sudo install -m 0600 \
   "/usr/lib/linux-image-$abi/sp11-usb4-top-experimental.efi" \
   "/boot/vmlinuz-$abi-usb4-top-experimental"
@@ -251,15 +284,18 @@ Leave the command line and `initrd` line unchanged. Do not edit or add a
 
 ## Verify the live experiment before attachment
 
-With the TS4 still disconnected, require both the ABI and live model:
+With the TS4 still disconnected, require the ABI, live model, and one remaining
+guard:
 
 ```bash
 expected_model='Microsoft Surface Pro 11th Edition (OLED, top-port USB4 retimer experiment)'
 test "$(uname -r)" = '7.2.0-jg-0sp11v20-qcom-x1e'
 test "$(tr -d '\0' </proc/device-tree/model)" = "$expected_model"
+test "$(find /sys/firmware/devicetree/base \
+  -type f -name 'parade,disable-usb4' -print | wc -l)" -eq 1
 ```
 
-If either test fails, stop and do not attach the dock.
+If any check fails, stop and do not attach the dock.
 
 ## Collect the one-attach comparison
 
@@ -295,21 +331,47 @@ qmp-combo: USB4/TBT mux request ignored: no active host-router PHY consumer
 ```
 
 The first line means the former PS8830 device-tree rejection was bypassed and
-retimer programming completed. The second is the expected next blocker: no
-Linux Qualcomm host-router consumer initialized the USB4 PHY. Charging without
-a USB4 domain remains a valid result for this increment. If a domain or router
-appears unexpectedly, collect it passively; do not rebind or probe registers.
+the driver completed its USB4 configuration writes without error. It does not
+prove link training or a negotiated USB4 rate. The second means that no active
+host-router PHY consumer existed when the mux request arrived; it does not say
+why initialization was absent or prove that one consumer is the only remaining
+blocker. Charging without a USB4 domain remains a valid result for this
+increment. If a domain or router appears unexpectedly, collect it passively;
+do not rebind or probe registers.
+
+**Observed on 2026-08-30:**
+
+```text
+ps883x_retimer 5-0008: USB4 mode accepted by retimer; host-router state not established
+qcom-qmp-combo-phy fda000.phy: USB4/TBT mux request ignored: no active host-router PHY consumer
+```
+
+The UCSI top-port partner appeared, but USB, PCI, DRM, Thunderbolt, and USB4
+domain snapshots showed no dock topology. This is a pass for the retimer-only
+qualification and a negative result for link, domain, and tunnel establishment.
 
 Disconnect the dock and power off. On the next boot, use the normal unedited
 v20 entry. Then remove the temporary copy before any future `update-grub`:
 
 ```bash
+abi=7.2.0-jg-0sp11v20-qcom-x1e
 sudo rm -- "/boot/vmlinuz-$abi-usb4-top-experimental"
 ```
 
 The packaged source remains available at
 `/usr/lib/linux-image-$abi/sp11-usb4-top-experimental.efi`, so the temporary
-copy is recoverable.
+copy is recoverable. Verify the guarded rollback:
+
+```bash
+test "$(uname -r)" = '7.2.0-jg-0sp11v20-qcom-x1e'
+test "$(tr -d '\0' </proc/device-tree/model)" = \
+  'Microsoft Surface Pro 11th Edition (OLED)'
+test "$(find /sys/firmware/devicetree/base \
+  -type f -name 'parade,disable-usb4' -print | wc -l)" -eq 2
+```
+
+The 2026-08-30 rollback passed those three checks. It did not repeat the manual
+touch, pen, USB3, or direct-DisplayPort regressions after rollback.
 
 ## Interpret against the Windows oracle
 

--- a/scripts/build-sp11-qcom-x1e-kernel-docker.sh
+++ b/scripts/build-sp11-qcom-x1e-kernel-docker.sh
@@ -528,6 +528,107 @@ find_qcom_kernel_debs() {
     -print | sort -u
 }
 
+write_artifact_sha256sums() {
+  local artifact_dir="$1"
+  local checksum_file="$artifact_dir/SHA256SUMS"
+  local checksum_tmp=""
+  local declared_debs=""
+  local exported_debs=""
+  local deb=""
+  local base=""
+  local required=""
+  local checksum_count=""
+  local -a checksum_names=()
+
+  rm -f "$checksum_file" || return 1
+
+  for required in \
+    "$artifact_dir/sp11-kernel-build-manifest.txt" \
+    "$artifact_dir/sp11-kernel-debs.txt"; do
+    if [ ! -f "$required" ] || [ -L "$required" ]; then
+      echo "Missing required regular artifact: $required" >&2
+      return 1
+    fi
+  done
+
+  declared_debs="$(
+    while IFS= read -r deb || [ -n "$deb" ]; do
+      [ -n "$deb" ] || continue
+      base="${deb##*/}"
+      case "$base" in
+        linux-*.deb) printf '%s\n' "$base" ;;
+        *)
+          echo "Invalid package entry in $artifact_dir/sp11-kernel-debs.txt: $deb" >&2
+          exit 1
+          ;;
+      esac
+    done < "$artifact_dir/sp11-kernel-debs.txt" | LC_ALL=C sort
+  )" || return 1
+
+  if [ -z "$declared_debs" ]; then
+    echo "No packages declared in $artifact_dir/sp11-kernel-debs.txt." >&2
+    return 1
+  fi
+  if [ "$declared_debs" != "$(printf '%s\n' "$declared_debs" | LC_ALL=C sort -u)" ]; then
+    echo "Duplicate package entry in $artifact_dir/sp11-kernel-debs.txt." >&2
+    return 1
+  fi
+
+  exported_debs="$(
+    while IFS= read -r deb; do
+      [ -n "$deb" ] || continue
+      printf '%s\n' "${deb##*/}"
+    done < <(find_qcom_kernel_debs "$artifact_dir") | LC_ALL=C sort
+  )" || return 1
+  if [ "$exported_debs" != "$declared_debs" ]; then
+    echo "Exported qcom-x1e packages do not match sp11-kernel-debs.txt." >&2
+    return 1
+  fi
+
+  while IFS= read -r base; do
+    [ -n "$base" ] || continue
+    checksum_names+=("$base")
+  done <<< "$declared_debs"
+  checksum_names+=(
+    sp11-kernel-build-manifest.txt
+    sp11-kernel-debs.txt
+  )
+
+  checksum_tmp="$(mktemp "$artifact_dir/.SHA256SUMS.XXXXXX")" || return 1
+  if command -v sha256sum >/dev/null 2>&1; then
+    if ! (cd "$artifact_dir" && sha256sum -- "${checksum_names[@]}") > "$checksum_tmp"; then
+      rm -f "$checksum_tmp"
+      return 1
+    fi
+  elif command -v shasum >/dev/null 2>&1; then
+    if ! (cd "$artifact_dir" && shasum -a 256 -- "${checksum_names[@]}") > "$checksum_tmp"; then
+      rm -f "$checksum_tmp"
+      return 1
+    fi
+  else
+    echo "sha256sum or shasum is required to checksum exported artifacts." >&2
+    rm -f "$checksum_tmp"
+    return 1
+  fi
+
+  checksum_count="$(wc -l < "$checksum_tmp" | tr -d '[:space:]')"
+  if [ "$checksum_count" -ne "${#checksum_names[@]}" ]; then
+    echo "Incomplete checksum manifest for exported artifacts." >&2
+    rm -f "$checksum_tmp"
+    return 1
+  fi
+
+  if ! chmod 0644 "$checksum_tmp"; then
+    rm -f "$checksum_tmp"
+    return 1
+  fi
+
+  if ! mv -f "$checksum_tmp" "$checksum_file"; then
+    rm -f "$checksum_tmp"
+    return 1
+  fi
+}
+
 container_work_dir="${SP11_CONTAINER_WORK_DIR:-/linux-work}"
 if [ "$container_work_dir" != "/work" ]; then
   while IFS= read -r deb; do
@@ -540,6 +641,8 @@ if [ "$container_work_dir" != "/work" ]; then
     "$container_work_dir/sp11-kernel-debs.txt"; do
     [ -f "$manifest" ] && cp -f "$manifest" "$artifact_dir/"
   done
+
+  write_artifact_sha256sums "$artifact_dir"
 fi
 EOF
 chmod +x "$run_script"

--- a/scripts/collect-sp11-usb4-diagnostics.sh
+++ b/scripts/collect-sp11-usb4-diagnostics.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -euo pipefail
+export LC_ALL=C
+
+usage() {
+	cat <<'EOF'
+Usage: collect-sp11-usb4-diagnostics.sh --out DIR --port-label LABEL [options]
+
+Collect a passive Surface Pro 11 USB-C/USB4 topology snapshot. LABEL should
+describe the physical connector, for example top or bottom.
+
+Options:
+  --phase NAME                    Capture phase. Defaults to attached.
+  --expected-kernel-commit SHA    Expected full 40-character kernel source
+                                  commit. Recorded as evidence; the running
+                                  kernel cannot verify this value itself.
+  -h, --help                      Show this help.
+
+The output can contain hardware topology and kernel logs. This helper reads an
+explicit allowlist of standard sysfs text attributes and runs named read-only
+topology and log commands. It never reads raw MMIO, debugfs, firmware memory,
+device registers, or dedicated EDID and persistent-ID sysfs attributes. UUID
+and serial fields from boltctl are redacted before output is written. Other
+command and log output may still contain identifiers; review and redact the
+complete directory before sharing.
+EOF
+}
+
+out_dir=""
+port_label=""
+phase="attached"
+expected_kernel_commit="not-provided"
+
+while (($#)); do
+	case "$1" in
+	--out)
+		(($# >= 2)) || { usage >&2; exit 2; }
+		out_dir="$2"
+		shift 2
+		;;
+	--port-label)
+		(($# >= 2)) || { usage >&2; exit 2; }
+		port_label="$2"
+		shift 2
+		;;
+	--phase)
+		(($# >= 2)) || { usage >&2; exit 2; }
+		phase="$2"
+		shift 2
+		;;
+	--expected-kernel-commit)
+		(($# >= 2)) || { usage >&2; exit 2; }
+		expected_kernel_commit="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		printf 'error: unknown argument: %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
+
+[[ -n "$out_dir" ]] || { printf 'error: --out is required\n' >&2; exit 2; }
+[[ -n "$port_label" ]] || { printf 'error: --port-label is required\n' >&2; exit 2; }
+[[ "$port_label" =~ ^[A-Za-z0-9._-]+$ ]] || {
+	printf 'error: --port-label must contain only letters, digits, dot, underscore, or dash\n' >&2
+	exit 2
+}
+[[ "$phase" =~ ^[A-Za-z0-9._-]+$ ]] || {
+	printf 'error: --phase must contain only letters, digits, dot, underscore, or dash\n' >&2
+	exit 2
+}
+if [[ "$expected_kernel_commit" != "not-provided" &&
+	! "$expected_kernel_commit" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+	printf 'error: --expected-kernel-commit must be a full 40-character hexadecimal commit\n' >&2
+	exit 2
+fi
+
+hash_tool=""
+if command -v sha256sum >/dev/null 2>&1; then
+	hash_tool="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+	hash_tool="shasum"
+else
+	printf 'error: sha256sum or shasum is required to create SHA256SUMS\n' >&2
+	exit 1
+fi
+
+sha256_line() {
+	if [[ "$hash_tool" == "sha256sum" ]]; then
+		sha256sum -- "$1"
+	else
+		shasum -a 256 -- "$1"
+	fi
+}
+
+sha256_digest() {
+	local line
+
+	line="$(sha256_line "$1")"
+	printf '%s\n' "${line%% *}"
+}
+
+source_mtime_utc() {
+	local path="$1"
+	local epoch
+
+	if epoch="$(stat -c '%Y' -- "$path" 2>/dev/null)" &&
+		[[ "$epoch" =~ ^[0-9]+$ ]]; then
+		date -u -d "@$epoch" '+%Y-%m-%dT%H:%M:%SZ'
+	elif epoch="$(stat -f '%m' -- "$path" 2>/dev/null)" &&
+		[[ "$epoch" =~ ^[0-9]+$ ]]; then
+		date -u -r "$epoch" '+%Y-%m-%dT%H:%M:%SZ'
+	else
+		printf 'unavailable\n'
+	fi
+}
+
+umask 077
+if [[ -e "$out_dir" && ! -d "$out_dir" ]]; then
+	printf 'error: output path exists and is not a directory: %s\n' "$out_dir" >&2
+	exit 2
+fi
+if [[ -d "$out_dir" ]] && find "$out_dir" -mindepth 1 -print -quit | grep -q .; then
+	printf 'error: output directory is not empty: %s\n' "$out_dir" >&2
+	exit 2
+fi
+mkdir -p "$out_dir"
+chmod 700 "$out_dir"
+
+run_optional() {
+	local output="$1"
+	local output_path
+	local status
+	local argument
+	shift
+
+	output_path="$out_dir/$output"
+	{
+		printf 'Command:'
+		for argument in "$@"; do
+			printf ' %q' "$argument"
+		done
+		printf '\n'
+	} >"$output_path"
+
+	if command -v "$1" >/dev/null 2>&1; then
+		printf 'Available: yes\n--- output ---\n' >>"$output_path"
+		if "$@" >>"$output_path" 2>&1; then
+			status=0
+		else
+			status=$?
+		fi
+		printf '\n--- end output ---\nExit status: %d\n' "$status" >>"$output_path"
+	else
+		printf 'Available: no\nExit status: 127\n' >>"$output_path"
+	fi
+}
+
+redact_persistent_identifiers() {
+	awk '
+	{
+		lower = tolower($0)
+		if (lower ~ /(^|[^[:alnum:]_])(uuid|unique[_ -]?id|serial([_ -]?number)?)[[:space:]]*:/) {
+			line = $0
+			sub(/:.*/, ": <redacted>", line)
+			print line
+		} else {
+			print
+		}
+	}'
+}
+
+run_optional_redacted() {
+	local output="$1"
+	local output_path
+	local command_status
+	local filter_status
+	local argument
+	local pipeline_status
+	shift
+
+	output_path="$out_dir/$output"
+	{
+		printf 'Command:'
+		for argument in "$@"; do
+			printf ' %q' "$argument"
+		done
+		printf '\nRedacted fields: UUID, unique ID, serial\n'
+	} >"$output_path"
+
+	if command -v "$1" >/dev/null 2>&1; then
+		printf 'Available: yes\n--- redacted output ---\n' >>"$output_path"
+		if "$@" 2>&1 | redact_persistent_identifiers >>"$output_path"; then
+			pipeline_status=("${PIPESTATUS[@]}")
+		else
+			pipeline_status=("${PIPESTATUS[@]}")
+		fi
+		command_status="${pipeline_status[0]}"
+		filter_status="${pipeline_status[1]}"
+		printf '\n--- end output ---\nExit status: %d\nRedaction filter exit status: %d\n' \
+			"$command_status" "$filter_status" >>"$output_path"
+	else
+		printf 'Available: no\nExit status: 127\nRedaction filter exit status: not-run\n' \
+			>>"$output_path"
+	fi
+}
+
+write_allowed_attr() {
+	local entry="$1"
+	local attribute="$2"
+	local attribute_path="$entry/$attribute"
+	local line
+	local saw_line="false"
+
+	[[ -f "$attribute_path" ]] || return 1
+	printf '  %s:\n' "$attribute"
+	if [[ ! -r "$attribute_path" ]]; then
+		printf '    <unreadable>\n'
+		return 0
+	fi
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		printf '    %s\n' "$line"
+		saw_line="true"
+	done < <(head -c 16384 -- "$attribute_path" 2>/dev/null)
+	if [[ "$saw_line" == "false" ]]; then
+		printf '    <empty>\n'
+	fi
+	return 0
+}
+
+snapshot_sysfs_entries() {
+	local root="$1"
+	local output="$2"
+	local entry
+	local entry_name
+	local link_target
+	local attribute
+	local found_entry="false"
+	local found_attribute
+	shift 2
+	local attributes=("$@")
+
+	if [[ ! -d "$root" ]]; then
+		printf 'sysfs path unavailable: %s\n' "$root" >"$out_dir/$output"
+		return
+	fi
+
+	: >"$out_dir/$output"
+	for entry in "$root"/*; do
+		[[ -e "$entry" || -L "$entry" ]] || continue
+		found_entry="true"
+		entry_name="${entry##*/}"
+		printf '[%s]\n' "$entry_name" >>"$out_dir/$output"
+		if link_target="$(readlink "$entry" 2>/dev/null)"; then
+			printf '  topology-link: %s\n' "$link_target" >>"$out_dir/$output"
+		else
+			printf '  topology-link: <not-a-symlink>\n' >>"$out_dir/$output"
+		fi
+
+		found_attribute="false"
+		for attribute in "${attributes[@]}"; do
+			if write_allowed_attr "$entry" "$attribute" >>"$out_dir/$output"; then
+				found_attribute="true"
+			fi
+		done
+		if [[ "$found_attribute" == "false" ]]; then
+			printf '  allowed-attributes: <none present>\n' >>"$out_dir/$output"
+		fi
+	done
+
+	if [[ "$found_entry" == "false" ]]; then
+		printf 'no sysfs entries present under: %s\n' "$root" >"$out_dir/$output"
+	fi
+}
+
+snapshot_usb4_domains() {
+	local root="/sys/bus/thunderbolt/devices"
+	local path
+	local found="false"
+
+	: >"$out_dir/usb4-domains.txt"
+	if [[ ! -d "$root" ]]; then
+		printf 'sysfs path unavailable: %s\n' "$root" >"$out_dir/usb4-domains.txt"
+		return
+	fi
+
+	for path in "$root"/domain*; do
+		[[ -e "$path" || -L "$path" ]] || continue
+		printf '%s\n' "${path##*/}" >>"$out_dir/usb4-domains.txt"
+		found="true"
+	done
+	if [[ "$found" == "false" ]]; then
+		printf 'no USB4 domains present\n' >"$out_dir/usb4-domains.txt"
+	fi
+}
+
+typec_attributes=(
+	active
+	accessory_mode
+	data_role
+	mode
+	number_of_alternate_modes
+	orientation
+	plug_type
+	port_type
+	power_operation_mode
+	power_role
+	preferred_role
+	svid
+	supports_usb_power_delivery
+	usb_power_delivery_revision
+	usb_typec_revision
+)
+thunderbolt_attributes=(
+	authorized
+	boot
+	deauthorization
+	device
+	device_name
+	generation
+	iommu_dma_protection
+	link_speed
+	nvm_version
+	route
+	rx_lanes
+	rx_speed
+	security
+	tx_lanes
+	tx_speed
+	usb4_version
+	vendor
+	vendor_name
+)
+drm_attributes=(
+	dpms
+	enabled
+	link_status
+	modes
+	status
+)
+
+collector_source="${BASH_SOURCE[0]}"
+capture_started_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+boot_id="unavailable"
+if [[ -r /proc/sys/kernel/random/boot_id ]]; then
+	IFS= read -r boot_id </proc/sys/kernel/random/boot_id || boot_id="unavailable"
+fi
+
+{
+	printf 'Capture started UTC: %s\n' "$capture_started_utc"
+	printf 'Collector source modified UTC: %s\n' "$(source_mtime_utc "$collector_source")"
+	printf 'Collector source SHA-256: %s\n' "$(sha256_digest "$collector_source")"
+	printf 'Kernel release: %s\n' "$(uname -r)"
+	printf 'Kernel build version: %s\n' "$(uname -v)"
+	printf 'Expected kernel source commit: %s\n' "$expected_kernel_commit"
+	printf 'Expected commit verification: metadata-only; compare with the kernel build manifest\n'
+	printf 'Boot ID: %s\n' "$boot_id"
+	printf 'Physical port label: %s\n' "$port_label"
+	printf 'Phase: %s\n' "$phase"
+	printf 'Safety boundary: explicit read-only sysfs allowlist; no raw MMIO or device-register access\n'
+} >"$out_dir/metadata.txt"
+
+snapshot_sysfs_entries \
+	/sys/class/typec sys-class-typec.txt "${typec_attributes[@]}"
+snapshot_sysfs_entries \
+	/sys/bus/thunderbolt/devices sys-bus-thunderbolt-devices.txt \
+	"${thunderbolt_attributes[@]}"
+snapshot_sysfs_entries \
+	/sys/class/drm sys-class-drm.txt "${drm_attributes[@]}"
+
+run_optional lsusb-tree.txt lsusb -t
+run_optional lspci-nnk.txt lspci -nnk
+run_optional_redacted boltctl-list.txt boltctl list
+snapshot_usb4_domains
+run_optional kernel-log.txt journalctl -k -b --no-pager
+
+capture_completed_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'Capture completed UTC: %s\n' "$capture_completed_utc" >>"$out_dir/metadata.txt"
+
+(
+	cd "$out_dir"
+	for output_file in *; do
+		[[ "$output_file" == "SHA256SUMS" || ! -f "$output_file" ]] && continue
+		sha256_line "$output_file"
+	done
+) >"$out_dir/SHA256SUMS"
+
+printf 'USB4 diagnostic snapshot written to %s\n' "$out_dir"
+printf 'Review and redact the directory before sharing or attaching it to an issue.\n'

--- a/scripts/collect-sp11-usb4-diagnostics.sh
+++ b/scripts/collect-sp11-usb4-diagnostics.sh
@@ -16,6 +16,9 @@ Options:
   --expected-kernel-commit SHA    Expected full 40-character kernel source
                                   commit. Recorded as evidence; the running
                                   kernel cannot verify this value itself.
+  --expected-device-tree-model MODEL
+                                  Require an exact live device-tree model
+                                  match before creating the output directory.
   -h, --help                      Show this help.
 
 The output can contain hardware topology and kernel logs. This helper reads an
@@ -32,6 +35,8 @@ out_dir=""
 port_label=""
 phase="attached"
 expected_kernel_commit="not-provided"
+expected_device_tree_model="not-provided"
+device_tree_model_path="/proc/device-tree/model"
 
 while (($#)); do
 	case "$1" in
@@ -53,6 +58,11 @@ while (($#)); do
 	--expected-kernel-commit)
 		(($# >= 2)) || { usage >&2; exit 2; }
 		expected_kernel_commit="$2"
+		shift 2
+		;;
+	--expected-device-tree-model)
+		(($# >= 2)) || { usage >&2; exit 2; }
+		expected_device_tree_model="$2"
 		shift 2
 		;;
 	-h | --help)
@@ -81,6 +91,48 @@ if [[ "$expected_kernel_commit" != "not-provided" &&
 	! "$expected_kernel_commit" =~ ^[0-9A-Fa-f]{40}$ ]]; then
 	printf 'error: --expected-kernel-commit must be a full 40-character hexadecimal commit\n' >&2
 	exit 2
+fi
+if [[ -z "$expected_device_tree_model" || ${#expected_device_tree_model} -gt 512 ||
+	"$expected_device_tree_model" == *$'\n'* ||
+	"$expected_device_tree_model" == *$'\r'* ]]; then
+	printf 'error: --expected-device-tree-model must be a nonempty single-line value of at most 512 characters\n' >&2
+	exit 2
+fi
+read_device_tree_model() {
+	local model=""
+	local model_with_sentinel=""
+	local byte_count="0"
+
+	if [[ -f "$device_tree_model_path" && -r "$device_tree_model_path" ]]; then
+		byte_count="$(head -c 4097 -- "$device_tree_model_path" 2>/dev/null | wc -c)"
+		if ((byte_count > 4096)); then
+			printf 'error: live device-tree model exceeds 4096 bytes\n' >&2
+			return 1
+		fi
+		model_with_sentinel="$(
+			head -c 4096 -- "$device_tree_model_path" 2>/dev/null | tr -d '\0'
+			printf '.'
+		)"
+		model="${model_with_sentinel%.}"
+		if [[ "$model" == *$'\n'* || "$model" == *$'\r'* ]]; then
+			printf 'error: live device-tree model is not a single-line value\n' >&2
+			return 1
+		fi
+	fi
+	if [[ -n "$model" ]]; then
+		printf '%s\n' "$model"
+	else
+		printf 'unavailable\n'
+	fi
+}
+
+live_device_tree_model="$(read_device_tree_model)"
+if [[ "$expected_device_tree_model" != "not-provided" &&
+	"$live_device_tree_model" != "$expected_device_tree_model" ]]; then
+	printf 'error: live device-tree model does not match the required model\n' >&2
+	printf '  required: %s\n' "$expected_device_tree_model" >&2
+	printf '  live:     %s\n' "$live_device_tree_model" >&2
+	exit 1
 fi
 
 hash_tool=""
@@ -363,6 +415,13 @@ fi
 	printf 'Kernel build version: %s\n' "$(uname -v)"
 	printf 'Expected kernel source commit: %s\n' "$expected_kernel_commit"
 	printf 'Expected commit verification: metadata-only; compare with the kernel build manifest\n'
+	printf 'Device tree model: %s\n' "$live_device_tree_model"
+	printf 'Expected device tree model: %s\n' "$expected_device_tree_model"
+	if [[ "$expected_device_tree_model" == "not-provided" ]]; then
+		printf 'Device tree model verification: not requested\n'
+	else
+		printf 'Device tree model verification: exact match\n'
+	fi
 	printf 'Boot ID: %s\n' "$boot_id"
 	printf 'Physical port label: %s\n' "$port_label"
 	printf 'Phase: %s\n' "$phase"

--- a/tests/test-kernel-patch-selection.sh
+++ b/tests/test-kernel-patch-selection.sh
@@ -22,6 +22,29 @@ assert_not_contains() {
   fi
 }
 
+verify_sha256sums() {
+  local directory="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$directory" && sha256sum -c SHA256SUMS >/dev/null)
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "$directory" && shasum -a 256 -c SHA256SUMS >/dev/null)
+  else
+    fail "sha256sum or shasum is required for checksum tests"
+  fi
+}
+
+file_mode() {
+  local path="$1"
+  local mode=""
+
+  if mode="$(stat -c '%a' "$path" 2>/dev/null)"; then
+    printf '%s\n' "$mode"
+  else
+    stat -f '%Lp' "$path"
+  fi
+}
+
 write_build_manifest() {
   local path="$1"
   local source_head="$2"
@@ -127,6 +150,8 @@ run_release_tests() {
 
 run_build_helper_tests() {
   local test_root wrapper_dir fixture source_head checkout manifest
+  local checksum_helper checksum_fixture failure_fixture scenario
+  local expected_checksum_names actual_checksum_names
   test_root="$(mktemp -d "${TMPDIR:-/tmp}/sp11-build-patches.XXXXXX")"
   trap 'rm -rf "$test_root"' RETURN
 
@@ -143,6 +168,77 @@ run_build_helper_tests() {
   if grep -Eq '^--patch-dir(s)?$' "$wrapper_dir/docker-build-args.txt"; then
     fail "wrapper forwarded a patch option when none was supplied"
   fi
+
+  checksum_helper="$test_root/artifact-checksum-helper.sh"
+  {
+    sed -n '/^find_qcom_kernel_debs() {/,/^}/p' \
+      "$wrapper_dir/docker-build-inside.sh"
+    sed -n '/^write_artifact_sha256sums() {/,/^}/p' \
+      "$wrapper_dir/docker-build-inside.sh"
+  } > "$checksum_helper"
+  assert_contains "$checksum_helper" "find_qcom_kernel_debs() {"
+  assert_contains "$checksum_helper" "write_artifact_sha256sums() {"
+  # shellcheck source=/dev/null
+  . "$checksum_helper"
+
+  checksum_fixture="$test_root/checksum-artifacts"
+  mkdir -p "$checksum_fixture"
+  for deb in \
+    linux-headers-7.2-test-qcom-x1e_7.2-test_arm64.deb \
+    linux-image-7.2-test-qcom-x1e_7.2-test_arm64.deb \
+    linux-modules-7.2-test-qcom-x1e_7.2-test_arm64.deb \
+    linux-qcom-x1e-headers-7.2-test_7.2-test_all.deb; do
+    printf 'fixture package: %s\n' "$deb" > "$checksum_fixture/$deb"
+    printf '/linux-work/source/%s\n' "$deb" >> \
+      "$checksum_fixture/sp11-kernel-debs.txt"
+  done
+  printf 'Source HEAD: fixture\nLocal patches: none\n' > \
+    "$checksum_fixture/sp11-kernel-build-manifest.txt"
+  printf 'unrelated stale file\n' > "$checksum_fixture/stale-note.txt"
+
+  write_artifact_sha256sums "$checksum_fixture"
+  [ "$(wc -l < "$checksum_fixture/SHA256SUMS" | tr -d '[:space:]')" -eq 6 ] || \
+    fail "artifact checksum manifest does not contain exactly six entries"
+  expected_checksum_names="$(printf '%s\n' \
+    linux-headers-7.2-test-qcom-x1e_7.2-test_arm64.deb \
+    linux-image-7.2-test-qcom-x1e_7.2-test_arm64.deb \
+    linux-modules-7.2-test-qcom-x1e_7.2-test_arm64.deb \
+    linux-qcom-x1e-headers-7.2-test_7.2-test_all.deb \
+    sp11-kernel-build-manifest.txt \
+    sp11-kernel-debs.txt)"
+  actual_checksum_names="$(awk '{ print $2 }' "$checksum_fixture/SHA256SUMS")"
+  [ "$actual_checksum_names" = "$expected_checksum_names" ] || \
+    fail "artifact checksum manifest is not deterministic"
+  assert_not_contains "$checksum_fixture/SHA256SUMS" "SHA256SUMS"
+  assert_not_contains "$checksum_fixture/SHA256SUMS" "stale-note.txt"
+  [ "$(file_mode "$checksum_fixture/SHA256SUMS")" = 644 ] || \
+    fail "artifact checksum manifest is not mode 0644"
+  verify_sha256sums "$checksum_fixture"
+
+  for scenario in missing-deb extra-deb missing-build-manifest missing-deb-manifest; do
+    failure_fixture="$test_root/checksum-$scenario"
+    cp -R "$checksum_fixture" "$failure_fixture"
+    case "$scenario" in
+      missing-deb)
+        rm -f "$failure_fixture/linux-image-7.2-test-qcom-x1e_7.2-test_arm64.deb"
+        ;;
+      extra-deb)
+        printf 'stale package\n' > \
+          "$failure_fixture/linux-modules-extra-7.2-test-qcom-x1e_7.2-test_arm64.deb"
+        ;;
+      missing-build-manifest)
+        rm -f "$failure_fixture/sp11-kernel-build-manifest.txt"
+        ;;
+      missing-deb-manifest)
+        rm -f "$failure_fixture/sp11-kernel-debs.txt"
+        ;;
+    esac
+    if write_artifact_sha256sums "$failure_fixture" >/dev/null 2>&1; then
+      fail "artifact checksum helper accepted $scenario"
+    fi
+    [ ! -e "$failure_fixture/SHA256SUMS" ] || \
+      fail "artifact checksum helper retained SHA256SUMS after $scenario"
+  done
 
   fixture="$test_root/source"
   git init -q "$fixture"

--- a/tests/test-usb4-integration-policy.sh
+++ b/tests/test-usb4-integration-policy.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -euo pipefail
+export LC_ALL=C
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+collector="$repo_dir/scripts/collect-sp11-usb4-diagnostics.sh"
+adr="$repo_dir/docs/adr/adr-0068-sp11-usb4-dp-integration.md"
+guide="$repo_dir/docs/how-to/how-to-test-sp11-usb4-dp.md"
+test_root=""
+
+fail() {
+	printf 'FAIL: %s\n' "$*" >&2
+	exit 1
+}
+
+cleanup() {
+	if [[ -n "$test_root" && -d "$test_root" ]]; then
+		rm -rf -- "$test_root"
+	fi
+}
+
+trap cleanup EXIT
+
+assert_contains() {
+	local path="$1"
+	local text="$2"
+
+	grep -Fq -- "$text" "$path" || fail "$path is missing: $text"
+}
+
+file_mode() {
+	local path="$1"
+	local mode
+
+	if mode="$(stat -c '%a' -- "$path" 2>/dev/null)"; then
+		printf '%s\n' "$mode"
+	else
+		stat -f '%Lp' -- "$path"
+	fi
+}
+
+assert_mode() {
+	local path="$1"
+	local expected="$2"
+	local actual
+
+	actual="$(file_mode "$path")"
+	[[ "$actual" == "$expected" ]] ||
+		fail "$path has mode $actual; expected $expected"
+}
+
+verify_sha256sums() {
+	local directory="$1"
+
+	if command -v sha256sum >/dev/null 2>&1; then
+		(cd "$directory" && sha256sum -c SHA256SUMS >/dev/null)
+	elif command -v shasum >/dev/null 2>&1; then
+		(cd "$directory" && shasum -a 256 -c SHA256SUMS >/dev/null)
+	else
+		fail 'sha256sum or shasum is required to verify the collector manifest'
+	fi
+}
+
+bash -n "$collector"
+"$collector" --help >/dev/null
+
+assert_contains "$adr" '7.2.0-jg-0sp11v20'
+assert_contains "$adr" 'sp11/integration-7.2.x-usb4-support'
+assert_contains "$adr" 'parade,disable-usb4'
+assert_contains "$adr" 'does not establish full USB4 support'
+assert_contains "$adr" 'linux_ms_dev_kit-sp11/pull/24'
+assert_contains "$adr" '5b5f1d124b7ad43b9aac076ad65aa27fa3689ce9'
+assert_contains "$adr" 'e056649b9b56622fedd806134d4f79dcf251a2f0'
+assert_contains "$guide" 'Direct USB-C DisplayPort Alt Mode'
+assert_contains "$guide" 'USB4-tunnel gate'
+# This is a literal Markdown fragment, not shell command substitution.
+# shellcheck disable=SC2016
+assert_contains "$guide" 'Do not use `devmem`'
+assert_contains "$collector" '--expected-kernel-commit'
+assert_contains "$collector" 'Capture started UTC:'
+assert_contains "$collector" 'Capture completed UTC:'
+assert_contains "$collector" 'Collector source modified UTC:'
+assert_contains "$collector" 'Boot ID:'
+assert_contains "$collector" 'data_role'
+assert_contains "$collector" 'usb4_version'
+assert_contains "$collector" 'link_status'
+assert_contains "$collector" 'SHA256SUMS'
+
+if grep -Eq '(^|[[:space:]])(devmem|i2cget|i2cset|i2ctransfer|setpci)([[:space:]]|$)|/dev/mem|/sys/kernel/debug|(^|[[:space:]])tee[[:space:]]+/sys/' "$collector"; then
+	fail 'collector contains a raw hardware-access command'
+fi
+
+sysfs_allowlist="$(sed -n \
+	-e '/^typec_attributes=(/,/^)/p' \
+	-e '/^thunderbolt_attributes=(/,/^)/p' \
+	-e '/^drm_attributes=(/,/^)/p' "$collector")"
+if printf '%s\n' "$sysfs_allowlist" |
+	grep -Eqi '(^|[^A-Za-z0-9_])(edid|unique_id|uuid|serial_number)([^A-Za-z0-9_]|$)'; then
+	fail 'sysfs allowlist contains a prohibited persistent identifier'
+fi
+
+if git -C "$repo_dir" ls-files --cached --others --exclude-standard |
+	grep -Eiq '(^|/)(sp11-usb4-uc-fw\.(bin|mbn|elf)|[^/]+\.(etl|evtx|sys|pdb|tmf))$'; then
+	fail 'tracked proprietary USB4 firmware, Windows driver, or ETL artifact found'
+fi
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/sp11-usb4-policy.XXXXXX")"
+fake_bin="$test_root/fake-bin"
+capture_dir="$test_root/capture"
+nonempty_dir="$test_root/nonempty"
+invalid_dir="$test_root/invalid-commit"
+expected_commit="0123456789abcdef0123456789abcdef01234567"
+mkdir -p "$fake_bin" "$nonempty_dir"
+
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'printf "%s\n" "fake lsusb tree"' >"$fake_bin/lsusb"
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'printf "%s\n" "fake lspci failure" >&2' \
+	'exit 7' >"$fake_bin/lspci"
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'printf "%s\n" "fake bolt topology" "  uuid: 01234567-89ab-cdef-0123-456789abcdef" "  serial: PRIVATE-SERIAL"' \
+	>"$fake_bin/boltctl"
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'printf "%s\n" "fake kernel log"' >"$fake_bin/journalctl"
+chmod 700 "$fake_bin"/*
+
+PATH="$fake_bin:$PATH" "$collector" \
+	--out "$capture_dir" \
+	--port-label top \
+	--phase baseline \
+	--expected-kernel-commit "$expected_commit" >/dev/null
+
+assert_mode "$capture_dir" 700
+for generated_file in "$capture_dir"/*; do
+	[[ -f "$generated_file" ]] || continue
+	assert_mode "$generated_file" 600
+done
+
+assert_contains "$capture_dir/metadata.txt" "Expected kernel source commit: $expected_commit"
+assert_contains "$capture_dir/metadata.txt" 'Expected commit verification: metadata-only'
+assert_contains "$capture_dir/metadata.txt" 'Capture started UTC:'
+assert_contains "$capture_dir/metadata.txt" 'Capture completed UTC:'
+assert_contains "$capture_dir/metadata.txt" 'Collector source SHA-256:'
+assert_contains "$capture_dir/metadata.txt" 'Boot ID:'
+assert_contains "$capture_dir/lsusb-tree.txt" 'Available: yes'
+assert_contains "$capture_dir/lsusb-tree.txt" 'Exit status: 0'
+assert_contains "$capture_dir/lspci-nnk.txt" 'Available: yes'
+assert_contains "$capture_dir/lspci-nnk.txt" 'Exit status: 7'
+assert_contains "$capture_dir/boltctl-list.txt" 'Exit status: 0'
+assert_contains "$capture_dir/boltctl-list.txt" 'uuid: <redacted>'
+assert_contains "$capture_dir/boltctl-list.txt" 'serial: <redacted>'
+if grep -Fq 'PRIVATE-SERIAL' "$capture_dir/boltctl-list.txt"; then
+	fail 'boltctl output retained a persistent serial value'
+fi
+if grep -Fq '01234567-89ab-cdef-0123-456789abcdef' "$capture_dir/boltctl-list.txt"; then
+	fail 'boltctl output retained a persistent UUID value'
+fi
+assert_contains "$capture_dir/kernel-log.txt" 'Exit status: 0'
+verify_sha256sums "$capture_dir"
+
+if grep -Fq 'SHA256SUMS' "$capture_dir/SHA256SUMS"; then
+	fail 'SHA256SUMS must not include itself'
+fi
+
+printf 'sentinel\n' >"$nonempty_dir/keep.txt"
+if "$collector" --out "$nonempty_dir" --port-label top >/dev/null 2>&1; then
+	fail 'collector accepted a nonempty output directory'
+fi
+assert_contains "$nonempty_dir/keep.txt" 'sentinel'
+
+if "$collector" \
+	--out "$invalid_dir" \
+	--port-label top \
+	--expected-kernel-commit short >/dev/null 2>&1; then
+	fail 'collector accepted a non-full expected kernel commit'
+fi
+[[ ! -e "$invalid_dir" ]] || fail 'invalid commit input created an output directory'
+
+printf 'PASS: USB4 integration policy\n'

--- a/tests/test-usb4-integration-policy.sh
+++ b/tests/test-usb4-integration-policy.sh
@@ -73,12 +73,26 @@ assert_contains "$adr" 'does not establish full USB4 support'
 assert_contains "$adr" 'linux_ms_dev_kit-sp11/pull/24'
 assert_contains "$adr" '5b5f1d124b7ad43b9aac076ad65aa27fa3689ce9'
 assert_contains "$adr" 'e056649b9b56622fedd806134d4f79dcf251a2f0'
+assert_contains "$adr" '672638f963d37f55a93544568db41bfc4469df6d'
+assert_contains "$adr" '5321047ea5e2d23d44b0041b69db776c46eb015f'
+assert_contains "$adr" '70ddec100fe953712c309067fe2db4d8207facc6'
+assert_contains "$adr" 'x1e80100-microsoft-denali-oled-usb4-top-experimental.dtb'
+assert_contains "$adr" 'sp11-usb4-top-experimental.efi'
 assert_contains "$guide" 'Direct USB-C DisplayPort Alt Mode'
 assert_contains "$guide" 'USB4-tunnel gate'
+assert_contains "$guide" '70ddec100fe953712c309067fe2db4d8207facc6'
+assert_contains "$guide" '/usr/lib/linux-image-$abi/sp11-usb4-top-experimental.efi'
+assert_contains "$guide" '/boot/vmlinuz-$abi-usb4-top-experimental'
+assert_contains "$guide" 'linux-modules'
+assert_contains "$guide" 'Leave the command line and `initrd` line unchanged'
+assert_contains "$guide" 'Do not edit or add a'
+assert_contains "$guide" 'CM_PROB_USED_BY_DEBUGGER'
 # This is a literal Markdown fragment, not shell command substitution.
 # shellcheck disable=SC2016
 assert_contains "$guide" 'Do not use `devmem`'
 assert_contains "$collector" '--expected-kernel-commit'
+assert_contains "$collector" '--expected-device-tree-model'
+assert_contains "$collector" '/proc/device-tree/model'
 assert_contains "$collector" 'Capture started UTC:'
 assert_contains "$collector" 'Capture completed UTC:'
 assert_contains "$collector" 'Collector source modified UTC:'
@@ -87,6 +101,13 @@ assert_contains "$collector" 'data_role'
 assert_contains "$collector" 'usb4_version'
 assert_contains "$collector" 'link_status'
 assert_contains "$collector" 'SHA256SUMS'
+
+if grep -Fq '/boot/sp11-denali-v20-usb4-top-experimental.dtb' "$guide"; then
+	fail 'guide still uses the ineffective loose-DTB Stubble boot flow'
+fi
+if grep -Fq 'preflight-sp11-kernel-test.sh' "$guide"; then
+	fail 'guide still invokes the distinct-ABI preflight for a same-ABI rebuild'
+fi
 
 if grep -Eq '(^|[[:space:]])(devmem|i2cget|i2cset|i2ctransfer|setpci)([[:space:]]|$)|/dev/mem|/sys/kernel/debug|(^|[[:space:]])tee[[:space:]]+/sys/' "$collector"; then
 	fail 'collector contains a raw hardware-access command'
@@ -111,6 +132,7 @@ fake_bin="$test_root/fake-bin"
 capture_dir="$test_root/capture"
 nonempty_dir="$test_root/nonempty"
 invalid_dir="$test_root/invalid-commit"
+model_mismatch_dir="$test_root/model-mismatch"
 expected_commit="0123456789abcdef0123456789abcdef01234567"
 mkdir -p "$fake_bin" "$nonempty_dir"
 
@@ -130,7 +152,8 @@ printf '%s\n' \
 	'printf "%s\n" "fake kernel log"' >"$fake_bin/journalctl"
 chmod 700 "$fake_bin"/*
 
-PATH="$fake_bin:$PATH" "$collector" \
+PATH="$fake_bin:$PATH" \
+	"$collector" \
 	--out "$capture_dir" \
 	--port-label top \
 	--phase baseline \
@@ -144,6 +167,9 @@ done
 
 assert_contains "$capture_dir/metadata.txt" "Expected kernel source commit: $expected_commit"
 assert_contains "$capture_dir/metadata.txt" 'Expected commit verification: metadata-only'
+assert_contains "$capture_dir/metadata.txt" 'Device tree model:'
+assert_contains "$capture_dir/metadata.txt" 'Expected device tree model: not-provided'
+assert_contains "$capture_dir/metadata.txt" 'Device tree model verification: not requested'
 assert_contains "$capture_dir/metadata.txt" 'Capture started UTC:'
 assert_contains "$capture_dir/metadata.txt" 'Capture completed UTC:'
 assert_contains "$capture_dir/metadata.txt" 'Collector source SHA-256:'
@@ -181,5 +207,15 @@ if "$collector" \
 	fail 'collector accepted a non-full expected kernel commit'
 fi
 [[ ! -e "$invalid_dir" ]] || fail 'invalid commit input created an output directory'
+
+if "$collector" \
+	--out "$model_mismatch_dir" \
+	--port-label top \
+	--expected-device-tree-model 'impossible-test-only-device-tree-model-0123456789abcdef' \
+	>/dev/null 2>&1; then
+	fail 'collector accepted a mismatched live device-tree model'
+fi
+[[ ! -e "$model_mismatch_dir" ]] || \
+	fail 'mismatched device-tree model created an output directory'
 
 printf 'PASS: USB4 integration policy\n'


### PR DESCRIPTION
## Summary

Define the production-safe OE boundary for Surface Pro 11 USB4 groundwork at `7.2.0-jg-0sp11v20`, and document the completed clean build plus one controlled top-port retimer qualification.

This is **not** complete USB4 support. Both production Denali PS8830 nodes retain `parade,disable-usb4`. The isolated experiment reached the retimer USB4 configuration path, but no active host-router PHY consumer, USB4 domain/router, dock USB/Thunderbolt enumeration, or USB3/PCIe/DisplayPort tunnel appeared.

- Base: `main` at `aecdfa10ad39d7f1e3e612b748f23bc5189a06dd`
- Support head: [`3dd3b4c`](https://github.com/ooaklee/linux-surface-pro-11-oe/commit/3dd3b4c)
- Kernel head: [`70ddec100fe9`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/70ddec100fe953712c309067fe2db4d8207facc6), reviewed in [kernel PR 24](https://github.com/ooaklee/linux_ms_dev_kit-sp11/pull/24)

## OE integration

- [`ADR0068`](https://github.com/ooaklee/linux-surface-pro-11-oe/blob/sp11/integration-7.2.x-usb4-support/docs/adr/adr-0068-sp11-usb4-dp-integration.md) records exact public-series provenance, the host-router boundary, build/package evidence, runtime results, and the remaining production gates.
- The [USB4 test guide](https://github.com/ooaklee/linux-surface-pro-11-oe/blob/sp11/integration-7.2.x-usb4-support/docs/how-to/how-to-test-sp11-usb4-dp.md) preserves v16 as the independent fallback and makes the alternate image an explicit, transient GRUB selection.
- `collect-sp11-usb4-diagnostics.sh` captures only bounded, passive Type-C, Thunderbolt, USB/PCI, DRM, and kernel-log evidence beneath ignored private build paths.
- The USB4 policy and preflight tests prohibit raw MMIO, debugfs register writes, firmware-memory access, driver rebinding, and user-triggered power-domain changes.
- [`d9f56ca`](https://github.com/ooaklee/linux-surface-pro-11-oe/commit/d9f56ca) makes Docker artifact export fail closed: it compares declared and exported package sets, requires both provenance manifests, and atomically writes a mode-`0644` `SHA256SUMS`.

## Clean v20 qualification build

The Ubuntu 26.04 build completed from exact kernel head `70ddec100fe953712c309067fe2db4d8207facc6` with source mode `git`, `Local patches: none`, target `binary-indep binary-qcom-x1e`, and eight jobs. All four packages report version `7.2.0-jg-0sp11v20`.

The operator intentionally cleared the earlier local build and untracked payload assets before this rebuild. The installed guarded v20 was the pre-install control; a complete v16 kernel, initrd, modules directory, and GRUB entry were confirmed as the independent rollback.

| Artifact | Arch | SHA-256 |
|---|---:|---|
| `linux-headers-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `arm64` | `535cef2ee7043a7756c9b57fd225d8353eff03c6b6404c1aed6750d59cb3404e` |
| `linux-image-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `arm64` | `ea0354d32dd11ae0fa0cb3b2d443099e37def695a6c119239b852d095c6a6333` |
| `linux-modules-7.2.0-jg-0sp11v20-qcom-x1e_7.2.0-jg-0sp11v20_arm64.deb` | `arm64` | `64fbda78899a0a145fe826e33657c7a9b6cb359c34d4cfd98255ac5ab41d1ac1` |
| `linux-qcom-x1e-headers-7.2.0-jg-0sp11v20_7.2.0-jg-0sp11v20_all.deb` | `all` | `763579b1d489a834c59ceb8710204810bb593a8fca56561084b5c0b68ce5238b` |

- Source/build manifest: `4d1a7675fbbdfc11c8ca84bd040aa3446f1a0a702ebcc97e48501002ac252348`
- Package-list manifest: `8fc74e8f48e3cef6a1cc487ff0c55e073f4244017607c7ae419ecfdd0adec358`
- Six-entry `SHA256SUMS`: `980d4c3dca485b7f575c4f95c5ef8b0482a7ac6c5306c80aec21fd4904e13c88`

Strict checksum verification passed independently. Package inspection also confirmed:

- normal PE image: 38 `.dtbauto` sections, ordinary production DTB set, no experimental marker;
- alternate PE image: exactly one `.dtbauto`, exact top-port experimental model;
- production/experimental guard counts: `2/1`;
- identical normal/alternate `.linux` payloads, differing only in embedded DTBs;
- the only experimental package path is `/usr/lib/linux-image-<ABI>/sp11-usb4-top-experimental.efi`; and
- no experimental image or loose experimental DTB is installed under `/boot` by the package.

## Controlled runtime result

The guarded v20 control boot used the ordinary OLED model and two live guards. One-, two-, and three-finger touch, pen inking/pressure/barrel button, and a direct USB3 device passed. Direct USB-C DisplayPort Alt Mode was not retested because suitable test hardware was unavailable. The guarded TS4 attach encountered the expected DT policy rejection and created no USB4 domain.

After a cold power cycle, the transient alternate image booted with the exact experimental model and only the bottom-port guard. One top-port attach of the matched CalDigit TS4 and bundled 40 Gb/s cable produced:

```text
ps883x_retimer 5-0008: USB4 mode accepted by retimer; host-router state not established
qcom-qmp-combo-phy fda000.phy: USB4/TBT mux request ignored: no active host-router PHY consumer
```

The first line is emitted after the driver completes its USB4 configuration writes without error. It does not prove a trained USB4 link or negotiated rate. The second establishes that no active host-router PHY consumer existed at the mux request; it does not establish why initialization was absent or prove that this is the sole remaining blocker.

UCSI reported the top Type-C/PD partner, but USB, PCI, DRM, Thunderbolt, and USB4-domain snapshots showed no dock topology. This passes the retimer-only qualification and remains a negative result for USB4 link, domain, dock, and tunnel functionality.

A subsequent cold boot of the normal unedited v20 image restored the ordinary model and both production guards. The private baseline and attached snapshots each pass their own checksum manifests; only the two driver lines and sanitized conclusions above are published.

## Hardware oracle and privacy boundary

The public, redacted [same-device Windows result](https://github.com/ooaklee/sp11-windows-capture/blob/85161cd5c84f2d7463f74d9ff2a81fcc175ff86c/analysis/usb4-first-attach-20260829/redacted-result.md) proves that this TS4, bundled cable, and top port can form a real USB4 connection with USB3, PCIe, and DisplayPort tunnels under Windows. It is a matched hardware oracle, not Linux source provenance.

Raw Windows output, proprietary firmware, raw Linux captures, controller memory, and unsafe register experiments remain private and outside the repository.

## Validation

| Gate | Result |
|---|---|
| Kernel PR integration CI | Pass |
| `git diff --check` and Bash syntax | Pass |
| Kernel patch-selection/release-provenance suite | Pass |
| Distinct-ABI hardware-test preflight | Pass: 29 cases |
| USB4 integration policy suite | Pass |
| Checksum success/failure/mode regression cases | Pass |
| Clean qcom-x1e package build and strict artifact verification | Pass at `70ddec100fe9` |
| Normal/alternate EFI and DTB isolation | Pass |
| Guarded control and guarded rollback | Pass |
| Top-port retimer-only qualification | Pass for the bounded scope |
| Direct DisplayPort regression | Not run; suitable hardware unavailable |
| USB4 link/domain/router/tunnels | Not established |

This PR publishes no kernel binary or proprietary payload.