### PR TITLE
userspace: consume native SP11 platform-profile class

### DIFF
--- a/docs/adr/adr-0061-sp11-platform-profile-framework-non-acpi.md
+++ b/docs/adr/adr-0061-sp11-platform-profile-framework-non-acpi.md
@@ -9,7 +9,13 @@ description: Architecture Decision Record (ADR) documenting why power-profiles-d
 
 ## Status
 
-Accepted and hardware-verified (2026-08-23). Kernel
+Partially superseded by
+[ADR0072](adr-0072-sp11-power-profiles-daemon-class-interface.md) on
+2026-09-02. The hardware evidence below remains valid, but new 7.2.2 SP11
+releases use the native class interface through updated userspace and do not
+re-create the legacy ACPI hierarchy in the kernel.
+
+Originally accepted and hardware-verified (2026-08-23). Kernel
 `7.2.0-jg-0sp11v8-qcom-x1e` is installed on the X1E80100 OLED device. The
 framework loads, the legacy sysfs interface is present, the SSAM device is
 bound, power-profiles-daemon (ppd) uses the `platform_profile` driver, and
@@ -101,5 +107,5 @@ Hardware verification on 2026-08-23 with the X1E80100 OLED device running
   `--build-target "binary-indep binary-qcom-x1e"`. This has no functional
   impact on the device because it has no DKMS or other out-of-tree module
   consumers.
-- The ADR is superseded only if ppd or the kernel later adopt a class-based
-  interface and the legacy path is dropped.
+- The class-based userspace integration and retirement of this synthetic
+  legacy path are recorded by ADR0072.

--- a/docs/adr/adr-0072-sp11-power-profiles-daemon-class-interface.md
+++ b/docs/adr/adr-0072-sp11-power-profiles-daemon-class-interface.md
@@ -1,0 +1,85 @@
+---
+id: adr-0072-sp11-power-profiles-daemon-class-interface
+title: "ADR0072: SP11 Power Profiles Use the Native Class Interface"
+# prettier-ignore
+description: Architecture Decision Record (ADR) replacing the SP11 synthetic ACPI platform-profile compatibility path with a pinned power-profiles-daemon class-interface integration.
+---
+
+# ADR0072: SP11 Power Profiles Use the Native Class Interface
+
+## Status
+
+Accepted on 2026-09-02. This decision supersedes the SP11-specific kernel
+compatibility mechanism in [ADR0061](adr-0061-sp11-platform-profile-framework-non-acpi.md),
+but retains its hardware evidence for the Surface profile handler and profile
+transitions.
+
+## Context
+
+The Surface Pro 11 boots from device tree with ACPI disabled. Kernel 7.2's
+platform-profile framework now registers its native per-handler class without
+ACPI, and the Surface handler appears as
+`/sys/class/platform-profile/platform-profile-0`. The same framework creates
+the historical aggregate files under `/sys/firmware/acpi` only when a genuine
+ACPI kobject exists.
+
+The interface change is commit `3953c459a0c6` in the history used by the
+`7.2.2-jg-0sp11v1-qcom-x1e` PR25 build. The current target branch carries the
+same implementation as `84f6900b705a`. The running SP11 system already exposes
+one native handler with all four expected choices, while distribution
+power-profiles-daemon 0.30 probes only the historical ACPI paths and therefore
+selects its placeholder driver.
+
+Creating a fake `/sys/firmware/acpi` hierarchy in the kernel would preserve an
+old userspace assumption in generic kernel code. It would also broaden a
+shared subsystem change beyond the Microsoft Denali guardrails used for the
+rest of the SP11 series.
+
+## Decision
+
+- Pin upstream power-profiles-daemon 0.30 and carry one reviewable userspace
+  patch in `userspace/power-profiles-daemon-sp11`.
+- Preserve the genuine ACPI interface as the first choice on ACPI systems.
+- When the legacy files are absent, consume exactly one complete
+  `platform-profile-*` class device. Reject multiple devices rather than
+  selecting one nondeterministically.
+- Recognise the kernel ABI's canonical `balanced-performance` spelling while
+  retaining 0.30's underscore spelling for compatibility.
+- Apply the patch through the existing meta-openembedded 0.30 recipe with a
+  `meta-sp11` append. Give the resulting package revision suffix `.sp11.1` so
+  it upgrades cleanly from the distribution build. Do not duplicate the
+  upstream recipe.
+- Treat `7.2.2-jg-0sp11v1-qcom-x1e` as the minimum supported 7.2.2 pairing.
+  Lexr evaluates compatibility against installed `/lib/modules` ABIs, so the
+  userspace can be staged before rebooting the new kernel. A missing live class
+  device is a runtime warning and leaves PPD's placeholder available; it is not
+  a reason to fabricate kernel ABI.
+- Keep the older 7.2.0/v8 result as historical evidence. New 7.2.2 releases do
+  not carry the synthetic legacy kernel interface.
+
+## Consequences
+
+- Kernel code remains aligned with the native class model and no longer needs
+  an SP11 userspace compatibility kobject.
+- The userspace patch is generic enough for a single non-ACPI handler, while
+  ambiguity remains fail-closed.
+- OpenEmbedded can build the integration directly. A checksum-pinned Ubuntu
+  `0.30-2+sp11.1` package is built for local qualification; publication still
+  requires a source-complete signed release and a verified Lexr install
+  workflow before it is offered as a production download.
+- The first physical qualification must verify class-device count, all three
+  desktop transitions, the four underlying kernel choices, persistence across
+  reboot, and a clean daemon/kernel journal.
+
+## Rejected Alternatives
+
+**Re-create `/sys/firmware/acpi` from generic kernel code.** This makes a
+userspace limitation a permanent kernel ABI and risks upstream rejection.
+
+**Hard-depend on one ABI-named Debian kernel package.** Ubuntu kernel image
+package names include the ABI, so this would prevent normal future upgrades
+and make install-before-reboot recovery unnecessarily fragile.
+
+**Pick the first class device when several exist.** Directory iteration order
+is not a machine-wide power policy. The daemon must fall back until explicit
+multi-handler aggregation is designed and tested upstream.

