### PR TITLE
feat(fedora): add native IPTSD RPM source contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ The first implemented image adapter is
 without being buildable; `catalog show` reports an entry's actual support
 level.
 
+Fedora Workstation Live 44 is implemented by Lexr's `fedora-live` adapter.
+Lexr owns its EROFS remastering, native custom-kernel RPM, boot policy,
+Anaconda hand-off, and ISO validation. This repository owns the corresponding
+reusable [Fedora IPTSD package-source input](userspace/iptsd-sp11/packaging/fedora/README.md),
+not a second Fedora build or remastering workflow.
+
 ## Build the CLI
 
 The build host needs Go 1.26 or newer. Image and kernel builds also need a

--- a/README.md
+++ b/README.md
@@ -43,17 +43,18 @@ The primary recorded X1E hardware target is:
 | Firmware/UEFI | `175.222.235`, dated 2026-02-23 |
 | Internal disk | Samsung `MZ9L4512HBLU-00BMV-SAMSUNG`, 476.9 GiB NVMe |
 | Windows source checked | Windows 11 Home Insider Preview build `29585` |
-| Latest published project kernel | [`sp11v19`](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2.0-jg-0sp11v19), based on Linux 7.2.0 |
-| Exact project source | [`2cbd1ec3…`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/2cbd1ec3e2da385e7bd91fd65c63ba5a8fb5b865) |
+| Most recent experimental kernel release | [`7.2.2-jg-0sp11v1`](https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2.2-jg-0sp11v1), based on Linux 7.2.2 |
+| Exact project source | [`050f0cb5…`](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/050f0cb5533e1d88e3955a515b5e8e4c847ffe0d) |
 