--- a/docs/adr/adr-0073-sp11-7-2-2-target-userspace-contract.md
+++ b/docs/adr/adr-0073-sp11-7-2-2-target-userspace-contract.md
@@ -1,0 +1,81 @@
+---
+id: adr-0073-sp11-7-2-2-target-userspace-contract
+title: "ADR0073: SP11 7.2.2 Target Userspace Contract"
+# prettier-ignore
+description: Architecture Decision Record (ADR) mapping the focused 7.2.2 SP11 target series to the maintained OE userspace integrations and their release gates.
+---
+
+# ADR0073: SP11 7.2.2 Target Userspace Contract
+
+## Status
+
+Accepted for retrospective build validation on 2026-09-02. Physical
+qualification of the exact kernel and userspace release pair remains pending.
+
+## Context
+
+The `sp11/ubuntu-qcom-x1e-7.2.y-target` branch demonstrates the result of the
+focused SP11 pull requests against `jg/ubuntu-qcom-x1e-7.2.y`. The
+`sp11/ubuntu-qcom-x1e-7.2.y-target-fix-pt-2` retrospective adds two corrections:
+
+- accept AudioReach modules with more than eight input ports; and
+- publish the complete Denali QSPI event-ring doorbell address before channel
+  activation, while keeping the completion workarounds Denali-gated.
+
+Those changes repair kernel implementation behavior. They must not silently
+change a userspace identifier, replace a proven payload, or pull unrelated
+experiments from `sp11/integration-7.2.x`.
+
+## Decision
+
+Use the following compatibility classification when propagating the fixes to
+the focused pull-request branches and then rebuilding the demonstration target.
+
+| Integration | Kernel contract on the 7.2.2 target | Userspace action |
+| --- | --- | --- |
+| FullIO audio topology | Card model, protected private-data type values, and playback graph identities are unchanged. The v19c topology reaches its `sp11.sal.4001` widget and fails only at the old eight-input parser bound. | Keep the complete checksum-pinned v19c topology. Revalidate it after the parser fix; do not rebuild merely because comments, type spelling, or kernel implementation structure changed. |
+| UCM microphone capture | `VA Capture`, `TX Capture`, `TX_CODEC_DMA_TX_3`, the Denali card model, and the two TX/VA DMIC routes are present. | Keep the existing two-channel Surface UCM. Revalidate both ALSA and PipeWire capture after the card probes. |
+| IPTSD pen | BUS SPI, vendor `045e`, product `0c83` for X1E and `0c80` for X1P, the HIDRAW-only bridge, and its report descriptor are preserved. The target replaces global module-policy switches with Kconfig and Denali DT opt-ins. | No configuration, udev, service, or binary edit. Confirm `_IPTSD=y`, one matching HIDRAW device, pen-only IPTSD configuration, and suspend/rebind behavior. |
+| Native touchscreen | The QSPI correction changes DMA event delivery, not evdev geometry or names. | No userspace edit. Requalify cold boot, multitouch, recovery, and suspend. |
+| IMX681 camera | Sensor name, 3840×2640 SRGGB10 format, endpoint link frequencies, and media graph identity are preserved; target endpoint validation is stricter. | Keep the existing libcamera Simple IPA patch and `imx681.yaml`. Repeat native package, media graph, RAW10, processed-stream, privacy, and suspend gates. |
+| Platform profiles | DT-only kernels expose one native `platform-profile-*` class device but no genuine ACPI aggregate files. PPD 0.30 probes only the latter and misspells `balanced-performance` while reading it. | Apply the source-pinned userspace change from ADR0072 and require the 7.2.2/sp11v1-or-newer pairing in Lexr diagnostics. Do not restore a synthetic kernel ACPI hierarchy. |
+| Battery | The target omits duplicate SAM BAT1/ACAD providers and retains the DT Qualcomm battery manager. | No payload edit. Verify UPower reports one battery and one AC source without duplicate devices. |
+| Firmware, Wi-Fi, Bluetooth, GPU | Neither retrospective correction changes their firmware filenames, private hand-off paths, or userspace service contracts. | No edit. Retain existing checksum and hardware validation gates. |
+
+The protected AudioReach numeric private-data identifiers are identical between
+the known-good v21 source and the focused target. The observed v1 failure after
+loading the existing topology is stronger compatibility evidence than a source
+timestamp: the loader reaches the named SAL module and rejects its declared
+ten input ports. A token-incompatible topology would fail earlier or at a
+different object. The smallest correction is therefore the parser-bound fix,
+not a newly generated binary.
+
+Lexr evaluates userspace compatibility against an installed, complete
+`/lib/modules/<ABI>` directory. This permits staging userspace before rebooting
+the paired kernel. Live class-device absence remains a separate diagnostic,
+so an installed ABI cannot falsely prove that the currently booted runtime is
+ready.
+
+## Guardrails
+
+- Propagate the AudioReach correction with the focused protected-audio series
+  and the GPI correction with the focused QSPI/touch series.
+- Keep Denali-specific behavior gated by `microsoft,denali` or the corresponding
+  DT opt-in; do not widen shared-driver quirks to unrelated hardware.
+- Do not import the integration branch's cluster-idle disable, SAM D3 override,
+  or USB PHY resume experiments. They are independent decisions and do not
+  repair the observed audio, microphone, touch, pen, or desktop profile failures.
+- Treat identical names and static tests as compatibility evidence, not physical
+  qualification. Publish only after the exact target tree and userspace bundle
+  pass the feature-specific runtime gates above.
+
+## Consequences
+
+- The only maintained OE userspace source change required by the retrospective
+  target is the power-profiles-daemon native-class integration.
+- Audio, microphone, IPTSD, camera, battery, firmware, and radio integrations
+  retain their existing assets but acquire an explicit 7.2.2 requalification
+  obligation.
+- The demonstration target can remain a faithful merge simulation of focused
+  upstream pull requests instead of becoming another integration branch with
+  unrelated fixes.

--- a/meta-sp11/README.md
+++ b/meta-sp11/README.md
@@ -1,12 +1,20 @@
 # meta-sp11
 
 OpenEmbedded integration for Surface Pro 11 support components. Add this
-directory and `meta-openembedded/meta-oe` to `BBLAYERS`, then include
-`iptsd-sp11` in the target image. The recipe builds pinned upstream iptsd and
-installs device-matched pen-only presets, a guarded udev rule, a dynamic
-systemd service, and suspend/resume handling.
+directory and `meta-openembedded/meta-oe` to `BBLAYERS`, then include the
+required components in the target image. The `iptsd-sp11` recipe builds pinned
+upstream iptsd and installs device-matched pen-only presets, a guarded udev
+rule, a dynamic systemd service, and suspend/resume handling. The
+`power-profiles-daemon_0.30.bbappend` teaches the upstream daemon to use one
+native platform-profile class device on DT-only systems while preserving its
+ACPI path on ACPI systems.
 
 `iptsd-sp11` conflicts with `g6-pen`: the latter is retained only for raw HEAT
 diagnostics and deterministic replay, and the two consumers must not run
 together. The layer targets the post-5.0 `UNPACKDIR` layout (Styhead through
 the current Wrynose 6.0 LTS).
+
+The power-profile append is paired with SP11 kernel
+`7.2.2-jg-0sp11v1-qcom-x1e` or newer on the 7.2.2 line. It deliberately does
+not synthesize an ACPI sysfs hierarchy or impose an ABI-named kernel package
+dependency.

--- a/meta-sp11/recipes-support/upower/power-profiles-daemon_0.30.bbappend
+++ b/meta-sp11/recipes-support/upower/power-profiles-daemon_0.30.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/../../../userspace/power-profiles-daemon-sp11:"
+
+# Make the native-class integration a distinct, upgradeable package revision.
+PR:append = ".sp11.1"
+
+SRC_URI += " \
+    file://0001-platform-profile-consume-single-class-device.patch \
+    file://SP11-NATIVE-CLASS \
+"
+
+do_install:append() {
+    install -d ${D}${docdir}/${BPN}
+    install -m 0644 ${UNPACKDIR}/SP11-NATIVE-CLASS \
+        ${D}${docdir}/${BPN}/SP11-NATIVE-CLASS
+}