-The published `sp11v19` package is a Linux 7.2.0-based downstream integration,
-not the latest official Linux kernel. As of 2026-08-31, kernel.org lists stable
-7.2.2 and mainline 7.3-rc1; consult the current
-[kernel.org release record](https://www.kernel.org/releases.json) rather than
-inferring upstream status from the project release number. The final v19
-rebuild was package- and source-validated but was not separately boot-tested as
-one all-up image. Individual green entries below name hardware evidence from
-the relevant accepted integration generation.
+The published `7.2.2-jg-0sp11v1` bundle is a Linux 7.2.2-based downstream
+integration, not a claim about the latest official Linux kernel. As of
+2026-08-31, kernel.org lists stable 7.2.2 and mainline 7.3-rc1. Check the
+current [kernel.org release record](https://www.kernel.org/releases.json)
+instead of inferring upstream status from the project release number. The v1
+bundle was
+package-, source-, and Stubble-image-validated, but has not been boot-tested on
+Surface hardware as one all-up image. Individual green entries below name
+hardware evidence from the relevant accepted integration generation.
 
 Legend: ✅ hardware-verified; ⚠️ hardware-verified with material limitations or
 older-version scope; 🧪 experimental hardware result, not supported; 🧩

--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ established
 [OE release page](https://github.com/ooaklee/linux-surface-pro-11-oe/releases).
 
 > [!NOTE]
-> Lexr.sh remains private during the repository migration. Only authenticated
-> GitHub users with access to Lexr can populate `cli/lexr`; an ordinary clone
-> of this OE repository still works, but CLI-dependent procedures require the
-> populated submodule. The recorded HTTPS URL will work anonymously without
-> another OE change when Lexr becomes public.
+> Lexr.sh is public. The pinned HTTPS submodule can be populated anonymously,
+> including by `git clone --recurse-submodules`; credentials are needed only
+> for operations that write to GitHub or for private forks.
 
 > [!WARNING]
 > The generated media, custom kernels and hardware support remain
@@ -113,8 +111,7 @@ The build host needs Go 1.26 or newer. Image and kernel builds also need a
 running Docker daemon with Linux ARM64 container support. Initialise the pinned
 submodule after cloning this repository, then build Lexr from its module.
 
-For a new checkout, configure GitHub HTTPS credentials with access to Lexr
-while it remains private, then clone both repositories together:
+For a new checkout, clone both public repositories together:
 
 ```sh
 git clone --recurse-submodules \
@@ -137,9 +134,8 @@ These examples select the integration branch explicitly while the cut-over is
 under review. Omit `--branch cli/linux-armer` and the branch-switching steps
 after the same changes reach the repository's default branch.
 
-While Lexr remains private, both forms require GitHub HTTPS credentials with
-access to `ooaklee/lexr.sh`. Once that repository is public, the recorded HTTPS
-submodule URL will work without authentication.
+The recorded HTTPS submodule URL works anonymously. Add GitHub credentials only
+when pushing changes or when your chosen fork is private.
 
 Then use the provenance-aware source builder and run the command:
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ The published `7.2.2-jg-0sp11v1` bundle is a Linux 7.2.2-based downstream
 integration, not a claim about the latest official Linux kernel. As of
 2026-08-31, kernel.org lists stable 7.2.2 and mainline 7.3-rc1. Check the
 current [kernel.org release record](https://www.kernel.org/releases.json)
-instead of inferring upstream status from the project release number. The v1
-bundle was
-package-, source-, and Stubble-image-validated, but has not been boot-tested on
-Surface hardware as one all-up image. Individual green entries below name
-hardware evidence from the relevant accepted integration generation.
+instead of inferring upstream status from the project release number.
+
+The v1 bundle was package-, source-, and Stubble-image-validated, but has not
+been boot-tested on Surface hardware as one all-up image. Individual green
+entries below name hardware evidence from the relevant accepted integration
+generation.
 
 Legend: ✅ hardware-verified; ⚠️ hardware-verified with material limitations or
 older-version scope; 🧪 experimental hardware result, not supported; 🧩

--- a/docs/adr/adr-0069-standalone-lexr-workflow-ownership.md
+++ b/docs/adr/adr-0069-standalone-lexr-workflow-ownership.md
@@ -23,8 +23,9 @@ release lifecycle and issue tracker as [Lexr](https://github.com/ooaklee/lexr.sh
 
 Keeping a second source copy in OE would split issue ownership and allow the
 two implementations to drift. Running Lexr-dependent automation from OE would
-also require OE to obtain a private cross-repository checkout credential while
-Lexr remains access-controlled. That reverses the intended ownership boundary.
+also have required OE to obtain a private cross-repository checkout credential
+while Lexr was access-controlled. That would have reversed the intended
+ownership boundary.
 
 OE nevertheless remains the public authority for Surface Pro 11 integration
 evidence, kernel and device-support artefacts, historical decisions, patches,
@@ -45,7 +46,7 @@ those established release channels.
   repository-scoped credential permits only the required cross-repository OE
   release operation, and publication remains bound to an exact OE `main`
   revision.
-- OE does not run a workflow which checks out private Lexr source. The
+- OE does not run a workflow that checks out Lexr source. The
   superseded kernel-build, IPTSD-integration and script-test workflows are
   removed from OE.
 - The completed native-workflow audit assigns every former repository script,
@@ -67,12 +68,11 @@ OE cut-over advanced to it.
 
 ## Consequences
 
-- A recursive OE clone gives authorised contributors the exact reviewed Lexr
-  source; cloning without submodules still provides the complete OE evidence
-  and integration repository.
-- Contributors without access to Lexr cannot initialise the submodule during
-  the access-controlled phase. This restriction disappears if the standalone
-  repository becomes public; no OE history or URL change is then required.
+- A recursive OE clone gives contributors the exact reviewed Lexr source;
+  cloning without submodules still provides the complete OE evidence and
+  integration repository.
+- The public HTTPS submodule can be initialised anonymously. Read credentials
+  are needed only when a contributor substitutes a private fork.
 - OE pull requests do not need a Lexr repository token, and untrusted pull
   request code cannot receive the credential used for OE release publication.
 - The two repositories have clear release boundaries while users retain the

--- a/docs/adr/adr-0071-fedora-iptsd-package-source-ownership.md
+++ b/docs/adr/adr-0071-fedora-iptsd-package-source-ownership.md
@@ -1,0 +1,93 @@
+---
+id: adr-0071-fedora-iptsd-package-source-ownership
+title: "ADR0071: Fedora IPTSD Package-Source Ownership"
+# prettier-ignore
+description: Architecture Decision Record (ADR) for retaining Fedora IPTSD package-source inputs in OE while Lexr owns Fedora image and package-build orchestration.
+---
+
+# ADR0071: Fedora IPTSD Package-Source Ownership
+
+## Status
+
+Accepted on 2026-09-01.
+
+## Context
+
+Fedora Workstation Live needs distribution-native ownership for installed
+packages. The maintained Surface Pro 11 pen path also needs a native IPTSD
+build from the pinned upstream source and every corresponding Meson fallback;
+repackaging the portable payload's Ubuntu-built binaries would not provide a
+Fedora-native or source-complete result.
+
+OE remains the authority for Surface Pro 11 integration sources, presets,
+lifecycle templates, licences, and hardware evidence. Lexr owns executable
+image, kernel, userspace, and release orchestration under
+[ADR0069](adr-0069-standalone-lexr-workflow-ownership.md). Reintroducing a root
+RPM builder, kernel package, workflow, or shell validation suite in OE would
+restore the duplicate execution surface removed by
+[ADR0070](adr-0070-retire-superseded-repository-scripts.md).
+
+Fedora's image-specific boot and installation lifecycle is recorded in
+[Lexr ADR027](https://github.com/ooaklee/lexr.sh/blob/main/docs/adr/adr-027-fedora-erofs-remaster-and-installed-handoff.md).
+That adapter owns EROFS extraction and recreation, custom-kernel RPM
+construction, dracut and `kernel-install` policy, Anaconda hand-off, hybrid ISO
+publication, and structural validation. Those responsibilities are not
+userspace source inputs.
+
+## Decision
+
+- Retain the pinned IPTSD identity, device presets, lifecycle templates,
+  integration licence, and evidence under `userspace/iptsd-sp11`.
+- Add the reusable Fedora spec template and its archive contract under
+  `userspace/iptsd-sp11/packaging/fedora`. Do not add a root build wrapper,
+  Fedora workflow, root packaging tree, kernel RPM implementation, or a second
+  image-remastering path to OE.
+- Require a source archive containing the exact pinned upstream tree, every
+  corresponding Meson fallback source and patch, this repository's integration
+  tree, all redistributed licence texts, and `SOURCE.env`. Prebuilt payload
+  binaries are not package sources.
+- Render only the declared version, source timestamp, and changelog-date
+  placeholders. Lexr must checksum and validate its source archive before
+  invoking Fedora's native package toolchain.
+- Install the binaries under `/usr/libexec`, presets under `/usr/share`, and
+  the systemd and udev integration under Fedora's `/usr/lib` paths. The package
+  conflicts with both generic `iptsd` and legacy `g6-pen`, and provides
+  `sp11-iptsd = %{version}-%{release}`.
+- On installation, reload udev rules and retrigger only already-enumerated
+  HIDRAW nodes whose parent is one of the maintained `001C:045E:0C80` or
+  `001C:045E:0C83` digitizers. Never emit a subsystem-wide synthetic event for
+  unrelated HIDRAW devices.
+- Keep the kernel as the sole direct-touch provider. The packaged IPTSD daemon
+  decodes the private HIDRAW stylus stream and creates only the pen device.
+
+## Consequences
+
+- OE keeps the reusable, reviewable Fedora userspace source contract next to
+  the hardware integration it packages, without regaining a runnable distro
+  build surface.
+- Lexr can build a Fedora-native binary RPM and source RPM from authenticated
+  inputs while keeping image, kernel, Anaconda, and publication policy in one
+  adapter.
+- The source RPM can satisfy redistribution obligations for IPTSD and its
+  fallback dependencies instead of relying on binaries built for another
+  distribution.
+- Updating the integration README or adding Fedora packaging files changes
+  Lexr's exact checked-in integration-file contract; the linked Lexr revision
+  must advance those digests and file identities at the same time.
+- A successful native build and structural image validation do not qualify
+  stylus, touch, suspend/resume, USB boot, installation, or installed-system
+  behavior. Those remain explicit physical Surface Pro 11 gates.
+
+## Alternatives Considered
+
+**Keep all Fedora packaging in Lexr (rejected).** The executable workflow
+belongs there, but the IPTSD spec is part of the device integration and must
+evolve with its pinned sources, presets, licence set, and lifecycle templates.
+
+**Restore the complete Fedora kernel and userspace packaging draft in OE
+(rejected).** That would duplicate Lexr's adapter-owned kernel, image, and
+validation policy and contradict the completed repository migration.
+
+**Repackage the portable IPTSD binaries (rejected).** Those binaries were
+built against an Ubuntu userspace. A Fedora package must be rebuilt natively
+from the exact source-complete input.

--- a/docs/how-to/how-to-bring-up-bluetooth.md
+++ b/docs/how-to/how-to-bring-up-bluetooth.md
@@ -16,9 +16,8 @@ from the same Surface Pro 11. The maintained implementation is internal to
 ## Collect the private hand-off on Windows
 
 [Initialise the Lexr submodule](../../README.md#build-the-cli) on the same
-Surface. This requires authenticated repository access while Lexr remains
-private; once it is public, ordinary anonymous submodule initialisation is
-sufficient. In an elevated PowerShell session, first complete Lexr's
+Surface. The public HTTPS submodule can be initialised anonymously. In an
+elevated PowerShell session, first complete Lexr's
 [protected-parent procedure](https://github.com/ooaklee/lexr.sh#collect-on-windows)
 to create a new private parent on the fixed local NTFS volume. From the root of
 the checkout in that same session, run:

--- a/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
+++ b/docs/how-to/how-to-build-patched-qcom-x1e-kernel.md
@@ -73,9 +73,9 @@ licence files, then follow
 ## Use the bundle in an image
 
 The optional companion-source inclusion below requires the
-[initialised Lexr submodule](../../README.md#build-the-cli). While Lexr remains
-private, populating that submodule requires authenticated repository access;
-once it is public, ordinary anonymous submodule initialisation is sufficient.
+[initialised Lexr submodule](../../README.md#build-the-cli). Both public
+repositories can be populated anonymously through the recorded HTTPS submodule
+URL.
 Omit `--companion-source-dir` when the source checkout is intentionally
 unavailable.
 

--- a/docs/how-to/how-to-compile-sp11-bt-set-addr.md
+++ b/docs/how-to/how-to-compile-sp11-bt-set-addr.md
@@ -14,9 +14,8 @@ or install it. `lexr handoff apply` now owns the validated same-device
 address workflow and creates the required system integration itself.
 
 Before collecting, [initialise the Lexr submodule](../../README.md#build-the-cli)
-so that the canonical Windows collector is present. This requires an
-authenticated checkout while Lexr remains private; once it is public, ordinary
-anonymous submodule initialisation is sufficient.
+so that the canonical Windows collector is present. The public HTTPS submodule
+can be initialised anonymously.
 
 ## Migrate
 

--- a/docs/how-to/how-to-generate-service-report.md
+++ b/docs/how-to/how-to-generate-service-report.md
@@ -17,9 +17,8 @@ report: its contents are private and proprietary.
 
 - Boot Windows on the Surface that will receive the material.
 - [Initialise the Lexr submodule](../../README.md#build-the-cli) so that
-  `cli/lexr/tools/collect-sp11-windows-handoff.ps1` is present. This requires
-  authenticated repository access while Lexr remains private; once it is
-  public, ordinary anonymous submodule initialisation is sufficient.
+  `cli/lexr/tools/collect-sp11-windows-handoff.ps1` is present. The public HTTPS
+  submodule can be initialised anonymously.
 - In elevated PowerShell, follow Lexr's
   [protected-parent procedure](https://github.com/ooaklee/lexr.sh#collect-on-windows)
   to create a new private parent on the fixed local NTFS volume.

--- a/docs/how-to/how-to-install-sp11-firmware.md
+++ b/docs/how-to/how-to-install-sp11-firmware.md
@@ -17,9 +17,8 @@ guess public download locations or substitute files from another device.
 ## Collect on the same Surface
 
 Before collecting, [initialise the Lexr submodule](../../README.md#build-the-cli)
-on Windows. This requires authenticated repository access while Lexr remains
-private; once it is public, ordinary anonymous submodule initialisation is
-sufficient. In an elevated PowerShell session, first complete Lexr's
+on Windows. The public HTTPS submodule can be initialised anonymously. In an
+elevated PowerShell session, first complete Lexr's
 [protected-parent procedure](https://github.com/ooaklee/lexr.sh#collect-on-windows)
 to create a new private parent on the fixed local NTFS volume. From the root of
 the checkout in that same session, run:

--- a/docs/how-to/how-to-release-kernel-artifacts.md
+++ b/docs/how-to/how-to-release-kernel-artifacts.md
@@ -116,7 +116,7 @@ commit and tree from the build.
 Choose a tag-like release name and an absent output directory:
 
 ```bash
-release_name=sp11-kernel-7.2.0-jg-0sp11v19
+release_name=sp11-qcom-x1e-7.2.2-jg-0sp11v1
 release_dir="build/release/$release_name"
 
 lexr kernel release prepare \
@@ -192,8 +192,9 @@ Kernel publication automation lives in the standalone
 workflow, not in this repository. Dispatch it manually from Lexr's `main`
 branch. A build-only run is the appropriate first pass; request publication
 only after reviewing the selected source revision and its redistribution
-evidence. An explicit release name must begin with `sp11-kernel-`; otherwise
-the workflow derives that prefix and the ABI from the verified build.
+evidence. The workflow derives
+`sp11-qcom-x1e-<package-version>` from the verified build. An explicit release
+name is an exact assertion of that value rather than an alias.
 
 The workflow builds through the native CLI on the dedicated Linux
 `lexr-kernel` runner. When publication is requested, it materialises the exact
@@ -218,9 +219,9 @@ only when all of these controls are in place:
 
 Protect Lexr's `main` branch when the repository plan makes branch protection
 available. Before entering the secret-bearing step, the GitHub-hosted job
-revalidates the self-hosted builder's manifest release name, checksum set,
-required source and licence assets, experimental state, and `sp11-kernel-`
-namespace. It resolves OE `main` to an exact revision, refuses to reuse an
+revalidates the self-hosted builder's manifest release name against its package
+version, checksum set, required source and licence assets, and experimental
+state. It resolves OE `main` to an exact revision, refuses to reuse an
 existing release tag, and then uses `OE_RELEASE_TOKEN` to create a draft release
 against that revision in `ooaklee/linux-surface-pro-11-oe`. The hosted job
 verifies the new tag immediately, downloads every uploaded asset into a fresh

--- a/docs/how-to/how-to-repeat-kernel-build-for-new-release.md
+++ b/docs/how-to/how-to-repeat-kernel-build-for-new-release.md
@@ -63,9 +63,9 @@ for all required preparation inputs and release-note constraints.
 ## Build and validate test media
 
 The optional companion-source inclusion below requires the
-[initialised Lexr submodule](../../README.md#build-the-cli). While Lexr remains
-private, populating that submodule requires authenticated repository access;
-once it is public, ordinary anonymous submodule initialisation is sufficient.
+[initialised Lexr submodule](../../README.md#build-the-cli). Both public
+repositories can be populated anonymously through the recorded HTTPS submodule
+URL.
 Omit `--companion-source-dir` when the source checkout is intentionally
 unavailable.
 

--- a/docs/how-to/how-to-use-lexr.md
+++ b/docs/how-to/how-to-use-lexr.md
@@ -45,13 +45,10 @@ These examples select the integration branch explicitly while the cut-over is
 under review. Omit `--branch cli/linux-armer` and the branch-switching steps
 after the same changes reach the repository's default branch.
 
-During Lexr's private phase, recursive initialisation succeeds only for GitHub
-accounts which can read `ooaklee/lexr.sh`. Git uses the caller's normal GitHub
-authentication; do not place a token in a clone URL, shell history, repository
-file, or support report. Someone without access can clone the OE repository
-without `--recurse-submodules`, but cannot build or run the pinned CLI until
-access is granted or Lexr becomes public. The same recursive clone and submodule
-commands work anonymously after that transition.
+Both repositories are public, so the recorded HTTPS URL supports anonymous
+recursive initialisation. GitHub credentials are needed only for operations
+that write to GitHub or for private forks; do not place a token in a clone URL,
+shell history, repository file, or support report.
 
 `git submodule update` checks out the exact revision recorded by OE. It does not
 silently follow Lexr's default branch.

--- a/userspace/iptsd-sp11/README.md
+++ b/userspace/iptsd-sp11/README.md
@@ -52,6 +52,20 @@ the selected OE release and installs under the standard `/usr` prefix.
 Recipe parse and package-build validation in a supported BitBake environment
 remain pending; the Docker payload build does not validate the OE recipe.
 
+## Fedora package source
+
+The reusable Fedora RPM input is kept in
+[`packaging/fedora`](packaging/fedora/README.md). It consumes the same pinned,
+source-complete IPTSD payload and this directory's configuration, udev,
+systemd, sleep-lifecycle, provenance, and licence inputs. It builds natively
+for AArch64 and installs under Fedora's `/usr` layout; it never repackages the
+Ubuntu-built binaries from the portable payload.
+
+Fedora image remastering and package-build orchestration remain Lexr adapter
+responsibilities. This repository deliberately provides no second RPM wrapper,
+root script, or Fedora workflow. Changes to the RPM template still require a
+complete native package build in Lexr plus physical device qualification.
+
 The legacy `g6-pen` daemon and production `sp11-iptsd` service must never run
 at the same time. A generic `iptsd` package/service is also mutually exclusive:
 the OE recipe conflicts with it and the local installer masks its template.

--- a/userspace/iptsd-sp11/packaging/fedora/README.md
+++ b/userspace/iptsd-sp11/packaging/fedora/README.md
@@ -1,0 +1,34 @@
+# Fedora IPTSD package-source contract
+
+This directory contains the Fedora RPM metadata for the maintained Surface Pro
+11 IPTSD integration. It is a reusable source input, not a standalone package
+builder or image-remastering entry point. Lexr owns source-archive assembly,
+template rendering, the native AArch64 RPM build, and Fedora Live integration.
+
+`lexr-sp11-iptsd.spec.in` expects one source-complete archive named
+`lexr-sp11-iptsd-source.tar.xz` with this top-level layout:
+
+```text
+lexr-sp11-iptsd-source/
+|-- source/       # pinned upstream IPTSD plus every Meson fallback source
+|-- integration/  # this repository's IPTSD config and lifecycle templates
+|-- licenses/     # upstream and fallback dependency licence texts
+`-- SOURCE.env    # exact upstream and integration source identities
+```
+
+The renderer substitutes `@IPTSD_VERSION@`, `@SOURCE_DATE_EPOCH@`, and
+`@CHANGELOG_DATE@`. The archive must be assembled from the checksum-verified
+IPTSD source payload described in the parent directory; prebuilt Ubuntu
+binaries are not valid package sources.
+
+The resulting Fedora package uses the native `/usr` layout, conflicts with the
+generic `iptsd` package and the legacy `g6-pen` daemon, and preserves the
+kernel/userspace boundary: the kernel supplies direct touch while this service
+creates only the stylus device. Its post-install script reloads udev and emits
+synthetic add events only for already-enumerated HIDRAW nodes below the two
+maintained `001C:045E:0C80` and `001C:045E:0C83` digitizers.
+
+Changing the spec, source-tree layout, or template placeholders requires a
+complete native AArch64 RPM build and package-content inspection in Lexr. That
+structural result does not replace physical pen, touch, suspend/resume, or
+installation testing on Surface Pro 11 hardware.

--- a/userspace/iptsd-sp11/packaging/fedora/lexr-sp11-iptsd.spec.in
+++ b/userspace/iptsd-sp11/packaging/fedora/lexr-sp11-iptsd.spec.in
@@ -1,0 +1,133 @@
+Name:           lexr-sp11-iptsd
+Version:        @IPTSD_VERSION@
+Release:        1.sp11%{?dist}
+Summary:        Surface Pro 11 IPTSD stylus integration
+License:        GPL-2.0-or-later AND MIT AND BSD-3-Clause AND Apache-2.0 AND MPL-2.0
+URL:            https://github.com/linux-surface/iptsd
+Source0:        lexr-sp11-iptsd-source.tar.xz
+BuildArch:      aarch64
+
+BuildRequires:  gcc-c++
+BuildRequires:  meson
+BuildRequires:  ninja-build
+BuildRequires:  pkgconf-pkg-config
+BuildRequires:  systemd-rpm-macros
+Requires:       coreutils
+Requires:       gawk
+Requires:       systemd
+Requires:       systemd-udev
+Conflicts:      g6-pen
+Conflicts:      iptsd
+Provides:       sp11-iptsd = %{version}-%{release}
+
+%global debug_package %{nil}
+%global _build_id_links none
+
+%description
+Pinned upstream IPTSD plus the Surface Pro 11 HIDRAW lifecycle integration.
+The kernel remains the sole direct-touch provider; this package creates only
+the virtual stylus device. It supports the X1E/OLED and X1P/LCD digitizer
+product IDs carried by the maintained integration.
+
+%prep
+%setup -q -n lexr-sp11-iptsd-source
+
+%build
+export SOURCE_DATE_EPOCH=@SOURCE_DATE_EPOCH@
+export CXXFLAGS="%{optflags} -ffile-prefix-map=%{_builddir}=/usr/src/lexr-sp11-iptsd"
+meson setup build source \
+  --prefix=/usr \
+  --bindir=libexec \
+  --sysconfdir=/etc \
+  --buildtype=release \
+  -Doptimization=3 \
+  -Dwerror=false \
+  -Db_lto=false \
+  -Ddebug_tools=[] \
+  -Dservice_manager=[] \
+  -Dsample_config=false \
+  -Dforce_access_checks=true \
+  --force-fallback-for=CLI11,eigen3,fmt,INIReader,Microsoft.GSL,spdlog
+ninja -C build src/iptsd src/iptsd-check-device
+
+%install
+install -D -m 0755 build/src/iptsd \
+  %{buildroot}%{_libexecdir}/sp11-iptsd
+install -D -m 0755 build/src/iptsd-check-device \
+  %{buildroot}%{_libexecdir}/sp11-iptsd-check-device
+install -D -m 0644 integration/config/surface-pro-11-0c80.conf \
+  %{buildroot}%{_datadir}/iptsd/surface-pro-11-0c80.conf
+install -D -m 0644 integration/config/surface-pro-11-0c83.conf \
+  %{buildroot}%{_datadir}/iptsd/surface-pro-11-0c83.conf
+
+install -d %{buildroot}%{_unitdir} \
+  %{buildroot}%{_udevrulesdir} \
+  %{buildroot}%{_prefix}/lib/systemd/system-sleep
+sed \
+  -e 's|@IPTSD@|%{_libexecdir}/sp11-iptsd|g' \
+  -e 's|@CHECKER@|%{_libexecdir}/sp11-iptsd-check-device|g' \
+  -e 's|@SYSTEMCTL@|%{_bindir}/systemctl|g' \
+  -e 's|@SYSTEMD_ESCAPE@|%{_bindir}/systemd-escape|g' \
+  integration/packaging/sp11-iptsd@.service.in \
+  > %{buildroot}%{_unitdir}/sp11-iptsd@.service
+sed \
+  -e 's|@CHECKER@|%{_libexecdir}/sp11-iptsd-check-device|g' \
+  -e 's|@SYSTEMD_ESCAPE@|%{_bindir}/systemd-escape|g' \
+  integration/packaging/70-sp11-iptsd.rules.in \
+  > %{buildroot}%{_udevrulesdir}/70-sp11-iptsd.rules
+sed \
+  -e 's|@IPTSD@|%{_libexecdir}/sp11-iptsd|g' \
+  -e 's|@CHECKER@|%{_libexecdir}/sp11-iptsd-check-device|g' \
+  -e 's|@SYSTEMCTL@|%{_bindir}/systemctl|g' \
+  -e 's|@SYSTEMD_ESCAPE@|%{_bindir}/systemd-escape|g' \
+  integration/packaging/sp11-iptsd-restart.in \
+  > %{buildroot}%{_prefix}/lib/systemd/system-sleep/sp11-iptsd-restart
+chmod 0644 \
+  %{buildroot}%{_unitdir}/sp11-iptsd@.service \
+  %{buildroot}%{_udevrulesdir}/70-sp11-iptsd.rules
+chmod 0755 %{buildroot}%{_prefix}/lib/systemd/system-sleep/sp11-iptsd-restart
+
+install -d %{buildroot}%{_licensedir}/%{name}
+install -m 0644 licenses/* %{buildroot}%{_licensedir}/%{name}/
+install -D -m 0644 integration/README.md \
+  %{buildroot}%{_docdir}/%{name}/README.md
+install -D -m 0644 SOURCE.env \
+  %{buildroot}%{_docdir}/%{name}/SOURCE.env
+
+%post
+%systemd_post sp11-iptsd@.service
+/usr/bin/udevadm control --reload-rules >/dev/null 2>&1 || :
+# Installing the rule after boot must also handle an already-enumerated SP11
+# digitizer. Limit synthetic add events to the two maintained HID parent IDs.
+for hidraw in /sys/class/hidraw/hidraw*; do
+  [ -e "$hidraw" ] || continue
+  hid_parent="$(/usr/bin/readlink -f "$hidraw/device" 2>/dev/null || :)"
+  case "$hid_parent" in
+    */001C:045E:0C80.*|*/001C:045E:0C83.*)
+      /usr/bin/udevadm trigger --action=add --subsystem-match=hidraw \
+        --sysname-match="${hidraw##*/}" >/dev/null 2>&1 || :
+      ;;
+  esac
+done
+
+%preun
+%systemd_preun sp11-iptsd@.service
+
+%postun
+%systemd_postun_with_restart sp11-iptsd@.service
+/usr/bin/udevadm control --reload-rules >/dev/null 2>&1 || :
+
+%files
+%license %{_licensedir}/%{name}
+%doc %{_docdir}/%{name}
+%{_libexecdir}/sp11-iptsd
+%{_libexecdir}/sp11-iptsd-check-device
+%{_datadir}/iptsd/surface-pro-11-0c80.conf
+%{_datadir}/iptsd/surface-pro-11-0c83.conf
+%{_unitdir}/sp11-iptsd@.service
+%{_udevrulesdir}/70-sp11-iptsd.rules
+%{_prefix}/lib/systemd/system-sleep/sp11-iptsd-restart
+
+%changelog
+* @CHANGELOG_DATE@ Lexr maintainers <maintainers@lexr.invalid> - @IPTSD_VERSION@-1.sp11
+- Build the pinned, source-complete SP11 integration natively for Fedora.


### PR DESCRIPTION
## Summary

Lexr's experimental Fedora Live adapter needs a Fedora-native IPTSD package-source contract, and the reusable definition belongs beside the maintained Surface Pro 11 integration inputs in this repository.

This PR adds:

- a reviewed Fedora AArch64 RPM spec under `userspace/iptsd-sp11/packaging/fedora`;
- a source-complete contract covering IPTSD, Meson fallbacks, licences, provenance, integration files, and exact source identities;
- native `/usr` paths, RPM ownership, conflicts with generic `iptsd` and `g6-pen`, and a versioned `sp11-iptsd` capability; and
- maintained systemd, udev, sleep/resume, preset, provenance, licence, and bounded device-retrigger integration.

Image, kernel, package-build, and release orchestration remains in Lexr.

## Impact

- No generated RPMs, binaries, firmware, archives, captured device data, or secrets are committed.
- The package owns its `/usr` runtime layout and conflicts with generic `iptsd` and legacy `g6-pen`.
- The kernel remains the direct-touch provider; IPTSD creates only the pen device.
- Physical pen, touch, suspend/resume, USB boot, installation, and installed-system behaviour remain qualification gates.

## Validation

- Fedora 44 AArch64 `rpmbuild -ba` produced valid binary and source RPMs from the exact source-bearing payload.
- Package identity, architecture, ownership, runtime linkage, licences, and source coverage passed inspection.
- The public `sp11-iptsd-v2` release targets exact OE commit `6bd6d7d05998c19c25a25084994c22d2bf0e003d`.
- This branch pins the merged Lexr Fedora support commit `ed6e98158ad50ae9e2ecc8833d6bddfbba89c9b5`.
- The linked [Lexr policy and contract workflow](https://github.com/ooaklee/lexr.sh/actions/runs/33552785584) passed against this branch.
- A v2-backed Fedora ISO passed structural validation, USB write, and read-back verification.
- Physical Surface Pro 11 boot then reached the emergency path; removing `quiet` showed early text before a persistent black screen. This does not implicate the IPTSD package specifically, but it means the complete image path is not hardware-qualified.
- `git diff --check` passes.

## Linked changes

- Experimental Fedora Live adapter: https://github.com/ooaklee/lexr.sh/pull/10
- Fedora physical boot failure: https://github.com/ooaklee/lexr.sh/issues/17
- Kernel release: https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2.2-jg-0sp11v1
- IPTSD v2 release: https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-iptsd-v2