--- a/userspace/power-profiles-daemon-sp11/0001-platform-profile-consume-single-class-device.patch
+++ b/userspace/power-profiles-daemon-sp11/0001-platform-profile-consume-single-class-device.patch
@@ -1,0 +1,306 @@
+From: Leon Silcott <leon@boasi.io>
+Date: Wed, 2 Sep 2026 13:25:00 +0100
+Subject: [PATCH] platform-profile: consume a single class device
+
+The platform-profile framework registers its per-handler class on device-tree
+systems where ACPI and the legacy aggregate sysfs files are unavailable.
+power-profiles-daemon currently probes only the legacy ACPI paths, so it falls
+back to the placeholder driver even though a complete native handler exists.
+
+Keep the legacy paths preferred on ACPI systems.  When they are absent, select
+one complete /sys/class/platform-profile/platform-profile-* device.  Refuse
+more than one class device because selecting one arbitrarily would expose an
+incomplete or misleading machine-wide profile.
+
+Add integration coverage for a single class device and the ambiguous-device
+case.
+
+Also recognise the class ABI's canonical `balanced-performance` spelling when
+an external agent changes the selected profile. Keep the historical underscore
+spelling accepted for compatibility.
+
+Forwarded: no
+Last-Update: 2026-09-02
+---
+ src/ppd-driver-platform-profile.c | 89 +++++++++++++++++++++++++------
+ tests/integration_test.py         | 58 +++++++++++++++++++++
+ 2 files changed, 129 insertions(+), 18 deletions(-)
+
+diff --git a/src/ppd-driver-platform-profile.c b/src/ppd-driver-platform-profile.c
+index 28fc335..5b86a28 100644
+--- a/src/ppd-driver-platform-profile.c
++++ b/src/ppd-driver-platform-profile.c
+@@ -18,6 +18,7 @@
+ #define LAPMODE_SYSFS_NAME "dytc_lapmode"
+ #define ACPI_PLATFORM_PROFILE_PATH "/sys/firmware/acpi/platform_profile"
+ #define ACPI_PLATFORM_PROFILE_CHOICES_PATH "/sys/firmware/acpi/platform_profile_choices"
++#define PLATFORM_PROFILE_CLASS_PATH "/sys/class/platform-profile"
+ 
+ struct _PpdDriverPlatformProfile
+ {
+@@ -32,6 +33,8 @@ struct _PpdDriverPlatformProfile
+   GFileMonitor *lapmode_mon;
+   GFileMonitor *acpi_platform_profile_mon;
+   gulong acpi_platform_profile_changed_id;
++  char *platform_profile_path;
++  char *platform_profile_choices_path;
+ };
+ 
+ G_DEFINE_TYPE (PpdDriverPlatformProfile, ppd_driver_platform_profile, PPD_TYPE_DRIVER_PLATFORM)
+@@ -89,6 +92,7 @@ acpi_platform_profile_value_to_profile (const char *str)
+     return PPD_PROFILE_POWER_SAVER;
+ 
+   if (g_str_equal (str, "balanced") ||
++      g_str_equal (str, "balanced-performance") ||
+       g_str_equal (str, "balanced_performance") ||
+       g_str_equal (str, "cool"))
+     return PPD_PROFILE_BALANCED;
+@@ -101,18 +104,16 @@ acpi_platform_profile_value_to_profile (const char *str)
+ }
+ 
+ static PpdProfile
+-read_platform_profile (void)
++read_platform_profile (PpdDriverPlatformProfile *self)
+ {
+-  g_autofree char *platform_profile_path = NULL;
+   g_autofree char *new_profile_str = NULL;
+   g_autoptr(GError) error = NULL;
+   PpdProfile new_profile;
+ 
+-  platform_profile_path = ppd_utils_get_sysfs_path (ACPI_PLATFORM_PROFILE_PATH);
+-  if (!g_file_get_contents (platform_profile_path,
++  if (!g_file_get_contents (self->platform_profile_path,
+                             &new_profile_str, NULL, &error)) {
+     g_debug ("Failed to get contents for '%s': %s",
+-             platform_profile_path,
++             self->platform_profile_path,
+              error->message);
+     return PPD_PROFILE_UNSET;
+   }
+@@ -127,15 +128,13 @@ read_platform_profile (void)
+ static gboolean
+ save_platform_profile_choices (PpdDriverPlatformProfile *self)
+ {
+-  g_autofree char *platform_profile_choices_path = NULL;
+   g_autofree char *choices_str = NULL;
+   g_autoptr(GError) error = NULL;
+ 
+-  platform_profile_choices_path = ppd_utils_get_sysfs_path (ACPI_PLATFORM_PROFILE_CHOICES_PATH);
+-  if (!g_file_get_contents (platform_profile_choices_path,
++  if (!g_file_get_contents (self->platform_profile_choices_path,
+                             &choices_str, NULL, &error)) {
+     g_debug ("Failed to get contents for '%s': %s",
+-             platform_profile_choices_path,
++             self->platform_profile_choices_path,
+              error->message);
+     return FALSE;
+   }
+@@ -184,7 +183,7 @@ update_acpi_platform_profile_state (PpdDriverPlatformProfile *self)
+ {
+   PpdProfile new_profile;
+ 
+-  new_profile = read_platform_profile ();
++  new_profile = read_platform_profile (self);
+   if (new_profile == PPD_PROFILE_UNSET ||
+       new_profile == self->acpi_platform_profile)
+     return;
+@@ -218,7 +217,7 @@ acpi_platform_profile_changed (GFileMonitor      *monitor,
+ {
+   PpdDriverPlatformProfile *self = user_data;
+ 
+-  g_debug (ACPI_PLATFORM_PROFILE_PATH " changed (%d)", event_type);
++  g_debug ("%s changed (%d)", self->platform_profile_path, event_type);
+   if (self->probe_result == PPD_PROBE_RESULT_DEFER) {
+     g_signal_emit_by_name (G_OBJECT (self), "probe-request", 0);
+     return;
+@@ -238,7 +237,6 @@ ppd_driver_platform_profile_activate_profile (PpdDriver                   *drive
+ {
+   PpdDriverPlatformProfile *self = PPD_DRIVER_PLATFORM_PROFILE (driver);
+   g_autoptr(GError) local_error = NULL;
+-  g_autofree char *platform_profile_path = NULL;
+   const char *platform_profile_value;
+ 
+   g_return_val_if_fail (self->acpi_platform_profile_mon, FALSE);
+@@ -258,8 +256,7 @@ ppd_driver_platform_profile_activate_profile (PpdDriver                   *drive
+   }
+ 
+   g_signal_handler_block (G_OBJECT (self->acpi_platform_profile_mon), self->acpi_platform_profile_changed_id);
+-  platform_profile_path = ppd_utils_get_sysfs_path (ACPI_PLATFORM_PROFILE_PATH);
+-  if (!ppd_utils_write (platform_profile_path,
++  if (!ppd_utils_write (self->platform_profile_path,
+                         profile_to_acpi_platform_profile_value (self, profile), &local_error)) {
+     g_debug ("Failed to write to acpi_platform_profile: %s", local_error->message);
+     g_propagate_prefixed_error (error, g_steal_pointer (&local_error),
+@@ -274,6 +271,61 @@ ppd_driver_platform_profile_activate_profile (PpdDriver                   *drive
+   return TRUE;
+ }
+ 
++static gboolean
++resolve_platform_profile_paths (PpdDriverPlatformProfile *self)
++{
++  g_autofree char *legacy_profile = NULL;
++  g_autofree char *legacy_choices = NULL;
++  g_autofree char *class_path = NULL;
++  g_autoptr(GError) error = NULL;
++  GDir *class_dir;
++  const char *entry;
++
++  legacy_profile = ppd_utils_get_sysfs_path (ACPI_PLATFORM_PROFILE_PATH);
++  legacy_choices = ppd_utils_get_sysfs_path (ACPI_PLATFORM_PROFILE_CHOICES_PATH);
++  if (g_file_test (legacy_profile, G_FILE_TEST_EXISTS) &&
++      g_file_test (legacy_choices, G_FILE_TEST_EXISTS)) {
++    self->platform_profile_path = g_steal_pointer (&legacy_profile);
++    self->platform_profile_choices_path = g_steal_pointer (&legacy_choices);
++    return TRUE;
++  }
++
++  class_path = ppd_utils_get_sysfs_path (PLATFORM_PROFILE_CLASS_PATH);
++  class_dir = g_dir_open (class_path, 0, &error);
++  if (!class_dir) {
++    g_debug ("No platform profile class directory: %s", error->message);
++    return FALSE;
++  }
++
++  while ((entry = g_dir_read_name (class_dir))) {
++    g_autofree char *profile = NULL;
++    g_autofree char *choices = NULL;
++
++    if (!g_str_has_prefix (entry, "platform-profile-"))
++      continue;
++
++    profile = g_build_filename (class_path, entry, "profile", NULL);
++    choices = g_build_filename (class_path, entry, "choices", NULL);
++    if (!g_file_test (profile, G_FILE_TEST_EXISTS) ||
++        !g_file_test (choices, G_FILE_TEST_EXISTS))
++      continue;
++
++    if (self->platform_profile_path) {
++      g_debug ("More than one platform profile class device is available");
++      g_clear_pointer (&self->platform_profile_path, g_free);
++      g_clear_pointer (&self->platform_profile_choices_path, g_free);
++      g_dir_close (class_dir);
++      return FALSE;
++    }
++
++    self->platform_profile_path = g_steal_pointer (&profile);
++    self->platform_profile_choices_path = g_steal_pointer (&choices);
++  }
++
++  g_dir_close (class_dir);
++  return self->platform_profile_path != NULL;
++}
++
+ static int
+ find_dytc (GUdevDevice *dev,
+            gpointer     user_data)
+@@ -292,13 +344,11 @@ ppd_driver_platform_profile_probe (PpdDriver  *driver)
+ {
+   PpdDriverPlatformProfile *self = PPD_DRIVER_PLATFORM_PROFILE (driver);
+   g_autoptr(GFile) acpi_platform_profile = NULL;
+-  g_autofree char *platform_profile_path = NULL;
+ 
+   g_return_val_if_fail (self->probe_result == PPD_PROBE_RESULT_UNSET, PPD_PROBE_RESULT_FAIL);
+ 
+   /* Profile interface */
+-  platform_profile_path = ppd_utils_get_sysfs_path (ACPI_PLATFORM_PROFILE_PATH);
+-  if (!g_file_test (platform_profile_path, G_FILE_TEST_EXISTS)) {
++  if (!resolve_platform_profile_paths (self)) {
+     g_debug ("No platform_profile sysfs file");
+     return PPD_PROBE_RESULT_FAIL;
+   }
+@@ -310,7 +360,7 @@ ppd_driver_platform_profile_probe (PpdDriver  *driver)
+     return self->probe_result;
+   }
+ 
+-  acpi_platform_profile = g_file_new_for_path (platform_profile_path);
++  acpi_platform_profile = g_file_new_for_path (self->platform_profile_path);
+   self->acpi_platform_profile_mon = g_file_monitor (acpi_platform_profile,
+                                                     G_FILE_MONITOR_NONE,
+                                                     NULL,
+@@ -357,6 +407,8 @@ ppd_driver_platform_profile_finalize (GObject *object)
+   g_clear_object (&driver->device);
+   g_clear_object (&driver->lapmode_mon);
+   g_clear_object (&driver->acpi_platform_profile_mon);
++  g_clear_pointer (&driver->platform_profile_path, g_free);
++  g_clear_pointer (&driver->platform_profile_choices_path, g_free);
+   G_OBJECT_CLASS (ppd_driver_platform_profile_parent_class)->finalize (object);
+ }
+ 
+diff --git a/tests/integration_test.py b/tests/integration_test.py
+index 0994cf2..f2e9160 100644
+--- a/tests/integration_test.py
++++ b/tests/integration_test.py
+@@ -386,6 +386,22 @@ class Tests(dbusmock.DBusTestCase):
+             "low-power balanced performance custom\n",
+         )
+ 
++    def create_platform_profile_class(self, index=0):
++        profile_dir = os.path.join(
++            self.testbed.get_root_dir(),
++            "sys/class/platform-profile",
++            f"platform-profile-{index}",
++        )
++        os.makedirs(profile_dir, exist_ok=True)
++        self.write_file_contents(
++            os.path.join(profile_dir, "name"), "Surface Platform Profile\n"
++        )
++        self.write_file_contents(os.path.join(profile_dir, "profile"), "performance\n")
++        self.write_file_contents(
++            os.path.join(profile_dir, "choices"),
++            "low-power balanced balanced-performance performance\n",
++        )
++
+     def remove_platform_profile(self):
+         acpi_dir = os.path.join(self.testbed.get_root_dir(), "sys/firmware/acpi/")
+         os.remove(os.path.join(acpi_dir, "platform_profile_choices"))
+@@ -2005,6 +2021,48 @@ class Tests(dbusmock.DBusTestCase):
+             self.read_sysfs_file("sys/firmware/acpi/platform_profile"), b"balanced"
+         )
+ 
++    def test_platform_profile_class(self):
++        self.create_platform_profile_class()
++        self.start_daemon()
++
++        profiles = self.get_dbus_property("Profiles")
++        self.assertEqual(len(profiles), 3)
++        self.assertEqual(profiles[0]["PlatformDriver"], "platform_profile")
++        self.assertEqual(self.get_dbus_property("ActiveProfile"), "balanced")
++        self.assertEqual(
++            self.read_sysfs_file(
++                "sys/class/platform-profile/platform-profile-0/profile"
++            ),
++            b"balanced",
++        )
++
++        self.set_dbus_property("ActiveProfile", GLib.Variant.new_string("power-saver"))
++        self.assertEqual(
++            self.read_sysfs_file(
++                "sys/class/platform-profile/platform-profile-0/profile"
++            ),
++            b"low-power",
++        )
++
++        self.set_dbus_property("ActiveProfile", GLib.Variant.new_string("performance"))
++        self.write_file_contents(
++            os.path.join(
++                self.testbed.get_root_dir(),
++                "sys/class/platform-profile/platform-profile-0/profile",
++            ),
++            "balanced-performance\n",
++        )
++        self.assert_dbus_property_eventually_is("ActiveProfile", "balanced")
++
++    def test_multiple_platform_profile_class_devices_are_not_ambiguous(self):
++        self.create_platform_profile_class(0)
++        self.create_platform_profile_class(1)
++        self.start_daemon()
++
++        profiles = self.get_dbus_property("Profiles")
++        self.assertEqual(len(profiles), 2)
++        self.assertEqual(profiles[0]["PlatformDriver"], "placeholder")
++
+     def test_hold_release_profile(self):
+         self.create_platform_profile()
+         self.start_daemon()
+-- 
+2.51.0

--- a/userspace/power-profiles-daemon-sp11/BASE.txt
+++ b/userspace/power-profiles-daemon-sp11/BASE.txt
@@ -1,0 +1,13 @@
+Upstream project: https://gitlab.freedesktop.org/upower/power-profiles-daemon.git
+Upstream tag: 0.30
+Upstream commit: 5b4994c8a91290481bef87a5bae95391d0ec677f
+Upstream tree: 8310d18187f51b027004b3fc3e35f2bdd1ef5840
+Distribution package observed on device: 0.30-2 (arm64, Ubuntu resolute)
+Ubuntu source descriptor SHA256: 800ba32fed9823627faf9b47fcff15171e2d38f17035cb76da109ec60a4f2bc8
+Ubuntu upstream tarball SHA256: 528ee5b8ca0a27d8d66128ebf850e23be9571dc130cf2a82dd2463dac7d3a92f
+Ubuntu Debian tarball SHA256: a02b340e1198230a986c0dd05e58dfb359b1939109139acc2947bd0c631f1835
+SP11 package versions: OE revision .sp11.1; Ubuntu 0.30-2+sp11.1
+Kernel interface minimum: 7.2.2-jg-0sp11v1-qcom-x1e
+Kernel interface commit in PR25 history: 3953c459a0c63176bce0dcc5ef42d8486a60702e
+Equivalent current target commit: 84f6900b705a345ee7c62e8a783343bf249ff45f
+Validation date: 2026-09-02

--- a/userspace/power-profiles-daemon-sp11/README.md
+++ b/userspace/power-profiles-daemon-sp11/README.md
@@ -1,0 +1,77 @@
+# SP11 native platform-profile userspace
+
+This directory extends pinned upstream `power-profiles-daemon` 0.30 to consume
+the kernel's native per-handler platform-profile class on device-tree systems.
+It replaces the SP11-specific need for a synthetic
+`/sys/firmware/acpi/platform_profile` compatibility interface; it does not
+remove or override the genuine ACPI interface on ACPI systems.
+
+The daemon continues to prefer the upstream legacy files when both are
+present. When those files are absent, it accepts exactly one complete
+`/sys/class/platform-profile/platform-profile-*` device with `profile` and
+`choices` attributes. More than one class device is deliberately rejected
+rather than choosing an incomplete machine-wide policy arbitrarily.
+
+`BASE.txt` pins the upstream source and the first 7.2.2 SP11 ABI that contains
+the required class interface. The interface commit is in the history of the
+PR25 `sp11v1` build and is byte-equivalent to the current target branch's
+framework implementation. The daemon remains able to use a real legacy ACPI
+interface, but the supported DT-only SP11 pairing is
+`7.2.2-jg-0sp11v1-qcom-x1e` or newer on the 7.2.2 patch line.
+
+## OpenEmbedded build
+
+The `meta-sp11` append applies the patch to the upstream
+`power-profiles-daemon_0.30.bb` recipe from `meta-openembedded/meta-oe`. Add the
+layer and include `power-profiles-daemon` in the image as normal. The append
+assigns package revision suffix `.sp11.1`, so package feeds can distinguish
+and upgrade from an unmodified 0.30 build. It also installs the non-executable
+`SP11-NATIVE-CLASS` identity record used by
+Lexr to distinguish this integration from the unmodified distribution daemon.
+The marker is evidence of package contents, not evidence that the live kernel
+has instantiated the class device. The append
+does not fabricate a kernel package dependency: OpenEmbedded kernel package
+names vary by image, and blocking package installation before the matching
+kernel has booted would make upgrades harder to recover. Compatibility is
+enforced by the image/release pairing and reported by Lexr against installed
+kernel ABIs. On the 7.2.2 patch line, the exact-pair gate begins at
+`7.2.2-jg-0sp11v1-qcom-x1e`; later `sp11vN` generations remain compatible.
+
+## Validation
+
+The patch was compiled as ARM64 against the 0.30 tag in an Ubuntu 26.04
+container. Its two new upstream-style integration tests passed:
+
+- one class device binds the `platform_profile` driver and switches
+  `balanced` to `low-power`;
+- two class devices are rejected as ambiguous and retain the placeholder.
+
+For validation on the Ubuntu installation, the same patch is also built over
+the checksum-pinned `power-profiles-daemon` 0.30-2 source as
+`0.30-2+sp11.1`. That package installs the same `SP11-NATIVE-CLASS` identity
+record as the OE recipe. It is a local qualification artifact, not a committed
+binary or a substitute for publishing a signed package repository. The full
+upstream suite currently has two unrelated Python 3.14/umockdev byte-string
+comparison failures in `test_amd_pstate_upower`; 123 tests pass, six skip, and
+both native-class tests pass. The final binary package is therefore built with
+`DEB_BUILD_OPTIONS=nocheck` only after recording that test result.
+
+Physical release qualification must still boot the exact kernel and userspace
+pair, confirm there is exactly one class device, and exercise all profiles:
+
+```sh
+find /sys/class/platform-profile -mindepth 1 -maxdepth 1 -type l -print
+powerprofilesctl list
+powerprofilesctl set power-saver
+powerprofilesctl set performance
+powerprofilesctl set balanced
+journalctl -b -u power-profiles-daemon --no-pager
+```
+
+The expected SP11 choices are `low-power`, `balanced`,
+`balanced-performance`, and `performance`. Desktop exposure remains the three
+standard PPD profiles; `balanced-performance` is an internal kernel choice,
+not a fourth desktop profile.
+The patch also accepts the kernel ABI's canonical `balanced-performance`
+spelling when it observes a profile selected outside PPD; upstream 0.30 only
+recognises the non-canonical underscore spelling in that read path.

--- a/userspace/power-profiles-daemon-sp11/SP11-NATIVE-CLASS
+++ b/userspace/power-profiles-daemon-sp11/SP11-NATIVE-CLASS
@@ -1,0 +1,5 @@
+SP11 power-profiles-daemon native class integration
+upstream=0.30
+commit=5b4994c8a91290481bef87a5bae95391d0ec677f
+minimum-kernel=7.2.2-jg-0sp11v1-qcom-x1e
+interface=/sys/class/platform-profile/platform-profile-*/profile


### PR DESCRIPTION
## Summary

Surface Pro 11 kernels from `7.2.2-jg-0sp11v1` expose the upstream-style
platform-profile class, but power-profiles-daemon 0.30 only probes the legacy
ACPI firmware path. The result is a working kernel interface with no usable
desktop power-profile driver.

This change keeps that compatibility in userspace instead of adding a legacy
kernel shim. It:

- patches power-profiles-daemon 0.30 to prefer a genuine legacy ACPI interface
  when present, otherwise consume exactly one complete native
  `platform-profile-N` class device;
- rejects ambiguous multiple native handlers;
- recognises the canonical `balanced-performance` choice;
- installs the exact `SP11-NATIVE-CLASS` marker used by Lexr readiness policy;
- adds the `power-profiles-daemon_0.30.bbappend` with package revision
  `.sp11.1`; and
- records the interface decision and the complete 7.2.2 kernel/userspace
  qualification matrix in ADRs 0072 and 0073.

## Why this boundary

The v1 kernel already provides `profile` and `choices` through
`/sys/class/platform-profile/platform-profile-0`. Restoring
`/sys/firmware/acpi/platform_profile` in the kernel would preserve a duplicate
legacy ABI and risk diverging from the native class expected to move upstream.
Keeping the adaptation in power-profiles-daemon lets userspace support both
interfaces without pretending the hardware is ACPI-backed.

The retrospective also found no other required OE source changes:

- FullIO v19c topology and UCM already contain playback and VA/TX microphone
  routes; the kernel card failed before either could register.
- IPTSD configuration and rules already match the in-tree HIDRAW bridge; touch
  and pen failed in the shared Denali QSPI transport.
- Camera, firmware, battery, Wi-Fi, Bluetooth, and GPU userspace assets do not
  change for this kernel delta.

Those components remain in the physical requalification matrix rather than
receiving speculative package changes.

## Related implementation

- Kernel retrospective record: https://github.com/ooaklee/linux_ms_dev_kit-sp11/pull/26
- Lexr readiness policy: https://github.com/ooaklee/lexr.sh/pull/20
- QSPI/touch focused upstream PR: https://github.com/jglathe/linux_ms_dev_kit/pull/83
- Audio focused upstream PR: https://github.com/jglathe/linux_ms_dev_kit/pull/89
- Kernel release: https://github.com/ooaklee/linux-surface-pro-11-oe/releases/tag/sp11-qcom-x1e-7.2.2-jg-0sp11v2

## Impact

This changes release compatibility and power-profile discovery. The native
handler is accepted only when there is exactly one complete class device. A
real legacy ACPI interface remains preferred. No privilege, persisted-data,
firmware, bootloader, kernel ABI, or private-device-data behavior changes.

The package and kernel remain experimental until the v2 kernel has been booted
on physical Surface Pro 11 hardware and profile transitions have been checked.

## Validation

- Patch applied to the exact power-profiles-daemon 0.30 source used by the
  current `meta-openembedded/meta-oe` recipe.
- Both new native-class integration tests passed.
- Upstream test run: 123 passed, 6 skipped, and 2 unrelated failures in
  `test_amd_pstate_upower` caused by the Python 3.14/umockdev byte-string
  representation mismatch.
- ARM64 package `power-profiles-daemon_0.30-2+sp11.1_arm64.deb` built.
- `apt-get -s install` accepted it as an upgrade from 0.30-2.
- Package contents include the exact readiness marker.
- All package/build metadata SHA-256 checks passed.
- `git diff --check` passed.
